### PR TITLE
Wire tracking into App pv_arrays + fix multi-array temp fallback

### DIFF
--- a/breos/app.py
+++ b/breos/app.py
@@ -300,7 +300,7 @@ class App:
         if ambient_temp is not None:
             temp_series = apply_indoor_temperature_model(ambient_temp)
         else:
-            temp_series = pd.Series(25.0, index=dc_1mod.index)
+            temp_series = pd.Series(25.0, index=dc_system_base.index)
 
         # 5. Multi-year propagation
         replacement_cost_per_kwh = self._cost_params.battery_cost_per_kwh
@@ -456,15 +456,7 @@ class App:
         }
 
         if self._pv_arrays:
-            result["pv_arrays"] = [
-                {
-                    "modules": arr["modules"],
-                    "module": arr["module"],
-                    "tilt": arr["tilt"],
-                    "azimuth": arr["azimuth"],
-                }
-                for arr in self._pv_arrays
-            ]
+            result["pv_arrays"] = [dict(arr) for arr in self._pv_arrays]
 
         # Battery (only if present)
         if has_battery:
@@ -544,20 +536,33 @@ class App:
             self._cfg.get("azimuth") if self._cfg.get("azimuth") is not None else default_azimuth_fn(self._lat)
         )
 
+        tracking_passthrough_keys = (
+            "tracking",
+            "axis_tilt",
+            "axis_azimuth",
+            "max_angle",
+            "backtrack",
+            "gcr",
+            "cross_axis_tilt",
+            "dual_axis_max_tilt",
+        )
+
         normalized = []
         for arr in arrays:
             modules = int(arr["modules"])
             module = arr.get("module") or default_module
             tilt = arr.get("tilt", default_tilt)
             azimuth = arr.get("azimuth", default_azimuth)
-            normalized.append(
-                {
-                    "modules": modules,
-                    "module": module,
-                    "tilt": float(tilt),
-                    "azimuth": float(azimuth),
-                }
-            )
+            entry = {
+                "modules": modules,
+                "module": module,
+                "tilt": float(tilt),
+                "azimuth": float(azimuth),
+            }
+            for key in tracking_passthrough_keys:
+                if key in arr:
+                    entry[key] = arr[key]
+            normalized.append(entry)
         return normalized
 
     def _load_weather(self, freq: str, start_year: int) -> pd.DataFrame:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -200,6 +200,105 @@ class TestAppSimulateMultiArray:
         assert self.result["pv_production_kwh"] > 0
 
 
+class TestAppSimulateTracking:
+    def test_invalid_tracking(self, _patch_weather):
+        with pytest.raises(ValueError, match="tracking must be"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 6,
+                    "annual_consumption_kwh": 3000,
+                    "tracking": "trinity_axis",
+                }
+            )
+
+    def test_single_axis_runs(self, _patch_weather):
+        app = App(
+            {
+                "location": "porto",
+                "n_modules": 6,
+                "annual_consumption_kwh": 3000,
+                "cost_preset": "residential_pt",
+                "projection_years": 3,
+                "tracking": "single_axis",
+                "max_angle": 60.0,
+                "gcr": 0.35,
+            }
+        )
+        app.simulate()
+        result = app.result()
+        assert result["pv_production_kwh"] > 0
+        json.dumps(result)
+
+    def test_dual_axis_runs(self, _patch_weather):
+        app = App(
+            {
+                "location": "porto",
+                "n_modules": 6,
+                "annual_consumption_kwh": 3000,
+                "cost_preset": "residential_pt",
+                "projection_years": 3,
+                "tracking": "dual_axis",
+            }
+        )
+        app.simulate()
+        result = app.result()
+        assert result["pv_production_kwh"] > 0
+
+    def test_tracking_beats_fixed_via_app(self, _patch_weather):
+        """At the App level, single-axis (no backtrack, ±90°) should beat optimal fixed tilt."""
+        common = {
+            "location": "porto",
+            "n_modules": 6,
+            "annual_consumption_kwh": 3000,
+            "cost_preset": "residential_pt",
+            "projection_years": 1,
+        }
+        fixed = App(common)
+        fixed.simulate()
+        tracked = App({**common, "tracking": "single_axis", "backtrack": False, "max_angle": 90.0})
+        tracked.simulate()
+        assert tracked.result()["pv_production_kwh"] > fixed.result()["pv_production_kwh"]
+
+    def test_per_array_tracking_flows_through(self, _patch_weather):
+        """Tracking keys on pv_arrays entries must reach calculate_multi_array_production."""
+        fixed_app = App(
+            {
+                "location": "porto",
+                "annual_consumption_kwh": 3000,
+                "cost_preset": "residential_pt",
+                "projection_years": 1,
+                "pv_arrays": [
+                    {"modules": 6, "module": "Erlangen_445W", "tilt": 30, "azimuth": 180},
+                ],
+            }
+        )
+        fixed_app.simulate()
+        tracked_app = App(
+            {
+                "location": "porto",
+                "annual_consumption_kwh": 3000,
+                "cost_preset": "residential_pt",
+                "projection_years": 1,
+                "pv_arrays": [
+                    {
+                        "modules": 6,
+                        "module": "Erlangen_445W",
+                        "tracking": "single_axis",
+                        "axis_azimuth": 180,
+                        "max_angle": 90.0,
+                        "backtrack": False,
+                    },
+                ],
+            }
+        )
+        tracked_app.simulate()
+        # Tracking key must echo into result
+        assert tracked_app.result()["pv_arrays"][0].get("tracking") == "single_axis"
+        # And actually change production vs fixed
+        assert tracked_app.result()["pv_production_kwh"] != fixed_app.result()["pv_production_kwh"]
+
+
 class TestAppSimulateWithBattery:
     @pytest.fixture(autouse=True)
     def _setup(self, _patch_weather):


### PR DESCRIPTION
Follow-up polish for #16 (tracking).

## Summary
- `App._normalise_pv_arrays` now passes through tracking keys (`tracking`, `axis_tilt`, `axis_azimuth`, `max_angle`, `backtrack`, `gcr`, `cross_axis_tilt`, `dual_axis_max_tilt`). Previously they were silently dropped, so per-array tracking only worked via direct `calculate_multi_array_production` calls.
- The `result["pv_arrays"]` echo now copies the full array dict (including tracking config) instead of just `modules/module/tilt/azimuth`.
- Fix latent `NameError`: when `pv_arrays` was set and `ambient_temp` was None, the temperature-series fallback referenced the undefined `dc_1mod`. Use `dc_system_base.index` instead.

## Test plan
- [x] `TestAppSimulateTracking`: invalid tracking raises, single-axis runs, dual-axis runs, single-axis > fixed energy via App, per-array tracking keys reach the multi-array path and echo into the result
- [x] All 106 tests pass