### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-03
+
 ### Changed
 - Narrowed the top-level `breos.__all__` release surface to the stable facade,
   key configuration/result objects, and core composition helpers. Lower-level

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: BSD-3](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 
-A modular Python library for photovoltaic (PV) and battery energy system simulations, designed for research and engineering applications.
+A Python library for PV and battery energy-system simulation and optimization, designed for research and engineering applications.
 
 ## Features
 

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -1,7 +1,7 @@
 """
 BREOS - Building Renewable Energy Optimization Software
 
-A modular Python library for photovoltaic and battery energy system simulations.
+Python library for PV and battery energy-system simulation and optimization.
 Supports both hourly ('h') and 15-minute ('15min') time resolutions.
 
 Modules:
@@ -24,7 +24,7 @@ Usage:
 """
 
 # Version
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # Public facade
 from breos.app import App

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,8 +13,8 @@ Building Renewable Energy Optimization Software
 ::::
 
 ::::{div} sd-text-center sd-py-3
-A modular Python library for photovoltaic and battery energy system
-simulations, designed for research and engineering applications.
+A Python library for PV and battery energy-system simulation and
+optimization, designed for research and engineering applications.
 ::::
 
 ## Quick example
@@ -72,7 +72,7 @@ Design decisions and refactoring plans for BREOS's internal structure.
 
 ## Status
 
-BREOS is pre-1.0 (currently `0.1.0`, beta). The public API may change
+BREOS is pre-1.0 (current release `0.2.0`, beta). The public API may change
 between minor releases. The [roadmap](https://github.com/Str4vinci/breos/blob/main/ROADMAP.md)
 tracks larger refactoring work — notably, the planned [adapter layer for
 third-party libraries](architecture/third-party-wrapping.md) will change

--- a/docs/release.md
+++ b/docs/release.md
@@ -57,15 +57,11 @@ BREOS from the installed wheel instead of the source checkout.
 - Keep module-level APIs importable unless a removal is documented in the
   changelog with a migration path.
 
-## Open Positioning Question
+## Public Wording
 
-Before the public release, decide the project wording used in the README,
-package metadata, docs front page, and release notes:
-
-> Is BREOS a simulation engine, a framework, a model, or a library?
-
-Working recommendation: use **Python library for PV and battery energy-system
-simulation and optimization** as the default public wording.
+Use **Python library for PV and battery energy-system simulation and
+optimization** as the default public wording in the README, package metadata,
+docs front page, and release notes.
 
 Rationale:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "breos"
-version = "0.1.0"
-description = "Building Renewable Energy Optimization Software - A Python library for PV and battery energy system simulations"
+version = "0.2.0"
+description = "Python library for PV and battery energy-system simulation and optimization"
 readme = "README.md"
 license = "BSD-3-Clause"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "breos"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "geopy" },


### PR DESCRIPTION
Summary: Bumps version metadata and lock file to 0.2.0; moves the Unreleased changelog entry to 0.2.0 dated 2026-06-03; updates README/docs wording to the preferred public description. Verification: uv run ruff check breos/ tests/ tools/ passed; uv run ruff format --check breos/ tests/ tools/ passed; uv run pytest tests/ -v passed (147 passed); uv run python tools/verify_release_artifacts.py passed (built breos-0.2.0 wheel/sdist and installed-wheel smoke passed); uv run --extra docs sphinx-build -b html docs docs/_build/html passed.