### PR TITLE
Add pytest test suite (62 tests)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,12 @@ dependencies = [
 Homepage = "https://github.com/Str4vinci/BREOS"
 Repository = "https://github.com/Str4vinci/BREOS"
 
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,184 @@
+"""Shared fixtures for BREOS test suite."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from pvlib.location import Location
+
+from breos.battery import BatteryConfig, apply_indoor_temperature_model
+from breos.economics import CostParams
+from breos.emissions import EmissionsParams
+from breos.load_profiles import load_profile
+from breos.pv_modules import get_module
+from breos.solar import PVModuleParams, calculate_pv_production_dc
+from breos.weather import extract_ambient_temperature
+
+
+# ---------------------------------------------------------------------------
+# Synthetic weather (1 year, hourly, no API call)
+# ---------------------------------------------------------------------------
+
+def _build_synthetic_weather(year: int = 2023, freq: str = "h") -> pd.DataFrame:
+    """Build a realistic-ish 1-year weather DataFrame with sinusoidal patterns."""
+    steps_per_hour = 1 if freq == "h" else 4
+    n_steps = 8760 * steps_per_hour
+    index = pd.date_range(
+        start=f"{year}-01-01",
+        periods=n_steps,
+        freq="h" if freq == "h" else "15min",
+        tz="UTC",
+    )
+
+    hour_of_year = np.arange(n_steps, dtype=float) / steps_per_hour
+    day_of_year = hour_of_year / 24.0
+    hour_of_day = hour_of_year % 24
+
+    # Solar pattern: bell curve during daylight, zero at night
+    solar_angle = np.clip(np.sin((hour_of_day - 6) / 12 * np.pi), 0, 1)
+    # Seasonal modulation: summer has more sun
+    seasonal = 0.6 + 0.4 * np.sin((day_of_year - 80) / 365 * 2 * np.pi)
+    ghi = solar_angle * seasonal * 800  # W/m2 peak
+    dni = ghi * 0.7
+    dhi = ghi * 0.3
+
+    # Temperature: seasonal + diurnal
+    temp_air = (
+        15
+        + 8 * np.sin((day_of_year - 80) / 365 * 2 * np.pi)
+        + 4 * np.sin((hour_of_day - 14) / 24 * 2 * np.pi)
+    )
+    wind_speed = np.full(n_steps, 3.0)
+
+    return pd.DataFrame(
+        {"ghi": ghi, "dni": dni, "dhi": dhi, "temp_air": temp_air, "wind_speed": wind_speed},
+        index=index,
+    )
+
+
+@pytest.fixture
+def synthetic_weather():
+    return _build_synthetic_weather()
+
+
+@pytest.fixture
+def synthetic_weather_15min():
+    return _build_synthetic_weather(freq="15min")
+
+
+# ---------------------------------------------------------------------------
+# Location
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def porto_location():
+    return Location(41.1579, -8.6291, tz="Europe/Lisbon")
+
+
+# ---------------------------------------------------------------------------
+# PV module
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def pv_params():
+    return get_module("Suntech_STP550S_STC")
+
+
+# ---------------------------------------------------------------------------
+# Load profile
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sample_load():
+    return load_profile(
+        profile_type="6",
+        annual_consumption_kwh=3000,
+        start_date="2023-01-01",
+        freq="h",
+        num_years=1,
+        timezone="UTC",
+    )
+
+
+# ---------------------------------------------------------------------------
+# PV DC production (1 module, hourly, synthetic weather)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def dc_production(synthetic_weather, porto_location, pv_params):
+    return calculate_pv_production_dc(
+        weather_data=synthetic_weather,
+        location=porto_location,
+        slope=35,
+        surface_azimuth=180,
+        n_modules=1,
+        pv_params=pv_params,
+        freq="h",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Battery config
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def battery_config():
+    return BatteryConfig(nominal_energy_wh=5000, battery_type="lfp")
+
+
+# ---------------------------------------------------------------------------
+# Temperature series
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def temperature_series(synthetic_weather):
+    ambient = extract_ambient_temperature(synthetic_weather)
+    return apply_indoor_temperature_model(ambient)
+
+
+# ---------------------------------------------------------------------------
+# Cost params (residential_pt style)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cost_params():
+    return CostParams(
+        electricity_cost=0.2577,
+        electricity_sold_cost=0.04,
+        module_cost_per_w=0.125,
+        battery_cost_per_kwh=711.0,
+        inverter_cost_per_kw=102.58,
+        inverter_cost_per_kw_nobatt=48.37,
+        installation_cost_per_module=350.0,
+        battery_installation_cost=350.0,
+        maintenance_cost_per_panel=10.0,
+        other_cost_per_module=50.0,
+        inflation_rate=0.02,
+        discount_rate=0.03,
+        pv_degradation_rate=0.005,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Emissions params
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def emissions_params():
+    return EmissionsParams(
+        grid_carbon_intensity_gco2_kwh=110.52,
+        country="Portugal",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: monkeypatch weather for App tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _patch_weather(monkeypatch, synthetic_weather):
+    """Monkeypatch fetch_tmy_weather_data so App tests never hit the network."""
+    def _fake_fetch(*args, **kwargs):
+        return synthetic_weather, {"inputs": {"location": {"latitude": 41.15, "longitude": -8.63, "elevation": 0}}}
+
+    monkeypatch.setattr("breos.app.fetch_tmy_weather_data", _fake_fetch)
+    monkeypatch.setattr("breos.app.load_weather", lambda **kw: None)  # force fetch path

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,179 @@
+"""Tests for the public API facade (breos.App)."""
+
+import json
+
+import pytest
+
+import breos
+from breos.app import App
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+class TestAppValidation:
+    def test_missing_location(self):
+        with pytest.raises(ValueError, match="location"):
+            App({"n_modules": 10, "annual_consumption_kwh": 4000})
+
+    def test_missing_n_modules(self):
+        with pytest.raises(ValueError, match="n_modules"):
+            App({"location": "porto", "annual_consumption_kwh": 4000})
+
+    def test_missing_consumption(self):
+        with pytest.raises(ValueError, match="annual_consumption_kwh"):
+            App({"location": "porto", "n_modules": 10})
+
+    def test_invalid_location_key(self):
+        with pytest.raises(ValueError, match="Unknown location"):
+            App({"location": "atlantis", "n_modules": 10, "annual_consumption_kwh": 4000})
+
+    def test_invalid_n_modules_zero(self):
+        with pytest.raises(ValueError, match="n_modules"):
+            App({"location": "porto", "n_modules": 0, "annual_consumption_kwh": 4000})
+
+    def test_invalid_consumption_negative(self):
+        with pytest.raises(ValueError, match="annual_consumption_kwh"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": -100})
+
+    def test_invalid_resolution(self):
+        with pytest.raises(ValueError, match="resolution"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "resolution": "30min"})
+
+    def test_invalid_cost_preset(self):
+        with pytest.raises(ValueError, match="Unknown cost preset"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "cost_preset": "fake_preset"})
+
+    def test_invalid_emissions_country(self):
+        with pytest.raises(ValueError, match="Unknown emissions country"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "emissions_country": "XX"})
+
+    def test_custom_location_missing_fields(self):
+        with pytest.raises(ValueError, match="latitude"):
+            App({"location": {"longitude": -8.6}, "n_modules": 10, "annual_consumption_kwh": 4000})
+
+    def test_custom_location_valid(self):
+        app = App({
+            "location": {"latitude": 41.15, "longitude": -8.63, "timezone": "Europe/Lisbon"},
+            "n_modules": 6,
+            "annual_consumption_kwh": 3000,
+        })
+        assert app._lat == 41.15
+
+    def test_result_before_simulate(self):
+        app = App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000})
+        with pytest.raises(RuntimeError, match="simulate"):
+            app.result()
+
+
+# ---------------------------------------------------------------------------
+# Simulation (with monkeypatched weather)
+# ---------------------------------------------------------------------------
+
+class TestAppSimulateNoBattery:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _patch_weather):
+        self.app = App({
+            "location": "porto",
+            "n_modules": 6,
+            "annual_consumption_kwh": 3000,
+            "cost_preset": "residential_pt",
+            "emissions_country": "PT",
+            "projection_years": 5,
+        })
+        self.app.simulate()
+        self.result = self.app.result()
+
+    def test_result_is_dict(self):
+        assert isinstance(self.result, dict)
+
+    def test_json_serializable(self):
+        json.dumps(self.result)
+
+    def test_no_battery_keys(self):
+        assert "battery_soh_end_pct" not in self.result
+        assert "battery_replacements" not in self.result
+
+    def test_expected_keys_present(self):
+        expected = {
+            "n_modules", "pv_kwp", "battery_kwh",
+            "pv_production_kwh", "consumption_kwh", "self_consumption_kwh",
+            "grid_import_kwh", "grid_export_kwh",
+            "grid_independence_pct", "self_consumption_pct",
+            "total_investment_eur", "payback_year", "npv_savings_eur", "lcoe_eur_kwh",
+            "co2_avoided_year1_kg", "co2_avoided_total_kg",
+            "yearly",
+        }
+        assert expected.issubset(self.result.keys())
+
+    def test_yearly_length(self):
+        assert len(self.result["yearly"]) == 5
+
+    def test_system_echo(self):
+        assert self.result["n_modules"] == 6
+        assert self.result["battery_kwh"] == 0.0
+
+    def test_pv_production_positive(self):
+        assert self.result["pv_production_kwh"] > 0
+
+    def test_grid_independence_range(self):
+        gi = self.result["grid_independence_pct"]
+        assert 0 <= gi <= 100
+
+    def test_energy_conservation(self):
+        r = self.result
+        # self_consumption + export should approximately equal PV production
+        assert abs(r["self_consumption_kwh"] + r["grid_export_kwh"] - r["pv_production_kwh"]) < 1.0
+
+    def test_investment_positive(self):
+        assert self.result["total_investment_eur"] > 0
+
+    def test_lcoe_positive(self):
+        assert self.result["lcoe_eur_kwh"] > 0
+
+
+class TestAppSimulateWithBattery:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _patch_weather):
+        self.app = App({
+            "location": "porto",
+            "n_modules": 6,
+            "annual_consumption_kwh": 3000,
+            "battery_kwh": 5.0,
+            "cost_preset": "residential_pt",
+            "emissions_country": "PT",
+            "projection_years": 5,
+        })
+        self.app.simulate()
+        self.result = self.app.result()
+
+    def test_battery_keys_present(self):
+        assert "battery_soh_end_pct" in self.result
+        assert "battery_replacements" in self.result
+        assert "battery_replacement_cost_eur" in self.result
+
+    def test_battery_soh_range(self):
+        soh = self.result["battery_soh_end_pct"]
+        assert 0 < soh <= 100
+
+    def test_battery_improves_grid_independence(self, _patch_weather):
+        # Same system without battery should have lower grid independence
+        app_no_batt = App({
+            "location": "porto",
+            "n_modules": 6,
+            "annual_consumption_kwh": 3000,
+            "cost_preset": "residential_pt",
+            "projection_years": 5,
+        })
+        app_no_batt.simulate()
+        gi_no_batt = app_no_batt.result()["grid_independence_pct"]
+        gi_with_batt = self.result["grid_independence_pct"]
+        assert gi_with_batt >= gi_no_batt
+
+    def test_yearly_has_soh(self):
+        for year in self.result["yearly"]:
+            assert "soh_pct" in year
+
+    def test_json_serializable(self):
+        json.dumps(self.result)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,0 +1,119 @@
+"""Tests for the battery module."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from breos.battery import (
+    BatteryConfig,
+    apply_indoor_temperature_model,
+    simulate_energy_balance,
+)
+
+
+class TestBatteryConfig:
+    def test_defaults(self):
+        cfg = BatteryConfig(nominal_energy_wh=5000)
+        assert cfg.max_soc == 0.90
+        assert cfg.min_soc == 0.10
+        assert cfg.dc_coupled is True
+        assert cfg.inverter_efficiency == 0.96
+        assert cfg.battery_type == "lfp"
+        assert cfg.calendar_model == "naumann_lam_calibrated"
+
+    def test_replacement_cost_auto(self):
+        cfg = BatteryConfig(nominal_energy_wh=10000)
+        # 10 kWh * 711 €/kWh = 7110
+        assert cfg.replacement_cost == pytest.approx(7110.0, rel=0.01)
+
+    def test_replacement_cost_zero_battery(self):
+        cfg = BatteryConfig(nominal_energy_wh=0)
+        assert cfg.replacement_cost == 0.0
+
+    def test_replacement_cost_override(self):
+        cfg = BatteryConfig(nominal_energy_wh=5000, replacement_cost=1000.0)
+        assert cfg.replacement_cost == 1000.0
+
+    def test_battery_type_accessible(self):
+        cfg = BatteryConfig(nominal_energy_wh=5000, battery_type="lfp")
+        assert cfg.battery_type == "lfp"
+
+
+class TestSimulateEnergyBalance:
+    def test_no_battery(self, dc_production, sample_load):
+        results_df, total_pv, summary_df, rep_cost, n_rep, deg_df = simulate_energy_balance(
+            pv_dc=dc_production * 6,
+            houseload=sample_load,
+            battery_config=None,
+            freq="h",
+        )
+        assert isinstance(results_df, pd.DataFrame)
+        assert total_pv > 0
+        assert rep_cost == 0.0
+        assert n_rep == 0
+
+    def test_with_battery_returns_tuple(self, dc_production, sample_load, battery_config, temperature_series):
+        result = simulate_energy_balance(
+            pv_dc=dc_production * 6,
+            houseload=sample_load,
+            battery_config=battery_config,
+            freq="h",
+            temperature_series=temperature_series,
+        )
+        assert len(result) == 6
+        results_df, total_pv, summary_df, rep_cost, n_rep, deg_df = result
+        assert isinstance(results_df, pd.DataFrame)
+        assert total_pv > 0
+
+    def test_soc_within_bounds(self, dc_production, sample_load, battery_config, temperature_series):
+        results_df, *_ = simulate_energy_balance(
+            pv_dc=dc_production * 6,
+            houseload=sample_load,
+            battery_config=battery_config,
+            freq="h",
+            temperature_series=temperature_series,
+        )
+        if "SOC_Absolute" in results_df.columns:
+            soc = results_df["SOC_Absolute"]
+            # SOC should never exceed nominal capacity
+            assert soc.max() <= battery_config.nominal_energy_wh * 1.01  # 1% tolerance
+
+    def test_more_pv_means_more_independence(self, dc_production, sample_load, battery_config, temperature_series):
+        gi_values = []
+        for n_modules in [3, 10]:
+            results_df, *_ = simulate_energy_balance(
+                pv_dc=dc_production * n_modules,
+                houseload=sample_load,
+                battery_config=battery_config,
+                freq="h",
+                temperature_series=temperature_series,
+            )
+            total_load = results_df["Houseload"].sum()
+            total_import = results_df["Import_From_Grid"].sum()
+            gi = (1 - total_import / total_load) * 100 if total_load > 0 else 0
+            gi_values.append(gi)
+        assert gi_values[1] > gi_values[0]
+
+
+class TestIndoorTemperatureModel:
+    def test_output_shape(self):
+        outdoor = pd.Series(np.linspace(-5, 40, 100))
+        indoor = apply_indoor_temperature_model(outdoor)
+        assert len(indoor) == len(outdoor)
+
+    def test_clamping_floor(self):
+        outdoor = pd.Series([-20.0] * 10)
+        indoor = apply_indoor_temperature_model(outdoor, floor_c=15.0)
+        assert indoor.min() >= 15.0
+
+    def test_clamping_ceiling(self):
+        outdoor = pd.Series([50.0] * 10)
+        indoor = apply_indoor_temperature_model(outdoor, ceiling_c=35.0)
+        assert indoor.max() <= 35.0
+
+    def test_coupling_factor(self):
+        outdoor = pd.Series([10.0] * 10)
+        # alpha=0 means fully setpoint, alpha=1 means fully outdoor
+        indoor_low = apply_indoor_temperature_model(outdoor, setpoint_c=22.0, coupling_alpha=0.0)
+        indoor_high = apply_indoor_temperature_model(outdoor, setpoint_c=22.0, coupling_alpha=1.0)
+        assert indoor_low.iloc[0] > indoor_high.iloc[0]  # setpoint > outdoor, so less coupling = warmer

