### PR TITLE
Add support for PV arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ print(f"CO2 avoided: {result['co2_avoided_total_kg']:,.0f} kg")
 
 ## Configuration
 
-All keys except `location`, `n_modules`, and `annual_consumption_kwh` are optional with sensible defaults.
+All keys except `location`, `annual_consumption_kwh`, and either `n_modules` or `pv_arrays` are optional with sensible defaults.
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `location` | *required* | Preset key (`"porto"`, `"berlin"`, ...) or dict with `latitude`, `longitude`, `timezone` |
-| `n_modules` | *required* | Number of PV modules |
+| `n_modules` | *required unless `pv_arrays` is set* | Number of PV modules |
+| `pv_arrays` | `None` | Optional list of arrays with `modules`, `module`, `tilt`/`slope`, and `azimuth`; when present, the array module total overrides `n_modules` |
 | `annual_consumption_kwh` | *required* | Annual electricity demand (kWh) |
 | `battery_kwh` | `0.0` | Battery capacity (0 = no battery) |
 | `pv_module` | `None` | Module name from catalogue (`None` = default) |
@@ -98,7 +99,29 @@ All keys except `location`, `n_modules`, and `annual_consumption_kwh` are option
 | `co2_avoided_year1_kg` | Year 1 CO2 avoided |
 | `co2_avoided_total_kg` | Lifetime CO2 avoided |
 | `battery_soh_end_pct` | Battery state of health at end (if battery) |
+| `monthly` | Year 1 monthly balance rows for PV, load, imports, exports, and self-consumption |
+| `financial` | Yearly financial projection rows, including year 0 investment |
 | `yearly` | List of per-year dicts with detailed breakdown |
+
+### Multi-array PV systems
+
+Use `pv_arrays` when a roof has panels on different faces or orientations:
+
+```python
+app = breos.App({
+    "location": "porto",
+    "annual_consumption_kwh": 4000,
+    "pv_arrays": [
+        {"modules": 8, "module": "Erlangen_445W", "tilt": 10, "azimuth": 90},
+        {"modules": 8, "module": "Erlangen_445W", "tilt": 10, "azimuth": 270},
+    ],
+})
+app.simulate()
+```
+
+BREOS calculates production per array and combines the DC output before the
+energy balance, so east-west and pitched-roof layouts are not collapsed into a
+single representative tilt/azimuth.
 
 ## Advanced Usage
 

--- a/breos/app.py
+++ b/breos/app.py
@@ -491,7 +491,9 @@ class App:
 
         default_module = self._cfg.get("pv_module") or next(iter(MODULES))
         default_tilt = self._cfg.get("tilt") if self._cfg.get("tilt") is not None else estimate_optimal_tilt(self._lat)
-        default_azimuth = self._cfg.get("azimuth") if self._cfg.get("azimuth") is not None else default_azimuth_fn(self._lat)
+        default_azimuth = (
+            self._cfg.get("azimuth") if self._cfg.get("azimuth") is not None else default_azimuth_fn(self._lat)
+        )
 
         normalized = []
         for arr in arrays:

--- a/breos/app.py
+++ b/breos/app.py
@@ -29,7 +29,14 @@ from breos.economics import CostParams, calculate_costs, calculate_lcoe, cost_an
 from breos.emissions import EmissionsParams, calculate_co2_savings
 from breos.load_profiles import load_profile
 from breos.pv_modules import MODULES, get_module
-from breos.solar import calculate_pv_production_dc, default_azimuth, estimate_optimal_tilt
+from breos.solar import (
+    calculate_multi_array_production,
+    calculate_pv_production_dc,
+    estimate_optimal_tilt,
+)
+from breos.solar import (
+    default_azimuth as default_azimuth_fn,
+)
 from breos.utils import get_hours_per_step
 from breos.weather import extract_ambient_temperature, fetch_tmy_weather_data, load_weather, resample_to_15min
 
