### PR TITLE
Add docs build to CI gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra docs
 
       - name: Lint
         run: uv run ruff check breos/ tests/ tools/
@@ -33,3 +33,6 @@ jobs:
 
       - name: Verify release artifacts
         run: uv run python tools/verify_release_artifacts.py
+
+      - name: Build docs
+        run: uv run --extra docs sphinx-build -b html docs docs/_build/html


### PR DESCRIPTION
Summary: Adds docs extras to the CI dependency sync and runs the Sphinx HTML build in the existing Tests workflow so CI covers the full release gate set. Verification: uv run --extra docs sphinx-build -b html docs docs/_build/html passed locally.