### PR TITLE
Add golden outputs and release artifact smoke test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,13 @@ jobs:
         run: uv sync --extra dev
 
       - name: Lint
-        run: uv run ruff check breos/ tests/
+        run: uv run ruff check breos/ tests/ tools/
 
       - name: Check formatting
-        run: uv run ruff format --check breos/ tests/
+        run: uv run ruff format --check breos/ tests/ tools/
 
       - name: Run tests
         run: uv run pytest tests/ -v
+
+      - name: Verify release artifacts
+        run: uv run python tools/verify_release_artifacts.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,6 +99,7 @@ api/index
 :caption: Project
 
 resources
+release
 architecture/third-party-wrapping
 architecture/string-inverter-sizing
 legal/load-profile-data

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,79 @@
+# Public Release Checklist
+
+This checklist keeps the public release process reproducible and protects
+`develop` from regressions while BREOS is pre-1.0.
+
+## Branch Protection
+
+Before publishing a public package release, protect `develop` in GitHub
+repository settings.
+
+Recommended `develop` rules:
+
+- Require pull requests before merging.
+- Require the `Tests` workflow to pass, including the installed-wheel release
+  artifact smoke test.
+- Require branches to be up to date before merging.
+- Dismiss stale approvals when new commits are pushed.
+- Block force pushes.
+- Block branch deletion.
+- Require conversation resolution before merging.
+
+Use `main` only for stable releases and protect it at least as strictly as
+`develop`. Release tags should be created from `main` after the release commit
+has passed the same checks.
+
+## Pre-Release Gates
+
+Run these checks locally before cutting a release candidate:
+
+```bash
+uv run ruff check breos/ tests/ tools/
+uv run ruff format --check breos/ tests/ tools/
+uv run pytest tests/ -v
+uv run python tools/verify_release_artifacts.py
+uv run --extra docs sphinx-build -b html docs docs/_build/html
+```
+
+The release artifact verifier must build both wheel and sdist, confirm packaged
+runtime data is present, confirm generated docs are not shipped, and import
+BREOS from the installed wheel instead of the source checkout.
+
+## Data And Docs
+
+- Keep runtime config and redistributable load-profile data under `breos/data/`
+  and load it through package resources.
+- Keep generated docs out of git and release artifacts.
+- Keep Sphinx source docs in `docs/` so the documentation site is rebuildable.
+- Do not bundle external load profiles unless redistribution permission is
+  recorded and covered by tests.
+
+## API Stability
+
+- Treat `breos.App` and documented config/result keys as the primary stable
+  surface for 0.1.x.
+- Add golden-output tests before changing core energy balance, economics,
+  emissions, or time-resolution behavior.
+- Keep module-level APIs importable unless a removal is documented in the
+  changelog with a migration path.
+
+## Open Positioning Question
+
+Before the public release, decide the project wording used in the README,
+package metadata, docs front page, and release notes:
+
+> Is BREOS a simulation engine, a framework, a model, or a library?
+
+Working recommendation: use **Python library for PV and battery energy-system
+simulation and optimization** as the default public wording.
+
+Rationale:
+
+- `library` matches how users install and import BREOS.
+- `simulation and optimization` describes the main user-facing purpose.
+- `framework` can describe the internal/extensible architecture, but sounds
+  broader than the current 0.1.0 public surface.
+- `engine` can be used for the simulation core, but should not describe the
+  whole project unless a stable lower-level engine API is intentionally exposed.
+- `model` should refer to specific algorithms or component models, not the full
+  project.