--- a/tests/test_economics.py
+++ b/tests/test_economics.py
@@ -1,0 +1,112 @@
+"""Tests for the economics module."""
+
+import pytest
+
+from breos.economics import CostParams, calculate_costs, calculate_lcoe, find_payback_year
+
+
+class TestCalculateCosts:
+    def test_pv_only(self, cost_params):
+        costs = calculate_costs(
+            n_modules=10,
+            module_power_w=550,
+            battery_capacity_wh=0,
+            cost_params=cost_params,
+        )
+        assert costs["battery_cost"] == 0.0
+        assert costs["pv_cost"] == pytest.approx(10 * 550 * 0.125)
+        assert costs["total_initial_cost"] > 0
+        # No battery → simple inverter
+        assert costs["inverter_cost"] == pytest.approx(48.37 * 10 * 550 / 1000, rel=0.01)
+
+    def test_with_battery(self, cost_params):
+        costs = calculate_costs(
+            n_modules=10,
+            module_power_w=550,
+            battery_capacity_wh=5000,
+            cost_params=cost_params,
+        )
+        assert costs["battery_cost"] == pytest.approx(5 * 711.0)
+        # With battery → hybrid inverter (more expensive)
+        assert costs["inverter_cost"] == pytest.approx(102.58 * 10 * 550 / 1000, rel=0.01)
+        assert costs["total_initial_cost"] > costs["pv_cost"] + costs["battery_cost"]
+
+    def test_cost_breakdown_sums_to_total(self, cost_params):
+        costs = calculate_costs(
+            n_modules=6,
+            module_power_w=550,
+            battery_capacity_wh=5000,
+            cost_params=cost_params,
+        )
+        parts = (
+            costs["pv_cost"]
+            + costs["inverter_cost"]
+            + costs["battery_cost"]
+            + costs["installation_cost"]
+            + costs["other_costs"]
+            + costs.get("tes_cost", 0)
+            + costs.get("hp_cost", 0)
+            + costs.get("tes_installation_cost", 0)
+        )
+        assert costs["total_initial_cost"] == pytest.approx(parts, rel=0.001)
+
+
+class TestFindPaybackYear:
+    def test_known_payback(self):
+        import pandas as pd
+        # Savings turn positive at year 8
+        proj = pd.DataFrame({
+            "Year": range(1, 11),
+            "Savings_Cumulative_NPV": [-500, -400, -300, -200, -100, -50, -10, 30, 100, 200],
+        })
+        assert find_payback_year(proj) == 8
+
+    def test_no_payback(self):
+        import pandas as pd
+        proj = pd.DataFrame({
+            "Year": range(1, 6),
+            "Savings_Cumulative_NPV": [-500, -400, -300, -200, -100],
+        })
+        assert find_payback_year(proj) is None
+
+
+class TestLCOE:
+    def test_basic(self):
+        lcoe = calculate_lcoe(
+            total_investment=5000,
+            annual_production_kwh=5000,
+            annual_operation_cost=50,
+            lifetime_years=20,
+            discount_rate=0.0,
+            degradation_rate=0.0,
+        )
+        # (5000 + 50*20) / (5000*20) = 6000/100000 = 0.06
+        assert lcoe == pytest.approx(0.06, rel=0.01)
+
+    def test_degradation_increases_lcoe(self):
+        lcoe_no_deg = calculate_lcoe(
+            total_investment=5000,
+            annual_production_kwh=5000,
+            annual_operation_cost=50,
+            lifetime_years=20,
+            discount_rate=0.0,
+            degradation_rate=0.0,
+        )
+        lcoe_with_deg = calculate_lcoe(
+            total_investment=5000,
+            annual_production_kwh=5000,
+            annual_operation_cost=50,
+            lifetime_years=20,
+            discount_rate=0.0,
+            degradation_rate=0.01,
+        )
+        assert lcoe_with_deg > lcoe_no_deg
+
+    def test_zero_production(self):
+        lcoe = calculate_lcoe(
+            total_investment=5000,
+            annual_production_kwh=0,
+            annual_operation_cost=50,
+            lifetime_years=20,
+        )
+        assert lcoe == float("inf")

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -1,0 +1,51 @@
+"""Tests for the emissions module."""
+
+import numpy as np
+import pytest
+
+from breos.emissions import EmissionsParams, calculate_co2_projection, calculate_co2_savings
+
+
+class TestCO2Savings:
+    def test_basic(self):
+        params = EmissionsParams(grid_carbon_intensity_gco2_kwh=100.0)
+        result = calculate_co2_savings(
+            total_pv_kwh=10000,
+            self_consumed_kwh=6000,
+            emissions_params=params,
+        )
+        # 10000 kWh * 100 gCO2/kWh = 1_000_000 g = 1000 kg
+        assert result["CO2_Avoided_Total_kg"] == pytest.approx(1000.0)
+        # 6000 * 100 / 1000 = 600 kg
+        assert result["CO2_Avoided_SelfConsumed_kg"] == pytest.approx(600.0)
+        assert result["CO2_Avoided_Total_tCO2"] == pytest.approx(1.0)
+
+    def test_zero_production(self):
+        params = EmissionsParams(grid_carbon_intensity_gco2_kwh=110.52)
+        result = calculate_co2_savings(0.0, 0.0, params)
+        assert result["CO2_Avoided_Total_kg"] == 0.0
+        assert result["CO2_Avoided_SelfConsumed_kg"] == 0.0
+
+    def test_portugal_intensity(self, emissions_params):
+        result = calculate_co2_savings(1000.0, 500.0, emissions_params)
+        # 1000 * 110.52 / 1000 = 110.52 kg
+        assert result["CO2_Avoided_Total_kg"] == pytest.approx(110.52)
+
+
+class TestCO2Projection:
+    def test_shape(self):
+        params = EmissionsParams(grid_carbon_intensity_gco2_kwh=100.0)
+        yearly_pv = np.array([5000, 4975, 4950])
+        yearly_export = np.array([2000, 1990, 1980])
+        proj = calculate_co2_projection(yearly_pv, yearly_export, params)
+        assert len(proj) == 3
+        assert "CO2_Avoided_Total_kg" in proj.columns
+        assert "CO2_Avoided_Total_Cumulative_kg" in proj.columns
+
+    def test_cumulative_increasing(self):
+        params = EmissionsParams(grid_carbon_intensity_gco2_kwh=100.0)
+        yearly_pv = np.array([5000, 5000, 5000, 5000])
+        yearly_export = np.array([2000, 2000, 2000, 2000])
+        proj = calculate_co2_projection(yearly_pv, yearly_export, params)
+        cumulative = proj["CO2_Avoided_Total_Cumulative_kg"].values
+        assert all(cumulative[i] <= cumulative[i + 1] for i in range(len(cumulative) - 1))

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -1,0 +1,83 @@
+"""Tests for the solar module."""
+
+import pandas as pd
+import pytest
+
+from breos.solar import (
+    calculate_pv_production_dc,
+    default_azimuth,
+    estimate_optimal_tilt,
+)
+
+
+class TestTiltAndAzimuth:
+    def test_optimal_tilt_northern_hemisphere(self):
+        tilt = estimate_optimal_tilt(41.0)  # Porto latitude
+        assert 20 <= tilt <= 50
+
+    def test_optimal_tilt_equator(self):
+        tilt = estimate_optimal_tilt(0.0)
+        assert 0 <= tilt <= 20
+
+    def test_azimuth_northern_hemisphere(self):
+        assert default_azimuth(41.0) == 180  # South-facing
+
+    def test_azimuth_southern_hemisphere(self):
+        assert default_azimuth(-37.0) == 0  # North-facing
+
+
+class TestPVProduction:
+    def test_output_shape(self, synthetic_weather, porto_location, pv_params):
+        dc = calculate_pv_production_dc(
+            weather_data=synthetic_weather,
+            location=porto_location,
+            slope=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=pv_params,
+            freq="h",
+        )
+        assert isinstance(dc, pd.Series)
+        assert len(dc) == len(synthetic_weather)
+
+    def test_all_non_negative(self, dc_production):
+        assert (dc_production >= -0.01).all()  # small tolerance for floating point
+
+    def test_more_modules_more_production(self, synthetic_weather, porto_location, pv_params):
+        dc_1 = calculate_pv_production_dc(
+            weather_data=synthetic_weather,
+            location=porto_location,
+            slope=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=pv_params,
+            freq="h",
+        )
+        dc_5 = calculate_pv_production_dc(
+            weather_data=synthetic_weather,
+            location=porto_location,
+            slope=35,
+            surface_azimuth=180,
+            n_modules=5,
+            pv_params=pv_params,
+            freq="h",
+        )
+        assert dc_5.sum() == pytest.approx(dc_1.sum() * 5, rel=0.001)
+
+    def test_zero_ghi_zero_production(self, porto_location, pv_params):
+        # Night-time weather: all irradiance = 0
+        idx = pd.date_range("2023-01-01", periods=24, freq="h", tz="UTC")
+        weather = pd.DataFrame(
+            {"ghi": 0.0, "dni": 0.0, "dhi": 0.0, "temp_air": 10.0, "wind_speed": 3.0},
+            index=idx,
+        )
+        dc = calculate_pv_production_dc(
+            weather_data=weather,
+            location=porto_location,
+            slope=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=pv_params,
+            freq="h",
+        )
+        assert dc.sum() == pytest.approx(0.0, abs=1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,7 @@ dependencies = [
     { name = "geopy" },
     { name = "joblib" },
     { name = "matplotlib" },
+    { name = "nrel-pysam" },
     { name = "numba" },
     { name = "openmeteo-requests" },
     { name = "openpyxl" },
@@ -73,11 +74,17 @@ dependencies = [
     { name = "timezonefinder" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "geopy", specifier = ">=2.4.1" },
     { name = "joblib", specifier = ">=1.5.3" },
     { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "nrel-pysam", specifier = ">=7.1.0" },
     { name = "numba", specifier = ">=0.63.1" },
     { name = "openmeteo-requests", specifier = ">=1.7.4" },
     { name = "openpyxl", specifier = ">=3.1.0" },
@@ -85,10 +92,12 @@ requires-dist = [
     { name = "pvlib", specifier = "==0.14.0" },
     { name = "pyarrow", specifier = ">=19.0.0" },
     { name = "pymoo", specifier = ">=0.6.1.6" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rainflow", specifier = ">=3.2.0" },
     { name = "requests-cache", specifier = ">=1.2.1" },
     { name = "timezonefinder", specifier = ">=8.2.1" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "cattrs"
@@ -224,6 +233,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/ac/8c27720838e293898671f01b5c452236a0c74f4799a3f2d5fcccbbf50d71/cma-4.4.4.tar.gz", hash = "sha256:632bd654b5dce04c0eaa3166679d3e4773ce7a79eab7934e7f363c341b9a8170", size = 316645, upload-time = "2026-02-25T22:18:16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/d4/ec46cedab6a6145e21768baa8110db3e2e836a320d8499e4ef18bc894e61/cma-4.4.4-py3-none-any.whl", hash = "sha256:edb6d02eb2aac2d54650f16a8f0c70711ff17445957de7c9de92ff7fd4b7ef38", size = 328311, upload-time = "2026-02-25T22:18:09.602Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
@@ -460,6 +478,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jh2"
 version = "5.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -688,6 +715,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3c/c1/54176da7749a1f35d62cf9212b839dacd841a41a4c6fb15805d4631260b0/niquests-3.18.3.tar.gz", hash = "sha256:d561dfeb5a932f9b5c7724302543883774d4a175fc22d9301753ab304c89ce08", size = 1020598, upload-time = "2026-03-30T07:17:21.67Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/38/0dedd89270e47eaf9bfaff526dd109510426c869b0421846902617fef04f/niquests-3.18.3-py3-none-any.whl", hash = "sha256:3db9831becafd3e48323c2ab4044801a9ddf7f08a634dab2276013e117cf0ae7", size = 207748, upload-time = "2026-03-30T07:17:20.033Z" },
+]
+
+[[package]]
+name = "nrel-pysam"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/3f/b83a791cb0b930739c4572b91016f47443d3f21f787960aa786210fc5189/NREL_PySAM-7.1.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:2e03066c5f48a33ccb8f0d2257da60fe8864a2701f510a7c347fb274790078fa", size = 35476841, upload-time = "2025-08-11T16:26:41.147Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4c/f91306e5046e161adb79a808255380afecff587b911f0f5a8e6866048caf/NREL_PySAM-7.1.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:ec394d7be641b305cdc8e29777d34c1f3993904e7cf56666bd40264b53d61e94", size = 36278249, upload-time = "2025-08-11T16:41:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/50d7bab99f4608846d0376c131365ff1eaa41557a74f4657632caeef68bf/NREL_PySAM-7.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:ce4f7560db91e8b635a553ab2a809ca9f67b49d5110629eeafc1bce8b14dac80", size = 32854147, upload-time = "2025-08-11T16:41:14.654Z" },
+    { url = "https://files.pythonhosted.org/packages/58/75/cb75294901ece360b537e5ca4a91fc5d829d2efe32760bc1da418b4e3375/nrel_pysam-7.1.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:74d3c090711795b755d5f390d54e64f9e42b2bee5f33a5ecbe59e15ded3c41dd", size = 45196490, upload-time = "2025-08-11T16:26:44.909Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/c860ed724993aca7748770a351dc5eaa9612c81435d40cfcf115362b3fb7/nrel_pysam-7.1.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:0290f10db930367d688dc486aceb160a05cc285a0fb4df7096a78398356a00a4", size = 47251341, upload-time = "2025-08-11T16:41:06.753Z" },
 ]
 
 [[package]]
@@ -922,6 +961,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pvlib"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -984,6 +1032,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pymoo"
 version = "0.6.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1022,6 +1079,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add test suite with 62 tests covering the public API facade, battery, economics, emissions, and solar modules
- All tests run offline using synthetic weather fixtures (no API calls, ~8s total)
- Add pytest as a dev dependency

## Test plan
- [x] `uv run pytest tests/ -v` — 62/62 passing
- [x] No network dependencies
- [x] Verified on Python 3.13