@@ -39,6 +46,7 @@ _CONFIGS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "configs
 
 _DEFAULTS: Dict[str, Any] = {
     "battery_kwh": 0.0,
+    "pv_arrays": None,
     "pv_module": None,
     "load_profile": "6",
     "tilt": None,
@@ -99,12 +107,16 @@ class App:
 
         - ``location`` — preset key (``"porto"``) **or** dict with
           ``latitude``, ``longitude``, ``timezone``.
-        - ``n_modules`` — number of PV modules (int, > 0).
+        - ``n_modules`` — number of PV modules (int, > 0), unless
+          ``pv_arrays`` is provided.
         - ``annual_consumption_kwh`` — yearly electricity demand (float, > 0).
 
         Optional keys (with defaults):
 
         - ``battery_kwh`` (0.0) — battery capacity; 0 = no battery.
+        - ``pv_arrays`` (None) — list of arrays with ``modules``, ``module``,
+          ``tilt``/``slope``, and ``azimuth``. When set, BREOS calculates each
+          array separately and combines production before the energy balance.
         - ``pv_module`` (None) — PV module name from the catalogue; None = first available.
         - ``load_profile`` ("6") — load profile type ("1"–"8").
         - ``tilt`` (None) — tilt angle in degrees; None = auto from latitude.
@@ -145,15 +157,30 @@ class App:
             self._tz = loc["timezone"]
             self._loc_key = None
 
+        # Resolve PV arrays, if provided. Multi-array systems are the preferred
+        # representation for Designer rooftops because mixed faces cannot be
+        # reduced to one tilt/azimuth pair without losing production fidelity.
+        self._pv_arrays = self._normalise_pv_arrays(cfg.get("pv_arrays"))
+        if self._pv_arrays:
+            cfg["n_modules"] = sum(arr["modules"] for arr in self._pv_arrays)
+            total_power_w = sum(arr["modules"] * get_module(arr["module"]).Mpp for arr in self._pv_arrays)
+            self._avg_module_power_w = total_power_w / cfg["n_modules"]
+            self._system_kwp = total_power_w / 1000
+            module_name = self._pv_arrays[0]["module"]
+        else:
+            module_name = cfg["pv_module"]
+
         # Resolve PV module
-        module_name = cfg["pv_module"]
         if module_name is None:
             module_name = next(iter(MODULES))
         self._pv_params = get_module(module_name)
+        if not self._pv_arrays:
+            self._avg_module_power_w = self._pv_params.Mpp
+            self._system_kwp = cfg["n_modules"] * self._pv_params.Mpp / 1000
 
         # Resolve tilt / azimuth
         self._tilt = cfg["tilt"] if cfg["tilt"] is not None else estimate_optimal_tilt(self._lat)
-        self._azimuth = cfg["azimuth"] if cfg["azimuth"] is not None else default_azimuth(self._lat)
+        self._azimuth = cfg["azimuth"] if cfg["azimuth"] is not None else default_azimuth_fn(self._lat)
 
         # Resolve cost preset
         self._cost_params = self._resolve_costs(cfg)
@@ -190,15 +217,24 @@ class App:
 
         # 2. PV — 1-module DC production
         location = Location(self._lat, self._lon, tz=self._tz)
-        dc_1mod = calculate_pv_production_dc(
-            weather_data=weather,
-            location=location,
-            tilt=self._tilt,
-            surface_azimuth=self._azimuth,
-            n_modules=1,
-            pv_params=self._pv_params,
-            freq=freq,
-        )
+        if self._pv_arrays:
+            dc_system_base = calculate_multi_array_production(
+                weather_data=weather,
+                location=location,
+                arrays=self._pv_arrays,
+                freq=freq,
+            )
+        else:
+            dc_1mod = calculate_pv_production_dc(
+                weather_data=weather,
+                location=location,
+                tilt=self._tilt,
+                surface_azimuth=self._azimuth,
+                n_modules=1,
+                pv_params=self._pv_params,
+                freq=freq,
+            )
+            dc_system_base = dc_1mod * n_modules
 
         # 3. Load profile
         load_data = load_profile(
@@ -234,7 +270,7 @@ class App:
 
         for year_idx in range(projection_years):
             pv_degradation_factor = (1 - degradation_rate) ** year_idx
-            dc_power = dc_1mod * n_modules * pv_degradation_factor
+            dc_power = dc_system_base * pv_degradation_factor
 
             if has_battery:
                 batt_cfg = BatteryConfig(
@@ -334,7 +370,7 @@ class App:
 
         total_initial = costs_dict["total_initial_cost"]
         npv_savings = float(cost_proj["Savings_Cumulative_NPV"].iloc[-1])
-        system_kwp = n_modules * self._pv_params.Mpp / 1000
+        system_kwp = self._system_kwp
 
         lcoe = calculate_lcoe(
             total_investment=total_initial,
@@ -366,7 +402,20 @@ class App:
             "lcoe_eur_kwh": round(float(lcoe), 4),
             # Yearly breakdown
             "yearly": self._yearly_to_dicts(yearly_df),
+            "monthly": self._monthly_to_dicts(first_year_results_df, freq),
+            "financial": self._financial_to_dicts(cost_proj, total_initial),
         }
+
+        if self._pv_arrays:
+            result["pv_arrays"] = [
+                {
+                    "modules": arr["modules"],
+                    "module": arr["module"],
+                    "slope": arr["tilt"],
+                    "azimuth": arr["azimuth"],
+                }
+                for arr in self._pv_arrays
+            ]
 
         # Battery (only if present)
         if has_battery:
@@ -398,9 +447,13 @@ class App:
     @staticmethod
     def _validate(cfg: dict) -> None:
         # Required keys
-        for key in ("location", "n_modules", "annual_consumption_kwh"):
+        for key in ("location", "annual_consumption_kwh"):
             if key not in cfg:
                 raise ValueError(f"Missing required config key: '{key}'")
+
+        has_arrays = bool(cfg.get("pv_arrays"))
+        if not has_arrays and "n_modules" not in cfg:
+            raise ValueError("Missing required config key: 'n_modules'")
 
         loc = cfg["location"]
         if isinstance(loc, dict):
@@ -410,12 +463,51 @@ class App:
         elif not isinstance(loc, str):
             raise TypeError("'location' must be a string key or a dict with latitude/longitude/timezone")
 
-        if cfg["n_modules"] < 1:
+        if not has_arrays and cfg["n_modules"] < 1:
             raise ValueError("'n_modules' must be >= 1")
+        if has_arrays:
+            if not isinstance(cfg["pv_arrays"], list):
+                raise TypeError("'pv_arrays' must be a list")
+            for i, arr in enumerate(cfg["pv_arrays"]):
+                if not isinstance(arr, dict):
+                    raise TypeError(f"'pv_arrays[{i}]' must be a dict")
+                modules = arr.get("modules", arr.get("n_modules", 0))
+                if modules < 1:
+                    raise ValueError(f"'pv_arrays[{i}].modules' must be >= 1")
+                tilt = arr.get("tilt", arr.get("slope", cfg.get("tilt")))
+                azimuth = arr.get("azimuth", cfg.get("azimuth"))
+                if tilt is not None and not 0 <= tilt <= 90:
+                    raise ValueError(f"'pv_arrays[{i}].tilt' must be between 0 and 90")
+                if azimuth is not None and not 0 <= azimuth <= 360:
+                    raise ValueError(f"'pv_arrays[{i}].azimuth' must be between 0 and 360")
         if cfg["annual_consumption_kwh"] <= 0:
             raise ValueError("'annual_consumption_kwh' must be > 0")
         if cfg["resolution"] not in ("h", "15min"):
             raise ValueError("'resolution' must be 'h' or '15min'")
+
+    def _normalise_pv_arrays(self, arrays: Optional[list]) -> list[dict]:
+        if not arrays:
+            return []
+
+        default_module = self._cfg.get("pv_module") or next(iter(MODULES))
+        default_tilt = self._cfg.get("tilt") if self._cfg.get("tilt") is not None else estimate_optimal_tilt(self._lat)
+        default_azimuth = self._cfg.get("azimuth") if self._cfg.get("azimuth") is not None else default_azimuth_fn(self._lat)
+
+        normalized = []
+        for arr in arrays:
+            modules = int(arr.get("modules", arr.get("n_modules")))
+            module = arr.get("module") or default_module
+            tilt = arr.get("tilt", arr.get("slope", default_tilt))
+            azimuth = arr.get("azimuth", default_azimuth)
+            normalized.append(
+                {
+                    "modules": modules,
+                    "module": module,
+                    "tilt": float(tilt),
+                    "azimuth": float(azimuth),
+                }
+            )
+        return normalized
 
     def _load_weather(self, freq: str, start_year: int) -> pd.DataFrame:
         """Load TMY weather, falling back to PVGIS fetch."""
@@ -489,10 +581,61 @@ class App:
 
         return calculate_costs(
             n_modules=n_modules,
-            module_power_w=self._pv_params.Mpp,
+            module_power_w=self._avg_module_power_w,
             battery_capacity_wh=battery_kwh * 1000,
             cost_params=self._cost_params,
         )
+
+    @staticmethod
+    def _monthly_to_dicts(results_df: pd.DataFrame, freq: str) -> list:
+        """Convert first-year timestep results into monthly energy rows."""
+        hours_per_step = get_hours_per_step(freq)
+        df = results_df.copy()
+        if not isinstance(df.index, pd.DatetimeIndex):
+            if "Datetime" in df.columns:
+                df["Datetime"] = pd.to_datetime(df["Datetime"], utc=True)
+                df.set_index("Datetime", inplace=True)
+            else:
+                raise ValueError("results_df must have a DatetimeIndex or Datetime column")
+
+        monthly = df[["PV_Production", "Houseload", "Import_From_Grid", "Sell_To_Grid"]].resample("ME").sum()
+        monthly = monthly * hours_per_step / 1000
+
+        rows = []
+        for idx, row in monthly.iterrows():
+            pv = float(row["PV_Production"])
+            consumption = float(row["Houseload"])
+            export = float(row["Sell_To_Grid"])
+            imported = float(row["Import_From_Grid"])
+            self_consumption = pv - export
+            rows.append(
+                {
+                    "month": idx.strftime("%b"),
+                    "pv_kwh": round(pv, 2),
+                    "consumption_kwh": round(consumption, 2),
+                    "self_consumption_kwh": round(self_consumption, 2),
+                    "import_kwh": round(imported, 2),
+                    "export_kwh": round(export, 2),
+                    "grid_independence_pct": round((1 - imported / consumption) * 100, 2) if consumption > 0 else 0.0,
+                }
+            )
+        return rows
+
+    @staticmethod
+    def _financial_to_dicts(cost_proj: pd.DataFrame, total_initial_cost: float) -> list:
+        """Convert BREOS cost projection into the dashboard line-chart shape."""
+        rows = [{"year": 0, "balance": round(-float(total_initial_cost), 2), "reference": 0.0}]
+        for _, row in cost_proj.iterrows():
+            rows.append(
+                {
+                    "year": int(row["Year"]),
+                    "balance": round(float(row["Savings_Cumulative_NPV"]), 2),
+                    "reference": 0.0,
+                    "cost_with_system": round(float(row["Cost_System_Cumulative_NPV"]), 2),
+                    "cost_without_system": round(float(row["Cost_No_Sys_Cumulative_NPV"]), 2),
+                }
+            )
+        return rows
 
     @staticmethod
     def _yearly_to_dicts(yearly_df: pd.DataFrame) -> list:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -63,6 +63,19 @@ class TestAppValidation:
         )
         assert app._lat == 41.15
 
+    def test_pv_arrays_allow_missing_n_modules(self):
+        app = App(
+            {
+                "location": "porto",
+                "annual_consumption_kwh": 3000,
+                "pv_arrays": [
+                    {"modules": 3, "module": "Erlangen_445W", "tilt": 10, "azimuth": 90},
+                    {"modules": 3, "module": "Erlangen_445W", "tilt": 10, "azimuth": 270},
+                ],
+            }
+        )
+        assert app._cfg["n_modules"] == 6
+
     def test_result_before_simulate(self):
         app = App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000})
         with pytest.raises(RuntimeError, match="simulate"):
