### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-03
+
+### Documentation
+- Updated installation guidance to use the stable GitHub tag until PyPI
+  publishing is available.
+- Added PyPI trusted publishing to the roadmap.
+- Documented the full CI/release validation gates in the contributor guide.
+- Standardized API documentation wording around domain areas.
+
 ## [0.2.0] - 2026-06-03
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,16 @@ pip install -e ".[dev]"
 uv run pytest tests/ -v
 ```
 
+For release-style validation, run the same gates used by CI:
+
+```bash
+uv run ruff check breos/ tests/ tools/
+uv run ruff format --check breos/ tests/ tools/
+uv run pytest tests/ -v
+uv run python tools/verify_release_artifacts.py
+uv run --extra docs sphinx-build -b html docs docs/_build/html
+```
+
 ## Branching
 
 - `main` — stable, release-ready code. Do not push directly.
@@ -67,7 +77,8 @@ uv run pytest tests/test_app.py -v
 
 - PRs should target `develop`, not `main`
 - Include a brief description of what changed and why
-- Make sure CI passes (tests run automatically on every PR)
+- Make sure CI passes. It runs lint, format checks, tests, release artifact
+  verification, and the Sphinx docs build on every PR to `develop` or `main`.
 - Keep PRs focused — one feature or fix per PR
 
 ## Reporting Issues

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ A Python library for PV and battery energy-system simulation and optimization, d
 ## Installation
 
 ```bash
-pip install breos
+pip install "breos @ git+https://github.com/Str4vinci/breos.git@v0.2.1"
 ```
 
-Or from source:
+PyPI publishing is planned for a future release. Until then, install the latest
+stable tag from GitHub, or install from source:
 
 ```bash
 git clone https://github.com/Str4vinci/breos.git

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,21 @@ provide module, inverter, environment, MPPT, and string-topology data.
 - Non-goal: code-compliance certification, conductor/fuse sizing, and physical
   wiring auto-routing.
 
+## Distribution and release automation
+
+### PyPI trusted publishing
+
+BREOS releases are currently cut from protected `main` commits and published as
+GitHub Releases. Future work should add PyPI trusted publishing so tagged
+releases can publish the verified wheel and source distribution without storing
+long-lived upload tokens in the repository.
+
+- Use GitHub Actions OIDC trusted publishing for PyPI.
+- Publish only from protected `v*` tags that point at `main`.
+- Reuse the release artifact verifier before upload so packaged data, docs
+  exclusions, and installed-wheel smoke checks stay covered.
+- Add a TestPyPI dry-run path before enabling production PyPI uploads.
+
 ## Longer-Term Research Modules
 
 The following modules exist in the broader research codebase and may be

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -24,7 +24,7 @@ Usage:
 """
 
 # Version
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # Public facade
 from breos.app import App

--- a/docs/adr/0001-docs-architecture.md
+++ b/docs/adr/0001-docs-architecture.md
@@ -1,12 +1,12 @@
-# 0001 — Docs organized by puzzle piece, App-led
+# 0001 — Docs organized by domain area, App-led
 
-BREOS docs are organized by domain "puzzle piece" (Weather, PV, Load
-profiles, Energy balance, Battery, Cost analysis, Optimization, Plotting)
-rather than by Python module. The landing page leads with the
+BREOS docs are organized by domain area (Weather, PV, Load profiles, Energy
+balance, Battery, Cost analysis, Optimization, Plotting) rather than by Python
+module. The landing page leads with the
 {py:class}`~breos.App` facade — the unique thing BREOS offers — with
 composable submodule usage introduced later as "Building custom pipelines."
 
-The API reference mirrors the same eight puzzle pieces with hand-curated
+The API reference mirrors the same eight domain areas with hand-curated
 `autosummary` lists, plus a recursive `api/appendix.md` for utilities,
 constants, and other module APIs that remain importable but are not part of
 the narrow top-level release surface. Narrative ("user-guide/") will be
@@ -17,7 +17,7 @@ doesn't drown the practical battery-configuration page.
 
 - The App facade is BREOS's differentiator versus pvlib; leading with it
   gives a 30-second first-time-user win.
-- Puzzle pieces cross Python module boundaries (PV = `solar.py` +
+- Domain areas cross Python module boundaries (PV = `solar.py` +
   `pv_modules.py` + `inverter.py`). Documenting per-module would scatter
   related material.
 - Curated `autosummary` blocks keep the primary user-facing names on the

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,9 +1,9 @@
 # API reference
 
-BREOS's API reference is organized by domain "puzzle piece" rather than by
-Python module — the [PV reference](pv.md) pulls names from `breos.solar`,
+BREOS's API reference is organized by domain area rather than by Python
+module — the [PV reference](pv.md) pulls names from `breos.solar`,
 `breos.pv_modules`, and `breos.inverter`, since all three describe the same
-piece of a system.
+part of a system.
 
 The {py:class}`~breos.App` facade is the recommended entry point. The
 top-level `breos.__all__` list is intentionally narrower than the full
@@ -12,7 +12,7 @@ The pages below cover lower-level module APIs you reach for when composing a
 custom pipeline. Import those lower-level names from their modules, for example
 `from breos.solar import calculate_pv_production_dc`.
 
-## Puzzle pieces
+## Domain areas
 
 ::::{grid} 1 2 2 4
 :gutter: 3

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,11 +2,14 @@
 
 BREOS requires Python 3.13 or newer.
 
-## From PyPI
+## From the stable tag
 
 ```bash
-pip install breos
+pip install "breos @ git+https://github.com/Str4vinci/breos.git@v0.2.1"
 ```
+
+PyPI publishing is planned for a future release. Until then, install the latest
+stable GitHub tag or use a source checkout.
 
 ## From source
 
@@ -36,8 +39,8 @@ The repository uses [`uv`](https://docs.astral.sh/uv/) for dependency
 management. If you prefer uv, the equivalents are:
 
 ```bash
-uv sync --extra dev          # development
-uv sync --extra docs         # documentation
+uv sync --extra dev                  # development
+uv sync --extra dev --extra docs     # development plus documentation
 ```
 
 ## Verifying the install

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ Design decisions and refactoring plans for BREOS's internal structure.
 
 ## Status
 
-BREOS is pre-1.0 (current release `0.2.0`, beta). The public API may change
+BREOS is pre-1.0 (current release `0.2.1`, beta). The public API may change
 between minor releases. The [roadmap](https://github.com/Str4vinci/breos/blob/main/ROADMAP.md)
 tracks larger refactoring work — notably, the planned [adapter layer for
 third-party libraries](architecture/third-party-wrapping.md) will change

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "breos"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python library for PV and battery energy-system simulation and optimization"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "breos"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "geopy" },


### PR DESCRIPTION
Summary: Promotes the docs-only 0.2.1 patch from develop to main. This updates release metadata, changelog, installation guidance for stable GitHub tags, roadmap PyPI trusted publishing notes, contributor release-gate docs, and API docs terminology. Verification: PR #26 Tests workflow passed; local release gates passed before merge: ruff lint, ruff format check, pytest (147 passed), release artifact verification for breos-0.2.1, and Sphinx HTML docs build.