### PR TITLE
Narrow top-level public API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Changed
+- Narrowed the top-level `breos.__all__` release surface to the stable facade,
+  key configuration/result objects, and core composition helpers. Lower-level
+  module APIs remain importable from their modules.
+
 ## [0.1.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ single representative tilt/azimuth.
 
 ## Advanced Usage
 
-For full control over individual simulation steps, you can use the internal modules directly:
+For full control over individual simulation steps, use the lower-level modules directly:
 
 ```python
 from breos.weather import fetch_tmy_weather_data

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -17,11 +17,10 @@ Modules:
 
 Usage:
 ------
->>> from breos.weather import fetch_tmy_weather_data
->>> from breos.solar import calculate_pv_production, PVModuleParams
->>> from breos.battery import simulate_energy_balance, BatteryConfig
->>> from breos.load_profiles import load_profile
->>> from breos.economics import calculate_costs, cost_analysis_projection
+>>> import breos
+>>> app = breos.App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000})
+>>> app.simulate()
+>>> result = app.result()
 """
 
 # Version
@@ -266,72 +265,43 @@ __all__ = [
     "App",
     # Version
     "__version__",
-    # Utils
-    "is_leap_year",
-    "count_leap_years",
-    "number_of_cores",
-    "get_hours_per_step",
-    "get_steps_per_day",
-    "get_steps_per_year",
-    "remap_datetime_index_years",
-    # Constants
-    "R_GAS",
-    "T_REF_K",
-    "NAUMANN_K0_PERCENT",
-    "NAUMANN_EA_J_MOL",
-    "LAM_K0_FRAC",
-    "LAM_EA_J_MOL",
-    "DEFAULT_INDOOR_SETPOINT_C",
-    "DEFAULT_INDOOR_COUPLING_ALPHA",
-    "DEFAULT_INDOOR_FLOOR_C",
-    "DEFAULT_INDOOR_CEILING_C",
+    # Configuration and result objects
+    "BatteryConfig",
+    "CostParams",
+    "EmissionsParams",
+    "InverterConfig",
+    "InverterConversionResult",
+    "OptimizationResult",
+    "PVModuleParams",
     # Weather
-    "parse_weather_filename",
     "load_weather",
     "fetch_tmy_weather_data",
     "fetch_tmy_nsrdb",
     "fetch_weather_data",
     "read_epw_file",
-    "resample_tmy_to_15min",
-    "resample_to_15min",
-    "resample_to_hourly",
-    "csv_15min_to_hourly",
-    "csv_hourly_to_15min",
-    "select_random_year_and_replace_datetime",
-    "preload_weather_by_year",
-    "extract_ambient_temperature",
-    "build_battery_temperature_series",
     # Solar
     "calculate_pv_production_dc",
     "calculate_pv_production_dc_tracking",
     "calculate_multi_array_production",
     "calculate_pv_production_ac",
-    "calculate_pv_production_tmy",
     "dc_to_ac",
-    "PVModuleParams",
     "estimate_optimal_tilt",
     "default_azimuth",
-    "zeb_sizer",
+    # PV module catalogue
+    "get_module",
+    "get_module_info",
+    "list_modules",
     # Load Profiles
     "load_profile",
     "scale_to_annual_consumption",
     "align_load_to_pv",
     # Inverter
-    "INVERTER_PRESETS",
-    "InverterConfig",
-    "InverterConversionResult",
     "get_inverter_preset",
     "calculate_dc_ac_power",
-    "calculate_dc_ac_efficiency",
     # Battery
     "simulate_energy_balance",
-    "BatteryConfig",
-    "update_battery_soh_cyclewise",
-    "update_battery_soh_calendar",
-    "update_battery_soc",
     "apply_indoor_temperature_model",
     # Emissions
-    "EmissionsParams",
     "calculate_co2_savings",
     "calculate_co2_projection",
     # Economics
@@ -340,34 +310,14 @@ __all__ = [
     "cost_params_from_config",
     "find_payback_year",
     "calculate_lcoe",
-    "CostParams",
     # Optimization
     "optimize_tilt",
     "optimize_tilt_brent",
     "optimize_battery_size",
-    "size_for_zeb",
-    "OptimizationResult",
     # I/O
     "export_results",
-    "export_cost_analysis",
     "export_summary",
-    "save_simulation_report",
     "load_results",
     "export_monthly_summary",
     "export_yearly_summary",
-    # Polysun Degradation
-    "PolysunDegradationConfig",
-    "woehler_cycles_to_failure",
-    "compute_dod_histogram",
-    "compute_miner_damage",
-    "predict_polysun_lifetime",
-    "simulate_polysun_degradation",
-    # Plotting
-    "plot_calendar_aging_sensitivity",
-    "plot_grid_independence_heatmap",
-    "plot_location_comparison_delta",
-    "plot_co2_savings",
-    "plot_degradation_methodology_comparison",
-    "plot_lifetime_prediction_comparison",
-    "plot_temperature_sensitivity_comparison",
 ]

--- a/docs/adr/0001-docs-architecture.md
+++ b/docs/adr/0001-docs-architecture.md
@@ -8,10 +8,10 @@ composable submodule usage introduced later as "Building custom pipelines."
 
 The API reference mirrors the same eight puzzle pieces with hand-curated
 `autosummary` lists, plus a recursive `api/appendix.md` for utilities,
-constants, and other names that ended up in `__all__` but aren't part of
-the primary surface. Narrative ("user-guide/") will be separated from
-theory ("concepts/") in future PRs so degradation-model math doesn't drown
-the practical battery-configuration page.
+constants, and other module APIs that remain importable but are not part of
+the narrow top-level release surface. Narrative ("user-guide/") will be
+separated from theory ("concepts/") in future PRs so degradation-model math
+doesn't drown the practical battery-configuration page.
 
 ## Why
 
@@ -20,6 +20,6 @@ the practical battery-configuration page.
 - Puzzle pieces cross Python module boundaries (PV = `solar.py` +
   `pv_modules.py` + `inverter.py`). Documenting per-module would scatter
   related material.
-- Curated `autosummary` blocks keep ~30 user-facing names on the index
-  while still surfacing the full `__all__` via the appendix's recursive
-  crawl.
+- Curated `autosummary` blocks keep the primary user-facing names on the
+  index while the appendix still surfaces additional module APIs through a
+  recursive crawl.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,13 +1,16 @@
 # API reference
 
-BREOS's public API is organized by domain "puzzle piece" rather than by
+BREOS's API reference is organized by domain "puzzle piece" rather than by
 Python module — the [PV reference](pv.md) pulls names from `breos.solar`,
 `breos.pv_modules`, and `breos.inverter`, since all three describe the same
 piece of a system.
 
 The {py:class}`~breos.App` facade is the recommended entry point. The
-pages below cover the lower-level functions you reach for when composing a
-custom pipeline.
+top-level `breos.__all__` list is intentionally narrower than the full
+reference: it marks the stable release surface for `from breos import *`.
+The pages below cover lower-level module APIs you reach for when composing a
+custom pipeline. Import those lower-level names from their modules, for example
+`from breos.solar import calculate_pv_production_dc`.
 
 ## Puzzle pieces
 
@@ -76,9 +79,9 @@ fronts.
 
 ## Other surfaces
 
-[Appendix](appendix.md) documents the remaining public names — constants,
-I/O helpers, utilities, and other modules that are exposed but not
-load-bearing for typical use.
+[Appendix](appendix.md) documents additional module APIs — constants, I/O
+helpers, utilities, and research-validation modules that remain importable but
+are not part of the narrow top-level release surface.
 
 ```{toctree}
 :hidden:

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,8 +57,8 @@ result dict means.
 :link: api/index
 :link-type: doc
 
