### PR TITLE
Sanitize weather output filenames and cap request cache TTL

### DIFF
--- a/breos/utils.py
+++ b/breos/utils.py
@@ -4,6 +4,29 @@ Utility functions for breos library.
 
 import multiprocessing
 import os
+import re
+
+_SAFE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def safe_path_slug(name: str) -> str:
+    """Validate *name* as a safe filename component and return it lower-cased.
+
+    Input is lower-cased, then validated: allowed characters are ASCII letters,
+    digits, ``_``, ``-``. The result must start with an alphanumeric character
+    and be at most 64 characters. Anything else (path separators, ``..``, NUL
+    bytes, spaces, dots) is rejected so the value cannot be used to escape an
+    intended output directory when interpolated into a filename.
+    """
+    if not isinstance(name, str):
+        raise TypeError(f"safe_path_slug: expected str, got {type(name).__name__}")
+    lowered = name.lower()
+    if not _SAFE_SLUG_RE.match(lowered):
+        raise ValueError(
+            f"Cannot use {name!r} as a filename component "
+            "(allowed: a-z, 0-9, _, -; must start alphanumeric; max 64 chars)"
+        )
+    return lowered
 
 
 def is_leap_year(year: int) -> bool:

--- a/breos/weather.py
+++ b/breos/weather.py
@@ -10,6 +10,7 @@ This module handles:
 import os
 import random
 import re
+from datetime import timedelta
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
@@ -17,6 +18,8 @@ import pandas as pd
 import pvlib
 from pvlib.location import Location
 from scipy.interpolate import Akima1DInterpolator
+
+from breos.utils import safe_path_slug
 
 # Optional imports for API calls
 try:
@@ -289,8 +292,10 @@ def fetch_weather_data(
             "Install with: uv add openmeteo-requests requests-cache"
         )
 
-    # Setup the Open-Meteo API client with cache and retry
-    cache_session = requests_cache.CachedSession(".cache", expire_after=-1)
+    # Setup the Open-Meteo API client with cache and retry. Cache expires
+    # after 30 days so we don't serve indefinitely-stale entries if a single
+    # bad response was ever written.
+    cache_session = requests_cache.CachedSession(".cache", expire_after=timedelta(days=30))
     retries = Retry(total=5, backoff_factor=0.2, status_forcelist=[500, 502, 503, 504])
     cache_session.mount("https://", HTTPAdapter(max_retries=retries))
     cache_session.mount("http://", HTTPAdapter(max_retries=retries))
