### PR TITLE
Update upstream model values and presets

### DIFF
--- a/breos/app.py
+++ b/breos/app.py
@@ -27,7 +27,6 @@ from pvlib.location import Location
 from breos.battery import BatteryConfig, apply_indoor_temperature_model, simulate_energy_balance
 from breos.economics import CostParams, calculate_costs, calculate_lcoe, cost_analysis_projection, find_payback_year
 from breos.emissions import EmissionsParams, calculate_co2_savings
-from breos.inverter import InverterConfig
 from breos.load_profiles import load_profile
 from breos.pv_modules import MODULES, get_module
 from breos.solar import calculate_pv_production_dc, default_azimuth, estimate_optimal_tilt
@@ -469,10 +468,13 @@ class App:
             params["inverter_cost_per_kw_nobatt"] = preset.get("inverter_cost_per_kw_simple", 48.37)
             params["installation_cost_per_module"] = preset.get("installation_cost_per_module", 350.0)
             params["battery_installation_cost"] = preset.get("installation_cost_battery", 350.0)
-            params["maintenance_cost_per_panel"] = preset.get("maintenance_cost", 50.0)
-            params["other_cost_per_module"] = preset.get("other_costs", 50.0)
+            params["maintenance_cost_per_panel"] = preset.get("maintenance_cost_per_panel", 0.0)
+            params["maintenance_cost_fixed"] = preset.get("maintenance_cost", 50.0)
+            params["other_cost_per_module"] = preset.get("other_cost_per_module", 0.0)
+            params["other_cost_fixed"] = preset.get("other_costs", 50.0)
 
         # Financial defaults
+        params["dc_ac_ratio"] = cfg["inverter_loading_ratio"]
         params.setdefault("inflation_rate", cfg["inflation_rate"])
         params.setdefault("discount_rate", cfg["discount_rate"])
         params["pv_degradation_rate"] = cfg["pv_degradation_rate"]
@@ -484,35 +486,13 @@ class App:
         cfg = self._cfg
         n_modules = cfg["n_modules"]
         battery_kwh = cfg["battery_kwh"]
-        has_battery = battery_kwh > 0
 