--- a/tests/test_golden_outputs.py
+++ b/tests/test_golden_outputs.py
@@ -1,0 +1,211 @@
+"""Golden-output tests for release-critical simulation paths."""
+
+import pandas as pd
+import pytest
+
+from breos.battery import BatteryConfig, simulate_energy_balance
+from breos.economics import CostParams, calculate_costs, cost_analysis_projection
+from breos.emissions import EmissionsParams, calculate_co2_projection
+
+
+def _assert_numeric_record(record, expected, *, rel=1e-9, abs=1e-9):
+    for key, value in expected.items():
+        assert record[key] == pytest.approx(value, rel=rel, abs=abs)
+
+
+def _golden_battery_inputs():
+    idx = pd.date_range("2025-01-01 00:00", periods=48, freq="h", tz="UTC")
+    pv_dc = pd.Series(
+        ([0.0] * 7 + [900.0, 1600.0, 2200.0, 2400.0, 2000.0, 1500.0, 800.0, 200.0] + [0.0] * 9) * 2,
+        index=idx,
+    )
+    load = pd.DataFrame(
+        {"Load": ([450.0] * 6 + [900.0] * 3 + [650.0] * 8 + [1200.0] * 5 + [700.0] * 2) * 2},
+        index=idx,
+    )
+    temperature = pd.Series(22.0, index=idx)
+    config = BatteryConfig(
+        nominal_energy_wh=3000.0,
+        min_soc=0.1,
+        max_soc=0.9,
+        charge_efficiency=0.95,
+        discharge_efficiency=0.95,
+        inverter_efficiency=0.96,
+        enable_replacement=False,
+        standby_loss_wh=0.0,
+    )
+    return pv_dc, load, temperature, config
+
+
+def test_simulate_energy_balance_battery_golden_output():
+    pv_dc, load, temperature, config = _golden_battery_inputs()
+
+    results_df, total_pv, summary_df, replacement_cost, n_replacements, degradation_df = simulate_energy_balance(
+        pv_dc=pv_dc,
+        houseload=load,
+        battery_config=config,
+        freq="h",
+        temperature_series=temperature,
+    )
+
+    _assert_numeric_record(
+        summary_df.iloc[0].to_dict(),
+        {
+            "Total PV [kWh]": 22.272,
+            "Total Load [kWh]": 36.0,
+            "Sell [kWh]": 7.042558969772534,
+            "Import [kWh]": 19.04936863644225,
+            "Import [%]": 52.91491287900625,
+            "Grid Independence [%]": 47.08508712099375,
+            "Final SOH [%]": 99.7669719903168,
+            "N_Replacements": 0,
+            "Replacement_Cost": 0.0,
+        },
+    )
+    assert total_pv == pytest.approx(22272.0)
+    assert replacement_cost == pytest.approx(0.0)
+    assert n_replacements == 0
+    assert len(degradation_df) == 2
+    assert results_df["Battery_Energy"].iloc[-1] == pytest.approx(297.7074191036577)
+
+
+def test_simulate_energy_balance_15min_golden_output():
+    idx = pd.date_range("2025-01-01 00:00", periods=8, freq="15min", tz="UTC")
+    pv_dc = pd.Series([0.0, 400.0, 800.0, 1200.0, 1200.0, 800.0, 400.0, 0.0], index=idx)
+    load = pd.DataFrame({"Load": [500.0] * 8}, index=idx)
+
+    results_df, total_pv, summary_df, *_ = simulate_energy_balance(
+        pv_dc=pv_dc,
+        houseload=load,
+        battery_config=None,
+        freq="15min",
+    )
+
+    _assert_numeric_record(
+        summary_df.iloc[0].to_dict(),
+        {
+            "Total PV [kWh]": 1.152,
+            "Total Load [kWh]": 1.0,
+            "Sell [kWh]": 0.46,
+            "Import [kWh]": 0.308,
+            "Import [%]": 30.8,
+            "Grid Independence [%]": 69.2,
+            "Final SOH [%]": 100.0,
+            "N_Replacements": 0,
+            "Replacement_Cost": 0.0,
+        },
+    )
+    assert total_pv == pytest.approx(1152.0)
+    assert results_df["Import_From_Grid"].sum() * 0.25 / 1000 == pytest.approx(0.308)
+    assert results_df["Sell_To_Grid"].sum() * 0.25 / 1000 == pytest.approx(0.46)
+
+
+def test_cost_analysis_projection_golden_output():
+    cost_params = CostParams(
+        electricity_cost=0.30,
+        electricity_sold_cost=0.05,
+        daily_power_cost=0.20,
+        module_cost_per_w=0.10,
+        battery_cost_per_kwh=400.0,
+        dc_ac_ratio=1.25,
+        inverter_cost_per_kw=100.0,
+        inverter_cost_per_kw_nobatt=50.0,
+        installation_cost_per_module=100.0,
+        battery_installation_cost=200.0,
+        other_cost_per_module=10.0,
+        other_cost_fixed=25.0,
+        maintenance_cost_per_panel=5.0,
+        maintenance_cost_fixed=15.0,
+        operation_cost=20.0,
+        inflation_rate=0.02,
+        sell_price_inflation=0.01,
+        discount_rate=0.03,
+        pv_degradation_rate=0.005,
+    )
+    costs = calculate_costs(4, 500.0, 2000.0, cost_params)
+    yearly_summary = pd.DataFrame(
+        {
+            "Year": [1, 2, 3],
+            "Load_kWh": [1200.0, 1200.0, 1200.0],
+            "PV_Production_kWh": [900.0, 880.0, 860.0],
+            "Import_kWh": [450.0, 465.0, 480.0],
+            "Export_kWh": [150.0, 145.0, 140.0],
+            "PV_Degradation_Factor": [1.0, 0.98, 0.96],
+            "Replacement_Cost": [0.0, 0.0, 800.0],
+        }
+    )
+
+    projection = cost_analysis_projection(
+        pd.DataFrame(),
+        costs,
+        num_years=3,
+        inflation_rate=0.02,
+        sell_price_inflation=0.01,
+        discount_rate=0.03,
+        yearly_summary_df=yearly_summary,
+        total_replacement_cost=800.0,
+        emissions_params=EmissionsParams(average_grid_carbon_intensity_gco2_kwh=200.0, country="Testland"),
+    )
+
+    _assert_numeric_record(
+        costs,
+        {
+            "total_initial_cost": 1825.0,
+            "annual_operation_cost": 55.0,
+            "pv_cost": 200.0,
+            "inverter_cost": 160.0,
+            "battery_cost": 800.0,
+            "installation_cost": 600.0,
+            "other_costs": 65.0,
+        },
+    )
+    _assert_numeric_record(
+        projection.iloc[0].to_dict(),
+        {
+            "Cost_No_Sys_Annual": 433.0,
+            "Cost_System_Annual": 255.5,
+            "Savings_Cumulative_NPV": -1652.6699029126213,
+            "CO2_Avoided_Total_kg": 180.0,
+            "CO2_Avoided_SelfConsumed_kg": 150.0,
+        },
+    )
+    _assert_numeric_record(
+        projection.iloc[2].to_dict(),
+        {
+            "Cost_Replacement": 832.32,
+            "Cost_System_Annual": 1108.1681,
+            "Savings_Cumulative_NPV": -2088.5138282480434,
+            "CO2_Avoided_Total_Cumulative_kg": 528.0,
+            "CO2_Avoided_SelfConsumed_Cumulative_kg": 441.0,
+        },
+    )
+    assert projection.attrs["payback_year"] is None
+    assert projection.attrs["total_investment"] == pytest.approx(1825.0)
+    assert projection.attrs["total_replacement_cost"] == pytest.approx(800.0)
+    assert projection.attrs["final_npv_savings"] == pytest.approx(-2088.5138282480434)
+
+
+def test_co2_projection_uses_marginal_intensity_golden_output():
+    projection = calculate_co2_projection(
+        yearly_pv_kwh=pd.Series([1000.0, 900.0]).values,
+        yearly_export_kwh=pd.Series([100.0, 120.0]).values,
+        emissions_params=EmissionsParams(
+            average_grid_carbon_intensity_gco2_kwh=150.0,
+            marginal_grid_carbon_intensity_gco2_kwh=400.0,
+            country="Testland",
+        ),
+    )
+
+    assert projection["CO2_Avoided_CI_Type"].tolist() == ["marginal", "marginal"]
+    _assert_numeric_record(
+        projection.iloc[-1].to_dict(),
+        {
+            "CO2_Avoided_Total_kg": 360.0,
+            "CO2_Avoided_SelfConsumed_kg": 312.0,
+            "CO2_Avoided_Total_Cumulative_kg": 760.0,
+            "CO2_Avoided_SelfConsumed_Cumulative_kg": 672.0,
+            "CO2_Avoided_CI_gCO2_kWh": 400.0,
+            "Average_Grid_CI_gCO2_kWh": 150.0,
+            "Marginal_Grid_CI_gCO2_kWh": 400.0,
+        },
+    )