@@ -351,7 +356,7 @@ def fetch_weather_data(
         start_year = start_date[:4]
         end_year = end_date[:4]
         if location_name:
-            loc_slug = location_name.lower()
+            loc_slug = safe_path_slug(location_name)
         else:
             loc_slug = f"lat{latitude:.0f}_lon{longitude:.0f}"
         filename = os.path.join(output_dir, f"{loc_slug}_historical_{start_year}_{end_year}_openmeteo.csv")
@@ -818,8 +823,9 @@ def fetch_tmy_nsrdb(
         df = resample_to_15min(df, method="makima", latitude=latitude, longitude=longitude)
 
     if save_to_file and location_name:
-        vintage = year if year != "tmy" else "tmy"
-        filename = f"weather/{location_name}_tmy_{vintage}_nsrdb.csv"
+        loc_slug = safe_path_slug(location_name)
+        vintage = safe_path_slug(year) if year != "tmy" else "tmy"
+        filename = f"weather/{loc_slug}_tmy_{vintage}_nsrdb.csv"
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         df.to_csv(filename)
         print(f"Saved NSRDB data to {filename}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+"""Tests for breos.utils."""
+
+import pytest
+
+from breos.utils import safe_path_slug
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("porto", "porto"),
+        ("porto_2024", "porto_2024"),
+        ("porto-de", "porto-de"),
+        ("PORTO", "porto"),
+        ("Berlin", "berlin"),
+        ("a", "a"),
+        ("a" * 64, "a" * 64),
+    ],
+)
+def test_safe_path_slug_accepts_valid(name, expected):
+    assert safe_path_slug(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "../etc/passwd",
+        "/abs/path",
+        "porto/sub",
+        r"porto\sub",
+        "porto..bad",
+        ".hidden",
+        "_leading",
+        "-leading",
+        "porto bad",
+        "porto.bad",
+        "porto\x00null",
+        "a" * 65,
+    ],
+)
+def test_safe_path_slug_rejects_unsafe(name):
+    with pytest.raises(ValueError):
+        safe_path_slug(name)
+
+
+def test_safe_path_slug_rejects_non_string():
+    with pytest.raises(TypeError):
+        safe_path_slug(123)

--- a/tools/fetch_historical_weather.py
+++ b/tools/fetch_historical_weather.py
@@ -22,6 +22,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from breos.utils import safe_path_slug
 from breos.weather import fetch_weather_data
 
 LOCATIONS_PATH = PROJECT_ROOT / "configs" / "base" / "locations.json"
@@ -40,6 +41,9 @@ def resolve_cities(config: dict) -> dict[str, dict]:
     resolved = {}
 
     for key, value in config["cities"].items():
+        # Validate every key — it will later be interpolated into an output
+        # filename via fetch_city().
+        safe_path_slug(key)
         if isinstance(value, dict):
             resolved[key] = value
         elif value == "locations":
@@ -63,6 +67,9 @@ def add_cities_to_locations(cities: dict[str, dict], config: dict) -> None:
 
     for key, value in config["cities"].items():
         if isinstance(value, dict) and key not in locations:
+            # Validate as a safe filename slug so a later fetch_city call cannot
+            # use this key to escape WEATHER_DIR.
+            safe_path_slug(key)
             locations[key] = value
             added.append(key)
 
@@ -77,7 +84,9 @@ def add_cities_to_locations(cities: dict[str, dict], config: dict) -> None:
 
 def fetch_city(city_key: str, city_info: dict, start_year: int, end_year: int, source: str, force: bool) -> bool:
     """Fetch weather data for a single city. Returns True if data was fetched."""
-    outfile = WEATHER_DIR / f"{city_key}_historical_{start_year}_{end_year}_{source}.csv"
+    key_slug = safe_path_slug(city_key)
+    source_slug = safe_path_slug(source)
+    outfile = WEATHER_DIR / f"{key_slug}_historical_{start_year}_{end_year}_{source_slug}.csv"
 
     if outfile.exists() and not force:
         print(f"SKIP: {outfile.name} already exists (use --force to overwrite)")

--- a/tools/fetch_weather.py
+++ b/tools/fetch_weather.py
@@ -44,9 +44,11 @@ def resolve_location(name: str) -> dict:
 
 
 def fetch_tmy(args):
+    from breos.utils import safe_path_slug
     from breos.weather import fetch_tmy_weather_data, parse_weather_filename
 
     loc = resolve_location(args.location)
+    loc_slug = safe_path_slug(args.location)
     print(f"Location: {args.location} ({loc['latitude']}, {loc['longitude']})")
 
     # Check if TMY already exists locally
@@ -54,7 +56,7 @@ def fetch_tmy(args):
     existing = []
     for fname in os.listdir(WEATHER_DIR):
         parsed = parse_weather_filename(fname)
-        if parsed and parsed["location"] == args.location and parsed["type"] == "tmy":
+        if parsed and parsed["location"] == loc_slug and parsed["type"] == "tmy":
             existing.append(fname)
 
     if existing and not args.force:
@@ -76,7 +78,7 @@ def fetch_tmy(args):
     year_min = inputs.get("meteo_data", {}).get("year_min", "unknown")
     year_max = inputs.get("meteo_data", {}).get("year_max", "unknown")
     db_slug = f"pvgis-{rad_db.lower().replace('pvgis-', '')}"
-    filename = WEATHER_DIR / f"{args.location}_tmy_{year_min}_{year_max}_{db_slug}.csv"
+    filename = WEATHER_DIR / f"{loc_slug}_tmy_{year_min}_{year_max}_{db_slug}.csv"
 
     tmy_data.to_csv(filename)
     size_mb = filename.stat().st_size / 1e6
@@ -84,13 +86,15 @@ def fetch_tmy(args):
 
 
 def fetch_historical(args):
+    from breos.utils import safe_path_slug
     from breos.weather import fetch_weather_data
 
     loc = resolve_location(args.location)
+    loc_slug = safe_path_slug(args.location)
     print(f"Location: {args.location} ({loc['latitude']}, {loc['longitude']})")
     print(f"Period: {args.start}-{args.end}")
 
-    filename = WEATHER_DIR / f"{args.location}_historical_{args.start}_{args.end}_openmeteo.csv"
+    filename = WEATHER_DIR / f"{loc_slug}_historical_{args.start}_{args.end}_openmeteo.csv"
 
     if filename.exists() and not args.force:
         print(f"Already exists: {filename.name}")


### PR DESCRIPTION
## Summary

Two hardening fixes from a security review of the weather data path.

- **Path traversal (M1):** add `breos.utils.safe_path_slug` and apply it everywhere a caller-supplied string is interpolated into an output filename — `fetch_weather_data`, `fetch_tmy_nsrdb`, and the `tools/fetch_weather` + `tools/fetch_historical_weather` scripts. This prevents a value like `../../etc/foo` from escaping the intended `weather/` output directory when used as `location_name` or `city_key`. Also validates `city_key` at the config boundary in `resolve_cities` / `add_cities_to_locations` so a bad key cannot be persisted to `locations.json` and reused later.
- **Cache TTL (M2):** cap the Open-Meteo `requests_cache` TTL at 30 days (was `-1`, never expire). A one-off bad response can no longer be served indefinitely.

## Test plan

- [x] `uv run pytest tests/` — 91 passed (21 new tests in `tests/test_utils.py` covering `safe_path_slug` accept/reject behaviour).
- [x] `uv run ruff check breos/ tests/ tools/` — clean.
- [x] `uv run ruff format --check breos/ tests/ tools/` — clean.
- [ ] Spot-check that `python tools/fetch_weather.py tmy --location porto` still writes `weather/porto_tmy_*.csv` after the slug change.