-        inv_config = InverterConfig(
-            is_hybrid=has_battery,
-            dc_ac_ratio=cfg["inverter_loading_ratio"],
-            inverter_efficiency=cfg["inverter_efficiency"],
-        )
-        total_power_w = self._pv_params.Mpp * n_modules
-
-        costs = calculate_costs(
+        return calculate_costs(
             n_modules=n_modules,
             module_power_w=self._pv_params.Mpp,
             battery_capacity_wh=battery_kwh * 1000,
             cost_params=self._cost_params,
         )
-
-        # Override inverter cost with InverterConfig for correct loading ratio
-        costs["inverter_cost"] = inv_config.get_cost(total_power_w)
-
-        # Recalculate total with correct inverter cost
-        costs["total_initial_cost"] = (
-            costs["pv_cost"]
-            + costs["inverter_cost"]
-            + costs["battery_cost"]
-            + costs["installation_cost"]
-            + costs["other_costs"]
-        )
-
-        return costs
 
     @staticmethod
     def _yearly_to_dicts(yearly_df: pd.DataFrame) -> list:

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -38,6 +38,10 @@ from breos.constants import (
     LAM_CAL_HOURLY_K0_FRAC,
     LAM_CAL_HOURLY_SOC_EXPONENT_N,
     LAM_CAL_K0_FRAC,
+    LAM_CAL_OLD_EA_J_MOL,
+    LAM_CAL_OLD_EXPONENT_B,
+    LAM_CAL_OLD_K0_FRAC,
+    LAM_CAL_OLD_SOC_EXPONENT_N,
     LAM_CAL_RELAXED_EA_J_MOL,
     LAM_CAL_RELAXED_EXPONENT_B,
     LAM_CAL_RELAXED_K0_FRAC,
@@ -94,7 +98,7 @@ class BatteryConfig:
     enable_replacement: bool = True
     replacement_cost: Optional[float] = None  # Auto-computed from cost per kWh if not set
     calendar_model: str = (
-        "naumann_lam_calibrated"  # 'naumann_lam_calibrated', 'naumann_lam', 'naumann_lam_modern', 'naumann'
+        "naumann_lam_calibrated"  # Current field-calibrated fit; alias of 'lam_naumann_field_calibrated'
     )
     # Resistance fade tracking
     enable_resistance_fade: bool = False  # Enable Naumann resistance growth model
@@ -651,11 +655,14 @@ def _get_degradation_params(model: str) -> Tuple[float, float, float, float]:
     Lam et al. (2025) calendar params with different calibrations.
 
     Models:
-        'naumann'                      — Naumann 2020 calendar + cycle (NMC/LFP lab)
-        'naumann_lam'                  — Naumann cycle + Lam 2025 lab-derived calendar
-        'naumann_lam_calibrated'       — Naumann cycle + Lam calendar, field-calibrated (default)
-        'naumann_lam_calibrated_hourly'— Naumann cycle + Lam calendar, field-calibrated, hourly res.
-        'naumann_lam_modern'           — Naumann cycle + Lam calendar, projected 0.5×k₀ for 2020+ cells
+        'naumann'                        — Naumann 2020 calendar + cycle (NMC/LFP lab)
+        'naumann_lam'                    — Naumann cycle + Lam 2025 lab-derived calendar
+        'lam_naumann_field_calibrated'   — Current field-calibrated fit (canonical name)
+        'naumann_lam_calibrated'         — Backward-compatible alias for the current fit
+        'lam_naumann_field_calibrated_old' / 'naumann_lam_calibrated_old'
+                                         — Previous 15-min field calibration
+        'naumann_lam_calibrated_hourly'  — Hourly field calibration
+        'naumann_lam_modern'             — Projected 0.5×k₀ for 2020+ cells
     """
     model_lower = model.lower().replace("-", "_")
 
@@ -669,8 +676,12 @@ def _get_degradation_params(model: str) -> Tuple[float, float, float, float]:
         return LAM_K0_FRAC, LAM_EA_J_MOL, LAM_EXPONENT_B, LAM_SOC_EXPONENT_N
 
     # ── Naumann-Lam: field-calibrated (default) ──────────────────────────
-    elif model_lower in ("naumann_lam_calibrated", "lam_calibrated"):
+    elif model_lower in ("lam_naumann_field_calibrated", "naumann_lam_calibrated", "lam_calibrated"):
         return LAM_CAL_K0_FRAC, LAM_CAL_EA_J_MOL, LAM_CAL_EXPONENT_B, LAM_CAL_SOC_EXPONENT_N
+
+    # ── Naumann-Lam: previous field calibration ───────────────────────────
+    elif model_lower in ("lam_naumann_field_calibrated_old", "naumann_lam_calibrated_old", "lam_calibrated_old"):
+        return LAM_CAL_OLD_K0_FRAC, LAM_CAL_OLD_EA_J_MOL, LAM_CAL_OLD_EXPONENT_B, LAM_CAL_OLD_SOC_EXPONENT_N
 
     # ── Naumann-Lam: field-calibrated relaxed ─────────────────────────────
     elif model_lower in ("naumann_lam_calibrated_relaxed", "lam_calibrated_relaxed", "lam_calibrated_1.5ea"):
@@ -691,9 +702,11 @@ def _get_degradation_params(model: str) -> Tuple[float, float, float, float]:
 
     else:
         raise ValueError(
-            f"Unknown calendar model: {model}. Use 'naumann_lam_calibrated', 'naumann_lam', "
+            f"Unknown calendar model: {model}. Use 'lam_naumann_field_calibrated', "
+            f"'lam_naumann_field_calibrated_old', 'naumann_lam', "
             f"'naumann_lam_calibrated_hourly', 'naumann_lam_modern', or 'naumann'. "
-            f"Legacy aliases ('lam_calibrated', 'lam', 'modern_lfp') are also accepted."
+            f"Legacy aliases ('naumann_lam_calibrated', 'lam_calibrated', 'lam', 'modern_lfp') "
+            f"are also accepted."
         )
 
 

--- a/breos/constants.py
+++ b/breos/constants.py
@@ -44,17 +44,34 @@ LAM_EA_J_MOL = 38500.0  # Activation Energy (0.4 eV converted to J/mol)
 LAM_EXPONENT_B = 0.75  # Time exponent (Based on Lam Fig 5A LFP cluster)
 LAM_SOC_EXPONENT_N = 0.75  # Assume same SOC exponent as Naumann/general LFP
 
-# === Lam Calibrated Parameters (Field-calibrated for residential LFP systems) ===
-# Calibrated against 5 LFP home storage systems from Zenodo dataset (12091223)
-# using differential evolution on 2015-2023 field data with capacity test ground truth.
-#
-# 15-min resolution (default): Mean CV RMSE = 5.3pp, train RMSE = 4.3pp,
-# overfitting gap 1.07pp (37% narrower than hourly). System 20 RMSE 9.8pp→6.4pp.
-# LOO cross-validation (5 folds), LFP-only filter, --resolution 15min.
-LAM_CAL_K0_FRAC = 5.7841386975994235e-08  # ~1x lab — field rate closer to lab at 15-min
-LAM_CAL_EA_J_MOL = 3748.510470404377  # 0.10x lab — low temperature sensitivity in residential
-LAM_CAL_EXPONENT_B = 0.788762656479986  # 1.05x lab — slightly super-sqrt time dependence
-LAM_CAL_SOC_EXPONENT_N = 0.10230418425202481  # 0.14x lab — SOC stress much weaker in field cycling
+# === Lam + Naumann field-calibrated parameters (current default, 15-min) ===
+# Re-run on 2026-04-12 against the effective 5-system Zenodo LFP field set
+# (systems 14, 15, 17, 20, 21) using the finalized validation pipeline.
+# Mean RMSE = 4.40pp on the full calibration fit; LOO mean CV RMSE = 6.0pp.
+LAM_NAUMANN_FIELD_CALIBRATED_K0_FRAC = 8.019530e-08
+LAM_NAUMANN_FIELD_CALIBRATED_EA_J_MOL = 11876.09
+LAM_NAUMANN_FIELD_CALIBRATED_EXPONENT_B = 0.7701374
+LAM_NAUMANN_FIELD_CALIBRATED_SOC_EXPONENT_N = 0.1010299
+
+# Backward-compatible aliases for the primary field-calibrated model.
+LAM_CAL_K0_FRAC = LAM_NAUMANN_FIELD_CALIBRATED_K0_FRAC
+LAM_CAL_EA_J_MOL = LAM_NAUMANN_FIELD_CALIBRATED_EA_J_MOL
+LAM_CAL_EXPONENT_B = LAM_NAUMANN_FIELD_CALIBRATED_EXPONENT_B
+LAM_CAL_SOC_EXPONENT_N = LAM_NAUMANN_FIELD_CALIBRATED_SOC_EXPONENT_N
+
+# === Lam + Naumann field-calibrated parameters (previous 15-min fit) ===
+# Retained for reproducibility under the model name
+# `lam_naumann_field_calibrated_old`.
+LAM_NAUMANN_FIELD_CALIBRATED_OLD_K0_FRAC = 5.7841386975994235e-08
+LAM_NAUMANN_FIELD_CALIBRATED_OLD_EA_J_MOL = 3748.510470404377
+LAM_NAUMANN_FIELD_CALIBRATED_OLD_EXPONENT_B = 0.788762656479986
+LAM_NAUMANN_FIELD_CALIBRATED_OLD_SOC_EXPONENT_N = 0.10230418425202481
+
+# Optional aliases for code that wants to reference the old fit directly.
+LAM_CAL_OLD_K0_FRAC = LAM_NAUMANN_FIELD_CALIBRATED_OLD_K0_FRAC
+LAM_CAL_OLD_EA_J_MOL = LAM_NAUMANN_FIELD_CALIBRATED_OLD_EA_J_MOL
+LAM_CAL_OLD_EXPONENT_B = LAM_NAUMANN_FIELD_CALIBRATED_OLD_EXPONENT_B
+LAM_CAL_OLD_SOC_EXPONENT_N = LAM_NAUMANN_FIELD_CALIBRATED_OLD_SOC_EXPONENT_N
 
 # === Lam Calibrated Parameters — Hourly resolution (legacy) ===
 # Same calibration as above but fitted at hourly (1h) resolution.
@@ -76,7 +93,7 @@ LAM_CAL_RELAXED_EXPONENT_B = LAM_CAL_EXPONENT_B  # Same time exponent
 LAM_CAL_RELAXED_SOC_EXPONENT_N = LAM_CAL_SOC_EXPONENT_N  # Same SOC sensitivity
 
 # === Modern LFP Parameters (projected for 2020+ cells) ===
-# The lam_calibrated model was fitted to 2015-era residential LFP systems.
+# The lam_naumann_field_calibrated model was fitted to 2015-era residential LFP systems.
 # Modern cells (CATL/BYD, 2020+) use improved electrolyte formulations and
 # BMS designs that are expected to reduce calendar aging. No field calibration
 # data is available for these newer cells yet.

--- a/breos/economics.py
+++ b/breos/economics.py
@@ -8,7 +8,7 @@ This module handles:
 - Payback period analysis
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import numpy as np
@@ -32,15 +32,18 @@ class CostParams:
     # Equipment costs
     module_cost_per_w: float = 0.125  # €/W
     battery_cost_per_kwh: float = BATTERY_REPLACEMENT_COST_PER_KWH  # €/kWh
+    dc_ac_ratio: float = 1.25  # DC/AC sizing ratio for inverter CAPEX
     inverter_cost_per_kw: float = 102.58  # €/kW (with battery)
     inverter_cost_per_kw_nobatt: float = 48.37  # €/kW (without battery)
     installation_cost_per_module: float = 350.0  # €/module
     battery_installation_cost: float = 350.0  # € fixed
     other_cost_per_module: float = 50.0  # € cables, etc.
+    other_cost_fixed: float = 0.0  # € fixed misc. costs
     land_cost: float = 0.0
 
     # Operations
     maintenance_cost_per_panel: float = 10.0  # €/panel/year
+    maintenance_cost_fixed: float = 0.0  # € fixed /year
     operation_cost: float = 0.0  # € additional /year
 
     # Thermal system costs (TES + Heat Pump)
@@ -83,6 +86,7 @@ def calculate_costs(
         cost_params = CostParams()
 
     total_power_kw = n_modules * module_power_w / 1000
+    inverter_power_kw = total_power_kw / cost_params.dc_ac_ratio if cost_params.dc_ac_ratio > 0 else total_power_kw
     has_battery = battery_capacity_wh > 1
 
     # PV module costs
@@ -96,13 +100,13 @@ def calculate_costs(
     # Battery costs
     if has_battery:
         battery_cost = (battery_capacity_wh / 1000) * cost_params.battery_cost_per_kwh
-        inverter_cost = cost_params.inverter_cost_per_kw * total_power_kw
+        inverter_cost = cost_params.inverter_cost_per_kw * inverter_power_kw
     else:
         battery_cost = 0.0
-        inverter_cost = cost_params.inverter_cost_per_kw_nobatt * total_power_kw
+        inverter_cost = cost_params.inverter_cost_per_kw_nobatt * inverter_power_kw
 
     # Other costs
-    other_costs = cost_params.other_cost_per_module * n_modules
+    other_costs = (cost_params.other_cost_per_module * n_modules) + cost_params.other_cost_fixed
 
     # TES + Heat Pump costs
     tes_cost = tes_capacity_kwh_th * cost_params.tes_cost_per_kwh_th
@@ -112,8 +116,9 @@ def calculate_costs(
     # Maintenance
     annual_operation_cost = (
         cost_params.maintenance_cost_per_panel * n_modules
+        + cost_params.maintenance_cost_fixed
         + cost_params.operation_cost
-        + cost_params.hp_maintenance_annual
+        + (cost_params.hp_maintenance_annual if heat_pump_kw_th > 0 else 0.0)
     )
 
     # Total CAPEX

--- a/configs/costs.json
+++ b/configs/costs.json
@@ -1,7 +1,7 @@
 {
     "residential_pt": {
-        "electricity_cost": 0.2577,
-        "electricity_cost_excl_vat": 0.1675,
+        "electricity_cost": 0.2582,
+        "electricity_cost_excl_vat": 0.1695,
         "electricity_sold_cost": 0.04,
         "module_cost_per_w": 0.125,
         "inverter_cost_per_kw_hybrid": 102.58,
@@ -10,7 +10,7 @@
         "installation_cost_per_module": 350,
         "installation_cost_battery": 350,
         "maintenance_cost": 50,
-        "daily_power_cost": 0.30,
+        "daily_power_cost": 0.3,
         "other_costs": 50,
         "tes_cost_per_kwh_th": 200,
         "heat_pump_cost_per_kw_th": 500,
@@ -19,7 +19,8 @@
         "tes_installation_cost": 500
     },
     "residential_de": {
-        "electricity_cost": 0.4001,
+        "electricity_cost": 0.4042,
+        "electricity_cost_excl_vat": 0.2772,
         "electricity_sold_cost": 0.079,
         "module_cost_per_w": 0.25,
         "inverter_cost_per_kw_hybrid": 102.58,
@@ -28,7 +29,7 @@
         "installation_cost_per_module": 400,
         "installation_cost_battery": 400,
         "maintenance_cost": 75,
-        "daily_power_cost": 0.30,
+        "daily_power_cost": 0.3,
         "other_costs": 75,
         "tes_cost_per_kwh_th": 200,
         "heat_pump_cost_per_kw_th": 500,
@@ -37,7 +38,8 @@
         "tes_installation_cost": 500
     },
     "residential_es": {
-        "electricity_cost": 0.2845,
+        "electricity_cost": 0.2841,
+        "electricity_cost_excl_vat": 0.1967,
         "electricity_sold_cost": 0.08,
         "module_cost_per_w": 0.20,
         "inverter_cost_per_kw_hybrid": 102.58,
@@ -46,7 +48,7 @@
         "installation_cost_per_module": 350,
         "installation_cost_battery": 350,
         "maintenance_cost": 50,
-        "daily_power_cost": 0.30,
+        "daily_power_cost": 0.3,
         "other_costs": 50,
         "tes_cost_per_kwh_th": 200,
         "heat_pump_cost_per_kw_th": 500,

--- a/configs/emissions.json
+++ b/configs/emissions.json
@@ -1,26 +1,26 @@
 {
     "PT": {
-        "grid_carbon_intensity_gco2_kwh": 110.52,
-        "source": "Our World in Data / Ember Climate",
-        "year": 2024,
+        "grid_carbon_intensity_gco2_kwh": 127.91,
+        "source": "Ember Climate, Europe Yearly Full Release",
+        "year": 2025,
         "country": "Portugal"
     },
     "DE": {
-        "grid_carbon_intensity_gco2_kwh": 338.36,
-        "source": "Our World in Data / Ember Climate",
-        "year": 2024,
+        "grid_carbon_intensity_gco2_kwh": 329.65,
+        "source": "Ember Climate, Europe Yearly Full Release",
+        "year": 2025,
         "country": "Germany"
     },
     "ES": {
-        "grid_carbon_intensity_gco2_kwh": 145.89,
-        "source": "Our World in Data / Ember Climate",
-        "year": 2024,
+        "grid_carbon_intensity_gco2_kwh": 153.60,
+        "source": "Ember Climate, Europe Yearly Full Release",
+        "year": 2025,
         "country": "Spain"
     },
     "NO": {
-        "grid_carbon_intensity_gco2_kwh": 30.75,
-        "source": "Our World in Data / Ember Climate",
-        "year": 2024,
+        "grid_carbon_intensity_gco2_kwh": 28.11,
+        "source": "Ember Climate, Europe Yearly Full Release",
+        "year": 2025,
         "country": "Norway"
     },
     "AU": {

--- a/configs/financials.json
+++ b/configs/financials.json
@@ -2,6 +2,6 @@
     "inflation_elec": 0.02,
     "discount_rate": 0.03,
     "project_lifespan": 20,
-    "elec_price_grid": 0.2577,
+    "elec_price_grid": 0.2582,
     "elec_price_export": 0.04
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,10 +145,11 @@ def temperature_series(synthetic_weather):
 @pytest.fixture
 def cost_params():
     return CostParams(
-        electricity_cost=0.2577,
+        electricity_cost=0.2582,
         electricity_sold_cost=0.04,
         module_cost_per_w=0.125,
         battery_cost_per_kwh=711.0,
+        dc_ac_ratio=1.25,
         inverter_cost_per_kw=102.58,
         inverter_cost_per_kw_nobatt=48.37,
         installation_cost_per_module=350.0,
@@ -169,7 +170,8 @@ def cost_params():
 @pytest.fixture
 def emissions_params():
     return EmissionsParams(
-        grid_carbon_intensity_gco2_kwh=110.52,
+        grid_carbon_intensity_gco2_kwh=127.91,
+        year=2025,
         country="Portugal",
     )
 

--- a/tests/test_economics.py
+++ b/tests/test_economics.py
@@ -17,7 +17,7 @@ class TestCalculateCosts:
         assert costs["pv_cost"] == pytest.approx(10 * 550 * 0.125)
         assert costs["total_initial_cost"] > 0
         # No battery → simple inverter
-        assert costs["inverter_cost"] == pytest.approx(48.37 * 10 * 550 / 1000, rel=0.01)
+        assert costs["inverter_cost"] == pytest.approx(48.37 * (10 * 550 / 1000) / 1.25, rel=0.01)
 
     def test_with_battery(self, cost_params):
         costs = calculate_costs(
@@ -28,7 +28,7 @@ class TestCalculateCosts:
         )
         assert costs["battery_cost"] == pytest.approx(5 * 711.0)
         # With battery → hybrid inverter (more expensive)
-        assert costs["inverter_cost"] == pytest.approx(102.58 * 10 * 550 / 1000, rel=0.01)
+        assert costs["inverter_cost"] == pytest.approx(102.58 * (10 * 550 / 1000) / 1.25, rel=0.01)
         assert costs["total_initial_cost"] > costs["pv_cost"] + costs["battery_cost"]
 
     def test_cost_breakdown_sums_to_total(self, cost_params):

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -28,8 +28,8 @@ class TestCO2Savings:
 
     def test_portugal_intensity(self, emissions_params):
         result = calculate_co2_savings(1000.0, 500.0, emissions_params)
-        # 1000 * 110.52 / 1000 = 110.52 kg
-        assert result["CO2_Avoided_Total_kg"] == pytest.approx(110.52)
+        # 1000 * 127.91 / 1000 = 127.91 kg
+        assert result["CO2_Avoided_Total_kg"] == pytest.approx(127.91)
 
 
 class TestCO2Projection:


### PR DESCRIPTION
## Summary
- update the BREOS battery calendar-aging calibration to the latest upstream field-fit while keeping legacy aliases working
- align applicable cost semantics with upstream sizing and fixed-cost handling
- refresh shared costs, financial defaults, and emissions values, and update affected tests

## Verification
- uv run --extra dev python -m pytest tests/test_battery.py tests/test_economics.py tests/test_emissions.py tests/test_app.py