-Every public function and class, organized by what it does — weather, PV,
-battery, costs, and so on.
+Stable facade guidance and lower-level module reference, organized by what
+each piece does — weather, PV, battery, costs, and so on.
 :::
 
 :::{grid-item-card} Architecture

--- a/docs/release.md
+++ b/docs/release.md
@@ -50,8 +50,8 @@ BREOS from the installed wheel instead of the source checkout.
 
 ## API Stability
 
-- Treat `breos.App` and documented config/result keys as the primary stable
-  surface for 0.1.x.
+- Treat `breos.App`, documented config/result keys, and names in `breos.__all__`
+  as the primary stable surface for 0.2.x.
 - Add golden-output tests before changing core energy balance, economics,
   emissions, or time-resolution behavior.
 - Keep module-level APIs importable unless a removal is documented in the
@@ -72,7 +72,7 @@ Rationale:
 - `library` matches how users install and import BREOS.
 - `simulation and optimization` describes the main user-facing purpose.
 - `framework` can describe the internal/extensible architecture, but sounds
-  broader than the current 0.1.0 public surface.
+  broader than the current pre-1.0 public surface.
 - `engine` can be used for the simulation core, but should not describe the
   whole project unless a stable lower-level engine API is intentionally exposed.
 - `model` should refer to specific algorithms or component models, not the full