--- a/tools/verify_release_artifacts.py
+++ b/tools/verify_release_artifacts.py
@@ -29,6 +29,7 @@ REQUIRED_WHEEL_FILES = {
 REQUIRED_SDIST_FILES = {
     "docs/conf.py",
     "docs/index.md",
+    "docs/release.md",
     "docs/getting-started/quickstart.md",
     "docs/legal/load-profile-data.md",
 }

--- a/tools/verify_release_artifacts.py
+++ b/tools/verify_release_artifacts.py
@@ -1,0 +1,201 @@
+"""Build and smoke-test BREOS release artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import site
+import subprocess
+import sys
+import sysconfig
+import tarfile
+import tempfile
+import textwrap
+import venv
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_WHEEL_FILES = {
+    "breos/data/configs/locations.json",
+    "breos/data/configs/costs.json",
+    "breos/data/configs/electricity.json",
+    "breos/data/configs/emissions.json",
+    "breos/data/configs/financials.json",
+    "breos/data/rlp/h0SLP_demandlib_1000kwh_hourly.csv",
+    "breos/data/rlp/h0SLP_demandlib_1000kwh_15min.csv",
+}
+REQUIRED_SDIST_FILES = {
+    "docs/conf.py",
+    "docs/index.md",
+    "docs/getting-started/quickstart.md",
+    "docs/legal/load-profile-data.md",
+}
+
+
+def _run(
+    command: list[str], *, cwd: Path = REPO_ROOT, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(command, cwd=cwd, env=env, check=True, text=True, capture_output=True)
+    except subprocess.CalledProcessError as exc:
+        sys.stdout.write(exc.stdout or "")
+        sys.stderr.write(exc.stderr or "")
+        raise
+
+
+def _build_artifacts(dist_dir: Path) -> tuple[Path, Path]:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv is required to build release artifacts")
+
+    result = _run([uv, "build", "--out-dir", str(dist_dir)])
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+
+    wheels = sorted(dist_dir.glob("*.whl"))
+    sdists = sorted(dist_dir.glob("*.tar.gz"))
+    if len(wheels) != 1:
+        raise AssertionError(f"Expected exactly one wheel, found {len(wheels)}")
+    if len(sdists) != 1:
+        raise AssertionError(f"Expected exactly one sdist, found {len(sdists)}")
+    return wheels[0], sdists[0]
+
+
+def _assert_wheel_contents(wheel: Path) -> None:
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+
+    missing = sorted(REQUIRED_WHEEL_FILES - names)
+    if missing:
+        raise AssertionError(f"Wheel is missing packaged runtime data: {missing}")
+    leaked_build_docs = sorted(name for name in names if name.startswith("docs/_build/") or "/docs/_build/" in name)
+    if leaked_build_docs:
+        raise AssertionError(f"Wheel contains generated docs: {leaked_build_docs[:5]}")
+
+
+def _sdist_names(sdist: Path) -> set[str]:
+    with tarfile.open(sdist, "r:gz") as archive:
+        names = set()
+        for member in archive.getmembers():
+            path = Path(member.name)
+            try:
+                names.add(path.relative_to(path.parts[0]).as_posix())
+            except ValueError:
+                names.add(path.as_posix())
+        return names
+
+
+def _assert_sdist_contents(sdist: Path) -> None:
+    names = _sdist_names(sdist)
+    missing = sorted(REQUIRED_SDIST_FILES - names)
+    if missing:
+        raise AssertionError(f"Sdist is missing rebuildable docs source: {missing}")
+    leaked_build_docs = sorted(name for name in names if name.startswith("docs/_build/"))
+    if leaked_build_docs:
+        raise AssertionError(f"Sdist contains generated docs: {leaked_build_docs[:5]}")
+
+
+def _dependency_paths() -> str:
+    paths = set()
+    try:
+        paths.update(site.getsitepackages())
+    except AttributeError:
+        pass
+    user_site = site.getusersitepackages()
+    if user_site:
+        paths.add(user_site)
+    purelib = sysconfig.get_paths().get("purelib")
+    if purelib:
+        paths.add(purelib)
+    return os.pathsep.join(str(Path(path).resolve()) for path in paths if Path(path).exists())
+
+
+def _venv_paths(venv_dir: Path) -> tuple[Path, Path]:
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe", venv_dir / "Scripts" / "pip.exe"
+    return venv_dir / "bin" / "python", venv_dir / "bin" / "pip"
+
+
+def _smoke_test_installed_wheel(wheel: Path, work_dir: Path) -> None:
+    venv_dir = work_dir / "installed-wheel"
+    venv.EnvBuilder(with_pip=True).create(venv_dir)
+    python, pip = _venv_paths(venv_dir)
+
+    install = _run([str(pip), "install", "--no-deps", "--force-reinstall", str(wheel)], cwd=work_dir)
+    sys.stdout.write(install.stdout)
+    sys.stderr.write(install.stderr)
+
+    smoke_code = textwrap.dedent(
+        """
+        import json
+        import os
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(os.environ["BREOS_REPO_ROOT"]).resolve()
+        dep_paths = [p for p in os.environ.get("BREOS_DEPENDENCY_PATHS", "").split(os.pathsep) if p]
+
+        sys.path = [
+            p
+            for p in sys.path
+            if Path(p or ".").resolve() != repo_root
+            and repo_root not in Path(p or ".").resolve().parents
+        ]
+        for dep_path in dep_paths:
+            if dep_path not in sys.path:
+                sys.path.append(dep_path)
+
+        import breos
+        from breos.app import App
+        from breos.load_profiles import load_profile
+        from breos.resources import load_config_json, rlp_resource
+
+        breos_file = Path(breos.__file__).resolve()
+        if repo_root == breos_file or repo_root in breos_file.parents:
+            raise AssertionError(f"Imported breos from source tree: {breos_file}")
+
+        locations = load_config_json("locations.json")
+        if "porto" not in locations:
+            raise AssertionError("packaged locations.json did not contain porto")
+
+        hourly = rlp_resource("h0SLP_demandlib_1000kwh_hourly.csv")
+        if not hourly.is_file():
+            raise AssertionError(f"packaged RLP file is missing: {hourly}")
+
+        profile = load_profile("1", 1000, start_date="2025-01-01", freq="h", timezone="UTC")
+        if len(profile) != 8760:
+            raise AssertionError(f"unexpected hourly load profile length: {len(profile)}")
+
+        app = App({"location": "porto", "n_modules": 1, "annual_consumption_kwh": 1000})
+        if app._cfg["location"] != "porto":
+            raise AssertionError("App did not resolve packaged configuration")
+
+        print(json.dumps({"breos_file": str(breos_file), "profile_rows": len(profile)}))
+        """
+    )
+    env = os.environ.copy()
+    env["BREOS_REPO_ROOT"] = str(REPO_ROOT)
+    env["BREOS_DEPENDENCY_PATHS"] = _dependency_paths()
+    smoke = _run([str(python), "-c", smoke_code], cwd=work_dir, env=env)
+    sys.stdout.write(smoke.stdout)
+    sys.stderr.write(smoke.stderr)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="breos-release-") as tmp:
+        work_dir = Path(tmp)
+        dist_dir = work_dir / "dist"
+        dist_dir.mkdir()
+
+        wheel, sdist = _build_artifacts(dist_dir)
+        _assert_wheel_contents(wheel)
+        _assert_sdist_contents(sdist)
+        _smoke_test_installed_wheel(wheel, work_dir)
+
+    print("Release artifact verification passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add deterministic golden-output coverage for battery energy balance, 15-minute behavior, economics projection, replacements, and emissions
- add a release artifact verifier that builds wheel/sdist, checks packaged runtime data and docs source, and imports BREOS from an installed wheel
- run the artifact verifier in CI and include tools in Ruff checks

## Verification
- uv run ruff check breos/ tests/ tools/
- uv run ruff format --check breos/ tests/ tools/
- uv run pytest tests/ -v
- uv run python tools/verify_release_artifacts.py