### PR TITLE
Release prep: CHANGELOG, templates, version bump to 0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,30 @@
+name: Bug Report
+description: Report a bug in BREOS
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal code or steps to reproduce the issue
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Python version, OS, BREOS version
+      placeholder: |
+        Python: 3.13
+        OS: Ubuntu 24.04
+        BREOS: 0.2.0
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see added or changed?
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: How would this help your workflow?
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Summary
+<!-- Brief description of what this PR does -->
+
+## Test plan
+<!-- How was this tested? -->
+- [ ] Tests pass (`uv run pytest tests/ -v`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
+
+## [0.2.0] - 2026-04-04
+
+### Added
+- **Public API facade** (`breos.App`) — single entry point for simulations with config dict in, plain dict out
+- **Test suite** — 62 tests covering the public API, battery, economics, emissions, and solar modules (all offline, ~8s)
+- **CI/CD** — GitHub Actions runs tests on every push/PR to `main` and `develop`
+- **CONTRIBUTING.md** — development setup, branching workflow, and PR guidelines
+- `battery_type` field on `BatteryConfig` (was referenced internally but missing)
+- `nrel-pysam` as an explicit dependency (required by pvlib's `fit_cec_sam`)
+
+### Changed
+- README rewritten with `breos.App` as the primary Quick Start example
+- Configuration and Result reference tables added to README
+
+## [0.1.0] - 2026-04-04
+
+### Added
+- Initial open-source release
+- Weather data fetching (PVGIS, Open-Meteo) with hourly and 15-minute resolution
+- PV production calculations (DC/AC) with built-in module database
+- Battery simulation with calendar and cycle aging models (Naumann 2020, Lam 2025)
+- Economic analysis: NPV, LCOE, breakeven, cost projections
+- Multi-objective optimization (NSGA-II) for system sizing
+- CO2 emissions savings calculations
+- Standard load profiles (BDEW H0, EREDES, REE)
+- Publication-ready plotting utilities

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -25,7 +25,7 @@ Usage:
 """
 
 # Version
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # Public facade
 from breos.app import App

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "breos"
-version = "0.1.0"
+version = "0.2.0"
 description = "Building Renewable Energy Optimization Software - A Python library for PV and battery energy system simulations"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary
- Add CHANGELOG.md with v0.1.0 and v0.2.0 entries
- Add GitHub issue templates (bug report, feature request)
- Add pull request template
- Bump version to 0.2.0

## Test plan
- [ ] CI passes
- After merge: PR develop → main, tag v0.2.0