--- a/tests/test_inverter.py
+++ b/tests/test_inverter.py
@@ -32,13 +32,10 @@ def test_dc_ac_power_clips_negative_inputs_to_zero():
     assert result.total_dc_input_w == 0.0
 
 
-def test_package_all_exports_new_public_helpers():
+def test_package_all_exports_stable_inverter_helpers():
     expected = {
         "calculate_dc_ac_power",
         "InverterConversionResult",
-        "build_battery_temperature_series",
-        "preload_weather_by_year",
-        "remap_datetime_index_years",
     }
 
     assert expected.issubset(set(breos.__all__))

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,48 @@
+"""Tests for the documented top-level BREOS API surface."""
+
+import breos
+
+
+def test_top_level_all_is_narrow_release_surface():
+    stable_api = set(breos.__all__)
+
+    expected = {
+        "App",
+        "__version__",
+        "BatteryConfig",
+        "CostParams",
+        "EmissionsParams",
+        "InverterConfig",
+        "InverterConversionResult",
+        "OptimizationResult",
+        "PVModuleParams",
+        "fetch_tmy_weather_data",
+        "load_profile",
+        "calculate_pv_production_dc",
+        "calculate_multi_array_production",
+        "simulate_energy_balance",
+        "calculate_costs",
+        "cost_analysis_projection",
+        "calculate_co2_savings",
+        "optimize_tilt",
+        "optimize_battery_size",
+        "export_results",
+        "load_results",
+    }
+    intentionally_excluded = {
+        "R_GAS",
+        "plot_co2_savings",
+        "PolysunDegradationConfig",
+        "compute_dod_histogram",
+        "build_battery_temperature_series",
+        "remap_datetime_index_years",
+    }
+
+    assert expected.issubset(stable_api)
+    assert stable_api.isdisjoint(intentionally_excluded)
+
+
+def test_existing_top_level_attributes_remain_importable():
+    assert breos.R_GAS > 0
+    assert callable(breos.build_battery_temperature_series)
+    assert callable(breos.compute_dod_histogram)


### PR DESCRIPTION
## Summary
- narrow breos.__all__ to the stable top-level release surface while keeping existing top-level attributes importable
- document the distinction between stable top-level exports and lower-level module APIs
- add tests that lock the narrowed public API surface and compatibility for existing top-level attributes

## Verification
- uv run ruff check breos/ tests/ tools/
- uv run pytest tests/ -v
- uv run --extra docs sphinx-build -b html docs docs/_build/html
- uv run python tools/verify_release_artifacts.py