### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -v


### PR DESCRIPTION
## Summary
- Add `.github/workflows/tests.yml` to run pytest on every push/PR to `main` and `develop`
- Uses `uv` for fast dependency resolution and Python 3.13
- Runs the full 62-test suite

## Test plan
- [ ] Verify CI runs on this PR and shows green check