### PR TITLE
Scaffold Sphinx documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ dev/
 !rlp/*.csv
 .codex
 .claude/
+
+# Sphinx
+docs/_build/
+docs/api/generated/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "latest",
+    "version": "latest",
+    "url": "https://breos.readthedocs.io/en/latest/",
+    "preferred": true
+  }
+]

--- a/docs/adr/0001-docs-architecture.md
+++ b/docs/adr/0001-docs-architecture.md
@@ -1,0 +1,25 @@
+# 0001 — Docs organized by puzzle piece, App-led
+
+BREOS docs are organized by domain "puzzle piece" (Weather, PV, Load
+profiles, Energy balance, Battery, Cost analysis, Optimization, Plotting)
+rather than by Python module. The landing page leads with the
+{py:class}`~breos.App` facade — the unique thing BREOS offers — with
+composable submodule usage introduced later as "Building custom pipelines."
+
+The API reference mirrors the same eight puzzle pieces with hand-curated
+`autosummary` lists, plus a recursive `api/appendix.md` for utilities,
+constants, and other names that ended up in `__all__` but aren't part of
+the primary surface. Narrative ("user-guide/") will be separated from
+theory ("concepts/") in future PRs so degradation-model math doesn't drown
+the practical battery-configuration page.
+
+## Why
+
+- The App facade is BREOS's differentiator versus pvlib; leading with it
+  gives a 30-second first-time-user win.
+- Puzzle pieces cross Python module boundaries (PV = `solar.py` +
+  `pv_modules.py` + `inverter.py`). Documenting per-module would scatter
+  related material.
+- Curated `autosummary` blocks keep ~30 user-facing names on the index
+  while still surfacing the full `__all__` via the appendix's recursive
+  crawl.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+Short records of decisions whose context isn't visible in the code. ADRs
+exist to answer "why did you do it this way?" for future readers — the
+code shows the *what*.
+
+```{toctree}
+:maxdepth: 1
+
+0001-docs-architecture
+```

--- a/docs/api/appendix.md
+++ b/docs/api/appendix.md
@@ -1,0 +1,16 @@
+# Appendix
+
+Modules that are re-exported from the `breos` namespace but aren't part of
+the primary puzzle-piece surface — utilities, I/O helpers, model constants,
+and research-validation modules.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   breos.utils
+   breos.io
+   breos.constants
+   breos.polysun_degradation
+```

--- a/docs/api/battery.md
+++ b/docs/api/battery.md
@@ -1,0 +1,56 @@
+# Battery
+
+Configuration, indoor temperature modelling, and the calendar and cycle
+degradation primitives used by the energy balance.
+
+## Configuration
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.battery.BatteryConfig
+```
+
+## Temperature model
+
+The indoor temperature model couples ambient air temperature to a damped
+indoor series — relevant for calendar aging, which is strongly temperature
+dependent.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.battery.apply_indoor_temperature_model
+   breos.battery.compute_cell_temperature
+```
+
+## Cycle detection
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.battery.detect_cycles_rainflow
+   breos.battery.detect_half_cycles_from_soc_series
+   breos.battery.compute_halfcycle_energy_throughput
+```
+
+## Degradation primitives
+
+Low-level update functions that the energy balance loop calls each
+timestep. Use these directly only when reproducing or critiquing the
+degradation model.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.battery.update_battery_soc
+   breos.battery.update_battery_soh_calendar
+   breos.battery.update_battery_soh_cyclewise
+   breos.battery.update_battery_resistance_calendar
+   breos.battery.update_battery_resistance_cyclewise
+   breos.battery.resistance_to_efficiency
+```

--- a/docs/api/cost-analysis.md
+++ b/docs/api/cost-analysis.md
@@ -1,0 +1,47 @@
+# Cost analysis
+
+Cost parameters, NPV / LCOE / payback projections, and CO2 emissions
+projections. Emissions and economics share the same projection function
+because both produce per-year cumulative discounted series from the same
+energy balance.
+
+## Cost parameters
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.economics.CostParams
+   breos.economics.cost_params_from_config
+```
+
+## CAPEX and projection
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.economics.calculate_costs
+   breos.economics.cost_analysis_projection
+```
+
+## Metrics
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.economics.calculate_lcoe
+   breos.economics.find_payback_year
+```
+
+## Emissions
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.emissions.EmissionsParams
+   breos.emissions.calculate_co2_savings
+   breos.emissions.calculate_co2_projection
+```

--- a/docs/api/energy-balance.md
+++ b/docs/api/energy-balance.md
@@ -1,0 +1,25 @@
+# Energy balance
+
+Per-timestep dispatch of PV, load, battery, and grid. The dispatch engine
+runs the same way for PV-only and PV+battery systems — when no battery is
+configured, it simply skips the storage path.
+
+## Main entry point
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.battery.simulate_energy_balance
+```
+
+The function returns a six-tuple of `(results_df, total_pv_wh,
+summary_df, total_replacement_cost, n_replacements, degradation_df)`.
+Battery-specific outputs are empty when running without storage.
+
+## Coupling
+
+Whether the inverter is DC-coupled (hybrid) or AC-coupled affects when
+losses are applied. The {py:class}`~breos.BatteryConfig` `dc_coupled` flag
+controls this — see the [Battery reference](battery.md) for the full
+configuration.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,95 @@
+# API reference
+
+BREOS's public API is organized by domain "puzzle piece" rather than by
+Python module — the [PV reference](pv.md) pulls names from `breos.solar`,
+`breos.pv_modules`, and `breos.inverter`, since all three describe the same
+piece of a system.
+
+The {py:class}`~breos.App` facade is the recommended entry point. The
+pages below cover the lower-level functions you reach for when composing a
+custom pipeline.
+
+## Puzzle pieces
+
+::::{grid} 1 2 2 4
+:gutter: 3
+
+:::{grid-item-card} Weather
+:link: weather
+:link-type: doc
+
+TMY and historical data, file I/O, resampling, clear-sky scaling.
+:::
+
+:::{grid-item-card} PV
+:link: pv
+:link-type: doc
+
+DC and AC production, multi-array layouts, module catalogue, inverter
+sizing.
+:::
+
+:::{grid-item-card} Load profiles
+:link: load-profiles
+:link-type: doc
+
+Standard residential and commercial profiles, scaling, alignment.
+:::
+
+:::{grid-item-card} Energy balance
+:link: energy-balance
+:link-type: doc
+
+Per-timestep dispatch of PV, load, battery, and grid.
+:::
+
+:::{grid-item-card} Battery
+:link: battery
+:link-type: doc
+
+Configuration, indoor temperature model, calendar and cycle degradation.
+:::
+
+:::{grid-item-card} Cost analysis
+:link: cost-analysis
+:link-type: doc
+
+Cost parameters, NPV / LCOE / payback projections, emissions.
+:::
+
+:::{grid-item-card} Optimization
+:link: optimization
+:link-type: doc
+
+Tilt search, battery sizing, NSGA-II multi-objective Pareto.
+:::
+
+:::{grid-item-card} Plotting
+:link: plotting
+:link-type: doc
+
+Publication-ready figures for production, costs, degradation, and Pareto
+fronts.
+:::
+
+::::
+
+## Other surfaces
+
+[Appendix](appendix.md) documents the remaining public names — constants,
+I/O helpers, utilities, and other modules that are exposed but not
+load-bearing for typical use.
+
+```{toctree}
+:hidden:
+
+weather
+pv
+load-profiles
+energy-balance
+battery
+cost-analysis
+optimization
+plotting
+appendix
+```

--- a/docs/api/load-profiles.md
+++ b/docs/api/load-profiles.md
@@ -1,0 +1,23 @@
+# Load profiles
+
+Standard residential and commercial load profiles (BDEW H0, E-Redes BTN,
+REE 2.0TD) plus utilities for scaling and time alignment.
+
+## Loading and scaling
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.load_profiles.load_profile
+   breos.load_profiles.scale_to_annual_consumption
+```
+
+## Alignment
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.load_profiles.align_load_to_pv
+```

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -1,0 +1,35 @@
+# Optimization
+
+Single- and multi-objective optimization for system configuration. Brent's
+method handles smooth one-dimensional problems (tilt); NSGA-II via
+[pymoo](https://pymoo.org/) handles multi-objective sizing (PV count vs
+battery vs cost vs grid independence).
+
+## Tilt
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.optimization.optimize_tilt
+   breos.optimization.optimize_tilt_brent
+```
+
+## Battery sizing
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.optimization.optimize_battery_size
+   breos.optimization.size_for_zeb
+```
+
+## Result type
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.optimization.OptimizationResult
+```

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -1,0 +1,127 @@
+# Plotting
+
+Publication-ready matplotlib figures grouped by what they visualize.
+All functions write a PNG to a results directory and accept optional
+styling overrides.
+
+## Time series
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_timeseries
+   breos.plotting.plot_monthly_balance
+   breos.plotting.plot_monthly_comparison
+   breos.plotting.monthly_graphs
+   breos.plotting.weekly_graphs
+   breos.plotting.yearly_graphs
+```
+
+## Cost and breakeven
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_breakeven
+   breos.plotting.plot_breakeven_two
+   breos.plotting.plot_breakeven_comparison
+   breos.plotting.create_cost_plots
+```
+
+## Battery degradation
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_battery_soh_timeseries
+   breos.plotting.plot_resistance_and_efficiency
+   breos.plotting.plot_cell_temperature
+   breos.plotting.degradation_plots
+```
+
+## Tilt and azimuth optimization
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_tilt_optimization
+   breos.plotting.plot_azitilt_ew_1d
+   breos.plotting.plot_azitilt_landscape_2d
+   breos.plotting.plot_azitilt_landscape_3d
+```
+
+## Pareto front
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_pareto_front_analysis
+```
+
+## Sensitivity and Monte Carlo
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_calendar_aging_sensitivity
+   breos.plotting.plot_temperature_sensitivity_comparison
+   breos.plotting.plot_montecarlo_npv_distribution
+   breos.plotting.plot_montecarlo_grid_independence_distribution
+```
+
+## Batch comparison
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_grid_independence_heatmap
+   breos.plotting.plot_location_comparison_delta
+```
+
+## CO2
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_co2_savings
+```
+
+## Weather visualization
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_weather_annual_ghi_distribution
+   breos.plotting.plot_weather_monthly_comparison
+```
+
+## Validation plots
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.plot_validation_parity
+   breos.plotting.plot_validation_residuals
+   breos.plotting.plot_validation_soh_comparison
+   breos.plotting.plot_validation_degradation_split
+   breos.plotting.plot_validation_multi_system
+```
+
+## Presentation styling
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.plotting.set_presentation_mode
+```

--- a/docs/api/pv.md
+++ b/docs/api/pv.md
@@ -1,0 +1,56 @@
+# PV
+
+DC and AC production, multi-array layouts, the built-in module catalogue,
+and inverter sizing.
+
+## Production
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.solar.calculate_pv_production_dc
+   breos.solar.calculate_pv_production_ac
+   breos.solar.calculate_multi_array_production
+   breos.solar.dc_to_ac
+```
+
+## Module catalogue
+
+A built-in dictionary of PV module electrical parameters lives in
+`breos.pv_modules.MODULES`. Use the accessor functions below rather than
+indexing the dict directly — `get_module` raises a clear error on
+unknown keys, and `list_modules` returns the available keys.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.solar.PVModuleParams
+   breos.pv_modules.get_module
+   breos.pv_modules.list_modules
+   breos.pv_modules.get_module_info
+```
+
+## Geometry
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.solar.estimate_optimal_tilt
+   breos.solar.default_azimuth
+```
+
+## Inverter
+
+Common inverter configurations live in `breos.inverter.INVERTER_PRESETS`.
+Use `get_inverter_preset` to look one up by key.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.inverter.InverterConfig
+   breos.inverter.get_inverter_preset
+```

--- a/docs/api/weather.md
+++ b/docs/api/weather.md
@@ -1,0 +1,51 @@
+# Weather
+
+Sources, loaders, and resampling utilities for solar irradiance and
+temperature time series.
+
+## Loading from local files
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.weather.load_weather
+   breos.weather.parse_weather_filename
+   breos.weather.read_epw_file
+```
+
+## Fetching from external APIs
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.weather.fetch_tmy_weather_data
+   breos.weather.fetch_tmy_nsrdb
+   breos.weather.fetch_weather_data
+```
+
+## Resampling
+
+Convert between hourly and 15-minute resolutions. The 15-minute path uses
+Makima interpolation on clearness indices rather than raw irradiance so
+sunrise / sunset transitions stay physically consistent.
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.weather.resample_to_15min
+   breos.weather.resample_to_hourly
+   breos.weather.resample_tmy_to_15min
+```
+
+## Helpers
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   breos.weather.extract_ambient_temperature
+   breos.weather.preload_weather_by_year
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+```{include} ../CHANGELOG.md
+:start-line: 1
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,107 @@
+"""Sphinx configuration for the BREOS documentation."""
+
+from __future__ import annotations
+
+from importlib.metadata import version as pkg_version
+
+project = "BREOS"
+author = "Leonardo Rodrigues"
+copyright = "2026, Leonardo Rodrigues"
+release = pkg_version("breos")
+version = ".".join(release.split(".")[:2])
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.mathjax",
+    "myst_parser",
+    "sphinx_design",
+    "sphinx_copybutton",
+    "sphinx_autodoc_typehints",
+]
+
+# --- Source files -----------------------------------------------------------
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+master_doc = "index"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# --- Autosummary / autodoc --------------------------------------------------
+
+autosummary_generate = True
+autodoc_default_options = {
+    "members": True,
+    "inherited-members": False,
+    "show-inheritance": True,
+}
+autodoc_typehints = "description"
+autodoc_typehints_format = "short"
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+# --- Intersphinx ------------------------------------------------------------
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
+    "pvlib": ("https://pvlib-python.readthedocs.io/en/stable/", None),
+}
+
+# --- MyST -------------------------------------------------------------------
+
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "dollarmath",
+    "fieldlist",
+    "tasklist",
+    "substitution",
+]
+myst_heading_anchors = 3
+
+# --- HTML output ------------------------------------------------------------
+
+html_theme = "pydata_sphinx_theme"
+html_static_path = ["_static"]
+html_title = "BREOS"
+
+html_theme_options = {
+    "logo": {"text": "BREOS"},
+    "github_url": "https://github.com/Str4vinci/breos",
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
+    "show_prev_next": False,
+    "footer_start": ["copyright"],
+    "footer_end": ["sphinx-version", "theme-version"],
+    "switcher": {
+        "json_url": "https://breos.readthedocs.io/en/latest/_static/switcher.json",
+        "version_match": "latest",
+    },
+    "check_switcher": False,
+    "secondary_sidebar_items": ["page-toc", "edit-this-page"],
+    "use_edit_page_button": True,
+}
+
+html_context = {
+    "github_user": "Str4vinci",
+    "github_repo": "breos",
+    "github_version": "develop",
+    "doc_path": "docs",
+}
+
+# --- Misc -------------------------------------------------------------------
+
+# Silence warnings for references that can't be resolved against external
+# inventories (e.g. internal type aliases that don't intersphinx).
+nitpicky = False

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,93 @@
+# Configuration
+
+The {py:class}`~breos.App` constructor accepts a single `config` dict. Only
+three keys are strictly required:
+
+- `location`
+- `annual_consumption_kwh`
+- `n_modules` — *or* `pv_arrays` for multi-array systems
+
+Every other key has a sensible default.
+
+## All keys
+
+| Key | Default | Description |
+|---|---|---|
+| `location` | *required* | Preset key (e.g. `"porto"`, `"berlin"`) or `{"latitude": ..., "longitude": ..., "timezone": ...}` |
+| `n_modules` | *required unless `pv_arrays` is set* | Number of PV modules |
+| `pv_arrays` | `None` | List of arrays with `modules`, `module`, `tilt`, and `azimuth`. When present, the array module total overrides `n_modules` |
+| `annual_consumption_kwh` | *required* | Annual electricity demand (kWh) |
+| `battery_kwh` | `0.0` | Battery capacity in kWh (`0` = no battery) |
+| `pv_module` | `None` | Module key from the built-in catalogue. `None` uses the first available |
+| `load_profile` | `"6"` | Load profile type (see {py:func}`~breos.load_profile`) |
+| `tilt` | auto | Tilt angle (degrees). Auto-estimated from latitude when `None` |
+| `azimuth` | auto | Surface azimuth (degrees). Auto-set to 180 in the northern hemisphere |
+| `resolution` | `"h"` | Time resolution (`"h"` or `"15min"`) |
+| `projection_years` | `20` | Economic projection horizon |
+| `cost_preset` | `None` | Cost preset key from `configs/costs.json` |
+| `inflation_rate` | `0.02` | Annual electricity price inflation |
+| `discount_rate` | `0.03` | Discount rate for NPV |
+| `emissions_country` | `None` | Country code for CO2 calculations (`"PT"`, `"DE"`, `"ES"`, ...) |
+| `pv_degradation_rate` | `0.005` | Annual PV degradation rate (0.5% / year) |
+| `calendar_model` | `"naumann_lam_field_calibrated"` | Battery calendar aging model |
+| `dc_coupled` | `True` | DC-coupled / hybrid inverter (vs AC-coupled) |
+| `inverter_efficiency` | `0.96` | Inverter efficiency |
+| `inverter_loading_ratio` | `1.25` | DC/AC oversizing ratio |
+| `start_date` | `"2023-01-01"` | First simulation date |
+
+## Custom location
+
+Pass an explicit coordinate dict instead of a preset key:
+
+```python
+breos.App({
+    "location": {
+        "latitude": 41.1579,
+        "longitude": -8.6291,
+        "timezone": "Europe/Lisbon",
+    },
+    "n_modules": 10,
+    "annual_consumption_kwh": 4000,
+})
+```
+
+## Multi-array PV systems
+
+For roofs with panels facing different directions, use `pv_arrays`. Each
+array is simulated independently and its DC output combined before the
+energy balance — east-west or pitched-roof layouts are not collapsed into
+one representative tilt/azimuth:
+
+```python
+breos.App({
+    "location": "porto",
+    "annual_consumption_kwh": 4000,
+    "pv_arrays": [
+        {"modules": 8, "module": "Erlangen_445W", "tilt": 10, "azimuth": 90},
+        {"modules": 8, "module": "Erlangen_445W", "tilt": 10, "azimuth": 270},
+    ],
+})
+```
+
+When `pv_arrays` is set, `n_modules` is computed from the array totals and
+any explicit `n_modules` key is ignored.
+
+## Cost and emissions presets
+
+Built-in presets live in `configs/costs.json` and `configs/emissions.json`.
+Pass the key:
+
+```python
+breos.App({
+    "location": "porto",
+    "n_modules": 10,
+    "annual_consumption_kwh": 4000,
+    "cost_preset": "residential_pt",
+    "emissions_country": "PT",
+})
+```
+
+For full control, build a {py:class}`~breos.CostParams` and
+{py:class}`~breos.EmissionsParams` yourself and call the lower-level
+functions — see [Building custom pipelines](../api/index.md) once that
+guide lands, or browse the [Cost analysis API](../api/cost-analysis.md).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,13 @@
+# Getting started
+
+This section installs BREOS, walks through a first simulation, and explains
+what the result dict contains.
+
+```{toctree}
+:maxdepth: 1
+
+installation
+quickstart
+configuration
+interpreting-results
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,48 @@
+# Installation
+
+BREOS requires Python 3.13 or newer.
+
+## From PyPI
+
+```bash
+pip install breos
+```
+
+## From source
+
+```bash
+git clone https://github.com/Str4vinci/breos.git
+cd breos
+pip install -e .
+```
+
+## Development install
+
+If you plan to contribute, install with the dev extras for testing and
+linting:
+
+```bash
+pip install -e ".[dev]"
+```
+
+To build the documentation locally, install the `docs` extras:
+
+```bash
+pip install -e ".[docs]"
+sphinx-build -b html docs docs/_build/html
+```
+
+The repository uses [`uv`](https://docs.astral.sh/uv/) for dependency
+management. If you prefer uv, the equivalents are:
+
+```bash
+uv sync --extra dev          # development
+uv sync --extra docs         # documentation
+```
+
+## Verifying the install
+
+```python
+import breos
+print(breos.__version__)
+```

--- a/docs/getting-started/interpreting-results.md
+++ b/docs/getting-started/interpreting-results.md
@@ -1,0 +1,91 @@
+# Interpreting results
+
+`App.result()` returns a plain Python dict, JSON-serializable, with no
+pandas or numpy types. The same dict is written by the CLI's `--output`
+flag.
+
+## Top-level keys
+
+| Key | Description |
+|---|---|
+| `n_modules` | Number of PV modules used in the simulation |
+| `pv_kwp` | System DC nameplate capacity (kWp) |
+| `battery_kwh` | Battery capacity (kWh) |
+| `pv_production_kwh` | Year 1 PV production |
+| `consumption_kwh` | Year 1 load |
+| `self_consumption_kwh` | Year 1 PV directly self-consumed |
+| `grid_import_kwh` | Year 1 energy bought from the grid |
+| `grid_export_kwh` | Year 1 energy sold to the grid |
+| `grid_independence_pct` | Year 1 grid independence ratio |
+| `self_consumption_pct` | Year 1 self-consumption ratio |
+| `total_investment_eur` | Total CAPEX |
+| `payback_year` | First year with positive cumulative NPV (`None` if not reached) |
+| `npv_savings_eur` | Cumulative NPV savings over the projection horizon |
+| `lcoe_eur_kwh` | Levelized cost of electricity |
+| `monthly` | Year 1 monthly energy balance rows |
+| `financial` | Yearly financial projection rows (year 0 = investment) |
+| `yearly` | Per-year breakdown of production, load, imports, exports |
+
+## Battery-specific keys
+
+Present only when `battery_kwh > 0`:
+
+| Key | Description |
+|---|---|
+| `battery_soh_end_pct` | State of health at the end of the projection horizon |
+| `battery_replacements` | Total number of replacements over the projection |
+| `battery_replacement_cost_eur` | Total replacement cost |
+
+## Emissions keys
+
+Present only when `emissions_country` is set:
+
+| Key | Description |
+|---|---|
+| `co2_avoided_year1_kg` | Year 1 CO2 savings |
+| `co2_avoided_total_kg` | Lifetime CO2 savings over the projection horizon |
+
+## Multi-array systems
+
+When `pv_arrays` is set, the result also contains a `pv_arrays` list
+echoing each array's configuration (`modules`, `module`, `tilt`,
+`azimuth`).
+
+## Monthly and yearly breakdowns
+
+### `monthly`
+
+A list of 12 dicts, one per month of year 1:
+
+```python
+{
+    "month": "Jan",
+    "pv_kwh": 245.3,
+    "consumption_kwh": 412.5,
+    "self_consumption_kwh": 180.2,
+    "import_kwh": 232.3,
+    "export_kwh": 65.1,
+    "grid_independence_pct": 43.7,
+}
+```
+
+### `yearly`
+
+A list of one dict per simulation year (length `projection_years`). Each
+row contains the same fields as `monthly` aggregated to a year, plus
+`soh_pct` when a battery is present.
+
+### `financial`
+
+A list of dicts with one row per year (year 0 is the investment row):
+
+```python
+{"year": 0, "balance": -8500.0, "reference": 0.0}
+{"year": 1, "balance": -7950.4, "reference": 0.0, "cost_with_system": 542.1, "cost_without_system": 1092.5}
+# ...
+```
+
+`balance` is the cumulative NPV savings; `cost_with_system` and
+`cost_without_system` are the cumulative discounted costs of operating with
+and without the BREOS-sized system. The crossover point of `balance ≥ 0`
+defines `payback_year`.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,77 @@
+# Quickstart
+
+The fastest way to run a BREOS simulation is the {py:class}`~breos.App`
+facade. It takes a single config dict, runs the full PV + battery +
+economics + emissions pipeline, and returns a plain JSON-serializable
+result dict.
+
+## A minimal example
+
+```python
+import breos
+
+app = breos.App({
+    "location": "porto",              # preset or {"latitude": ..., "longitude": ..., "timezone": ...}
+    "n_modules": 10,
+    "annual_consumption_kwh": 4000,
+    "battery_kwh": 5.0,               # 0 for no battery
+    "cost_preset": "residential_pt",
+    "emissions_country": "PT",
+})
+
+app.simulate()
+result = app.result()
+
+print(f"Grid independence: {result['grid_independence_pct']:.1f}%")
+print(f"Payback: {result['payback_year']} years")
+print(f"NPV savings: {result['npv_savings_eur']:,.0f} EUR")
+print(f"CO2 avoided: {result['co2_avoided_total_kg']:,.0f} kg")
+```
+
+What just happened, end-to-end:
+
+1. **Weather** — BREOS loaded a Typical Meteorological Year (TMY) for Porto
+   from a local cache if present, otherwise fetched it from PVGIS.
+2. **PV** — Ten panels at the configured tilt and azimuth produced a
+   year-long DC power series.
+3. **Load** — A standard residential load profile (E-Redes BTN C) scaled
+   to 4000 kWh/yr.
+4. **Energy balance** — Per-timestep dispatch decided how much PV is
+   self-consumed, stored, or exported.
+5. **Battery degradation** — Twenty years of operation with Naumann calendar
+   aging and field-calibrated LFP cycle aging.
+6. **Economics** — Costs derived from the `residential_pt` preset, NPV /
+   LCOE / payback computed over the projection horizon.
+7. **Emissions** — CO2 savings computed against the Portuguese grid
+   intensity.
+
+## Running from the command line
+
+The same simulation can be run without writing Python:
+
+```bash
+breos run \
+  --location porto \
+  --n-modules 10 \
+  --annual-consumption-kwh 4000 \
+  --battery-kwh 5.0 \
+  --cost-preset residential-pt \
+  --emissions-country pt \
+  --output result.json
+```
+
+Or with a TOML or JSON config file:
+
+```bash
+breos run --config experiment1.toml --output result.json
+```
+
+The CLI writes the same JSON-serializable dict that `App.result()` returns.
+
+## Next steps
+
+- See [Configuration](configuration.md) for every option `App` accepts.
+- See [Interpreting results](interpreting-results.md) for what each result
+  key means.
+- See the [API reference](../api/index.md) for the lower-level functions
+  the `App` calls under the hood.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,104 @@
+---
+sd_hide_title: true
+---
+
+# BREOS
+
+::::{div} sd-text-center sd-fs-2 sd-fw-bold
+BREOS
+::::
+
+::::{div} sd-text-center sd-fs-4
+Building Renewable Energy Optimization Software
+::::
+
+::::{div} sd-text-center sd-py-3
+A modular Python library for photovoltaic and battery energy system
+simulations, designed for research and engineering applications.
+::::
+
+## Quick example
+
+```python
+import breos
+
+app = breos.App({
+    "location": "porto",
+    "n_modules": 10,
+    "annual_consumption_kwh": 4000,
+    "battery_kwh": 5.0,
+    "cost_preset": "residential_pt",
+    "emissions_country": "PT",
+})
+app.simulate()
+result = app.result()
+
+print(f"Grid independence: {result['grid_independence_pct']:.1f}%")
+print(f"Payback: {result['payback_year']} years")
+print(f"NPV savings: {result['npv_savings_eur']:,.0f} EUR")
+```
+
+`result` is a plain JSON-serializable dict — no pandas types leak out.
+
+## Where to start
+
+::::{grid} 1 2 2 3
+:gutter: 3
+
+:::{grid-item-card} Getting started
+:link: getting-started/index
+:link-type: doc
+
+Install BREOS, run a first simulation, and learn what every key in the
+result dict means.
+:::
+
+:::{grid-item-card} API reference
+:link: api/index
+:link-type: doc
+
+Every public function and class, organized by what it does — weather, PV,
+battery, costs, and so on.
+:::
+
+:::{grid-item-card} Architecture
+:link: architecture/third-party-wrapping
+:link-type: doc
+
+Design decisions and refactoring plans for BREOS's internal structure.
+:::
+
+::::
+
+## Status
+
+BREOS is pre-1.0 (currently `0.1.0`, beta). The public API may change
+between minor releases. The [roadmap](https://github.com/Str4vinci/breos/blob/main/ROADMAP.md)
+tracks larger refactoring work — notably, the planned [adapter layer for
+third-party libraries](architecture/third-party-wrapping.md) will change
+the signatures of `calculate_pv_production_dc` and similar functions that
+currently expose `pvlib.Location` directly. The `breos.App` facade is
+the most stable surface to build on.
+
+```{toctree}
+:hidden:
+:caption: Getting started
+
+getting-started/index
+```
+
+```{toctree}
+:hidden:
+:caption: Reference
+
+api/index
+```
+
+```{toctree}
+:hidden:
+:caption: Project
+
+architecture/third-party-wrapping
+adr/index
+changelog
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,14 @@ breos = "breos.cli:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "ruff>=0.15"]
+docs = [
+    "sphinx>=8.1",
+    "pydata-sphinx-theme>=0.16",
+    "myst-parser>=4.0",
+    "sphinx-design>=0.6",
+    "sphinx-copybutton>=0.5",
+    "sphinx-autodoc-typehints>=2.5",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,27 @@ wheels = [
 ]
 
 [[package]]
+name = "accessible-pygments"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c1/bbac6a50d02774f91572938964c582fff4270eee73ab822a4aeea4d8b11b/accessible_pygments-0.0.5.tar.gz", hash = "sha256:40918d3e6a2b619ad424cb91e556bd3bd8865443d9f22f1dcdf79e33c8046872", size = 1377899, upload-time = "2024-05-10T11:23:10.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/3f/95338030883d8c8b91223b4e21744b04d11b161a3ef117295d8241f50ab4/accessible_pygments-0.0.5-py3-none-any.whl", hash = "sha256:88ae3211e68a1d0b011504b2ffc1691feafce124b845bd072ab6f9f66f34d4b7", size = 1395903, upload-time = "2024-05-10T11:23:08.421Z" },
+]
+
+[[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
 name = "alive-progress"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -54,6 +75,28 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "breos"
 version = "0.1.0"
 source = { editable = "." }
@@ -79,12 +122,21 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "myst-parser" },
+    { name = "pydata-sphinx-theme" },
+    { name = "sphinx" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "geopy", specifier = ">=2.4.1" },
     { name = "joblib", specifier = ">=1.5.3" },
     { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0" },
     { name = "nrel-pysam", specifier = ">=7.1.0" },
     { name = "numba", specifier = ">=0.63.1" },
     { name = "openmeteo-requests", specifier = ">=1.7.4" },
@@ -92,14 +144,19 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pvlib", specifier = "==0.14.0" },
     { name = "pyarrow", specifier = ">=19.0.0" },
+    { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = ">=0.16" },
     { name = "pymoo", specifier = ">=0.6.1.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rainflow", specifier = ">=3.2.0" },
     { name = "requests-cache", specifier = ">=1.2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
+    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1" },
+    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.5" },
+    { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
+    { name = "sphinx-design", marker = "extra == 'docs'", specifier = ">=0.6" },
     { name = "timezonefinder", specifier = ">=8.2.1" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "docs"]
 
 [[package]]
 name = "cattrs"
@@ -323,6 +380,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -480,6 +546,15 @@ wheels = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -540,6 +615,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/ac/92f97f07f748bdc9280c5d50e787773bef188c29c32f6804f2fc72cca725/jh2-5.0.10-cp37-abi3-win_amd64.whl", hash = "sha256:9c730e3f40f22bd4ff0ab63ee41d70ee22aa1cc54e5cb295ae0ac3b0a016af3e", size = 246320, upload-time = "2025-10-05T06:17:25.313Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ad/e9f4035ddd847efe26914da64f9d54198bf5b0bdcfd0e8bbcf6a328e1f7c/jh2-5.0.10-cp37-abi3-win_arm64.whl", hash = "sha256:d18eccec757374afca8de31bf012a888fb82903d5803e84f2e6f0b707478ced6", size = 241790, upload-time = "2025-10-05T06:17:26.488Z" },
     { url = "https://files.pythonhosted.org/packages/93/57/d0fcb025736e24cb68c4e250cc4cf63a87b7e0bd7285e188c543018d05c1/jh2-5.0.10-py3-none-any.whl", hash = "sha256:1808c0e5d355c60485bb282b34c6aa3f15069b2634eb44779fb9f3bda0256ac0", size = 98099, upload-time = "2025-10-05T06:18:58.203Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -639,6 +726,70 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
@@ -686,6 +837,27 @@ wheels = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "moocore"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -703,6 +875,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/b0/79f0a968595c1d8a804fa9c66aa21cf676ffa9aacedf2ea50bd35d7f83d6/moocore-0.2.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d0699b770b5eebdeac477a356d539efa8807c6cf067a453a0682e0df2299a512", size = 724847, upload-time = "2026-01-11T11:43:14.275Z" },
     { url = "https://files.pythonhosted.org/packages/3f/f0/535c1d448dbfa8ee79a83c36a6ded5a54ea35d02fac1fe2907ae540e369b/moocore-0.2.0-cp310-abi3-win_amd64.whl", hash = "sha256:ea057409731e73dbc4ba4214cbf7747309695b01314f8786678b758cc9c561c4", size = 485644, upload-time = "2026-01-11T11:43:15.598Z" },
     { url = "https://files.pythonhosted.org/packages/ce/ca/29bdef14758bfe869b74a0eae94d1a1ce220f75ce26ed6e7f4965ca70b49/moocore-0.2.0-cp310-abi3-win_arm64.whl", hash = "sha256:a7683feddfd2a47b4a0f89ee8d370cae72331792f68e67f083ccb37bb2f1c8cf", size = 476178, upload-time = "2026-01-11T11:43:16.919Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
 ]
 
 [[package]]
@@ -1034,6 +1223,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pydata-sphinx-theme"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accessible-pygments" },
+    { name = "babel" },
+    { name = "beautifulsoup4" },
+    { name = "docutils" },
+    { name = "pygments" },
+    { name = "sphinx" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f7/c74c7100a7f4c0f77b5dcacb7dfdb8fee774fb70e487dd97acba2b930774/pydata_sphinx_theme-0.17.1.tar.gz", hash = "sha256:2cfc1d926c753c77039b7ee53f0ccebcbee5e81f0db61432b01cbb10ad7fd0af", size = 4991415, upload-time = "2026-04-21T13:00:34.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/bc/2cb8c78300ce1ace4eeac3b3522218cea2c2053bfa6b4e32cc972a477f9a/pydata_sphinx_theme-0.17.1-py3-none-any.whl", hash = "sha256:320b022d7808bdf5920d9a28e573f27aace9b23e1af6ca103eecc752411df492", size = 6823346, upload-time = "2026-04-21T13:00:31.978Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1118,6 +1325,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]
@@ -1221,6 +1464,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1303,6 +1555,142 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
+]
+
+[[package]]
+name = "sphinx-autodoc-typehints"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/75/9a5695b3d3b848a43cfe91c7d7d3c5ab543eb3bc5c2a12ffaf5003a2a4f6/sphinx_autodoc_typehints-3.10.2.tar.gz", hash = "sha256:34db651eb14343ba16bd9c03e0f5093971f9bbd3cc6b0a1470adecd578940b9c", size = 74241, upload-time = "2026-04-15T22:09:48.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f1c2e2592f995d301bc06901fbb2e947cbe4889397a418309710ccc3a1db/sphinx_autodoc_typehints-3.10.2-py3-none-any.whl", hash = "sha256:2d1bcac8f62b8d0d210f6ca44b8e016e314d07cc8c30d0512cf6986a0b042b26", size = 39231, upload-time = "2026-04-15T22:09:47.413Z" },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
+name = "sphinx-design"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/cf/45dd359f6ca0c3762ce0490f681da242f0530c49c81050c035c016bfdd3a/sphinx_design-0.7.0-py3-none-any.whl", hash = "sha256:f82bf179951d58f55dca78ab3706aeafa496b741a91b1911d371441127d64282", size = 2220350, upload-time = "2026-01-19T13:12:51.077Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First documentation PR — sets up the Sphinx build, the ReadTheDocs config,
and the initial Getting Started + API Reference content.

- **Theme & stack:** pydata-sphinx-theme + MyST + autosummary + napoleon,
  matching the look of pvlib's docs. Mixed Google / NumPy docstring styles
  in the codebase work as-is via napoleon.
- **Organization:** docs are organized by domain *puzzle piece* (Weather,
  PV, Load profiles, Energy balance, Battery, Cost analysis, Optimization,
  Plotting), not by Python module — the rationale is captured in
  [ADR 0001](docs/adr/0001-docs-architecture.md).
- **API reference:** hand-curated `autosummary` blocks per puzzle piece
  surface ~30 user-facing names, plus a recursive `api/appendix.md` for
  utils, constants, and other names that ended up in `__all__` but aren't
  load-bearing.
- **Getting Started:** installation, quickstart, configuration, and
  interpreting results — translated from the README so the docs site is
  usable on day one.
- **Hosting:** `.readthedocs.yaml` builds from `develop` initially; the
  pydata-sphinx-theme version switcher dropdown is enabled now so adding
  per-tag versions later is a config-only change.

User Guide and Concepts directories are intentionally **not** created in
this PR. Follow-up PRs will land them per puzzle piece (e.g.
"user-guide/battery.md + concepts/degradation-models.md" together) so each
PR delivers one piece's narrative end-to-end.

## Test plan

- [x] `uv run sphinx-build -b html docs docs/_build/html` — builds clean,
      zero warnings, 91 autosummary stubs generated.
- [x] `uv run pytest tests/ -q` — 91 passed (no code changes; verifying
      `pyproject.toml` edit didn't break anything).
- [x] `uv run ruff check breos/ tests/ tools/` — clean.
- [x] `uv run ruff format --check breos/ tests/ tools/` — clean.
- [ ] Connect this repo to ReadTheDocs (admin step — needs RTD project
      creation; first build will validate the `.readthedocs.yaml`).