@@ -119,11 +132,17 @@ class TestAppSimulateNoBattery:
             "co2_avoided_year1_kg",
             "co2_avoided_total_kg",
             "yearly",
+            "monthly",
+            "financial",
         }
         assert expected.issubset(self.result.keys())
 
     def test_yearly_length(self):
         assert len(self.result["yearly"]) == 5
+
+    def test_monthly_and_financial_lengths(self):
+        assert len(self.result["monthly"]) == 12
+        assert len(self.result["financial"]) == 6
 
     def test_system_echo(self):
         assert self.result["n_modules"] == 6
@@ -146,6 +165,38 @@ class TestAppSimulateNoBattery:
 
     def test_lcoe_positive(self):
         assert self.result["lcoe_eur_kwh"] > 0
+
+
+class TestAppSimulateMultiArray:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _patch_weather):
+        self.app = App(
+            {
+                "location": "porto",
+                "annual_consumption_kwh": 3000,
+                "cost_preset": "residential_pt",
+                "projection_years": 5,
+                "pv_arrays": [
+                    {"modules": 3, "module": "Erlangen_445W", "slope": 10, "azimuth": 90},
+                    {"modules": 3, "module": "Erlangen_445W", "slope": 10, "azimuth": 270},
+                ],
+            }
+        )
+        self.app.simulate()
+        self.result = self.app.result()
+
+    def test_arrays_are_echoed(self):
+        assert self.result["n_modules"] == 6
+        assert len(self.result["pv_arrays"]) == 2
+        assert {arr["azimuth"] for arr in self.result["pv_arrays"]} == {90.0, 270.0}
+
+    def test_multi_array_result_has_chart_data(self):
+        assert len(self.result["monthly"]) == 12
+        assert self.result["financial"][0]["year"] == 0
+        assert self.result["financial"][-1]["year"] == 5
+
+    def test_multi_array_energy_positive(self):
+        assert self.result["pv_production_kwh"] > 0
 
 
 class TestAppSimulateWithBattery:


### PR DESCRIPTION
## Summary
- allow simulations to accept multiple PV arrays with independent module counts, modules, tilt/slope, and azimuth
- combine multi-array DC production before energy balance and cost calculations
- document pv_arrays usage and add app tests for the new configuration path

## Tests
- uv run pytest