### PR TITLE
Split optional feature dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Changed
+- Slimmed the default runtime dependency set to the BREOS core simulation
+  stack and moved heavier workflow packages behind extras: `plots`,
+  `optimization`, `weather`, `fast`, `cec-fit`, `validation`, and
+  `location-tools`.
+- The `dev` extra now installs optional feature dependencies so contributor
+  test runs continue to cover optional paths.
+
 ## [0.2.3] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ A Python library for PV and battery energy-system simulation and optimization, d
 pip install "breos @ git+https://github.com/Str4vinci/breos.git@v0.2.3"
 ```
 
+Optional feature groups keep the default install focused on core PV +
+battery simulation:
+
+```bash
+pip install "breos[plots]"          # publication plots
+pip install "breos[optimization]"   # pymoo multi-objective sizing
+pip install "breos[weather]"        # Open-Meteo historical weather fetching
+pip install "breos[fast]"           # Numba kernels
+pip install "breos[validation]"     # Excel / Arrow validation workflows
+```
+
 PyPI publishing is planned for a future release. Until then, install the latest
 stable tag from GitHub, or install from source:
 

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -5,6 +5,9 @@ method handles smooth one-dimensional problems (tilt); NSGA-II via
 [pymoo](https://pymoo.org/) handles multi-objective sizing (PV count vs
 battery vs cost vs grid independence).
 
+Install `breos[optimization]` to use pymoo-backed multi-objective classes.
+The one-dimensional helpers use the core scientific stack.
+
 ## Tilt
 
 ```{eval-rst}

--- a/docs/api/weather.md
+++ b/docs/api/weather.md
@@ -3,6 +3,9 @@
 Sources, loaders, and resampling utilities for solar irradiance and
 temperature time series.
 
+Local weather loading and PVGIS/NSRDB TMY helpers use the core install.
+Open-Meteo historical fetching requires `breos[weather]`.
+
 ## Loading from local files
 
 ```{eval-rst}

--- a/docs/architecture/third-party-wrapping.md
+++ b/docs/architecture/third-party-wrapping.md
@@ -9,7 +9,7 @@
 BREOS imports several third-party libraries directly throughout the package
 (`pvlib`, `pandas`, `numpy`, `scipy`, `numba`, `rainflow`, `geopy`,
 `openmeteo-requests`, `timezonefinder`, `nrel-pysam`, `pymoo`,
-`requests-cache`, `joblib`, `matplotlib`, `openpyxl`).
+`requests-cache`, `matplotlib`, `openpyxl`).
 
 Direct usage means those libraries co-own the BREOS public API. When they
 change — and `pvlib` in particular has historically broken APIs across
@@ -112,7 +112,7 @@ signatures.
 - `nrel-pysam` → `breos.adapters.sam_model` (if/when used beyond optional
   paths).
 - `pymoo` → `breos.adapters.multi_objective` (used in `optimization.py`).
-- `openpyxl` → encapsulated inside `breos.io` already; keep as-is.
+- `openpyxl`, `pyarrow` → keep in validation/export-specific paths.
 
 ### Out of scope: pandas and numpy
 
@@ -129,8 +129,9 @@ If we later want stronger schema guarantees, introduce typed wrappers at
 specific boundaries (e.g. a `WeatherFrame` dataclass that validates
 columns) rather than a global abstraction.
 
-`matplotlib` is also kept direct — `plotting.py` is intentionally an
-output module, not a load-bearing core dependency.
+`matplotlib` is also kept direct inside `plotting.py`, but it is packaged as
+an optional `plots` extra because plotting is not a load-bearing core
+dependency.
 
 ## Migration mechanics
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,10 +19,25 @@ cd breos
 pip install -e .
 ```
 
+## Optional features
+
+The base install includes the core simulation stack. Install extras for
+workflows that need heavier optional packages:
+
+```bash
+pip install -e ".[plots]"          # matplotlib plotting helpers
+pip install -e ".[optimization]"   # pymoo multi-objective sizing
+pip install -e ".[weather]"        # Open-Meteo historical weather fetching
+pip install -e ".[fast]"           # Numba kernels
+pip install -e ".[validation]"     # Excel / Arrow validation workflows
+pip install -e ".[location-tools]" # geocoding and timezone lookup helpers
+```
+
 ## Development install
 
 If you plan to contribute, install with the dev extras for testing and
-linting:
+linting. The dev extra also installs BREOS's optional feature dependencies so
+the full local test suite can exercise optional paths:
 
 ```bash
 pip install -e ".[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,20 +19,11 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "geopy>=2.4.1",
-    "joblib>=1.5.3",
-    "matplotlib>=3.10.8",
-    "numba>=0.63.1",
-    "openpyxl>=3.1.0",
-    "openmeteo-requests>=1.7.4",
+    "numpy>=2.0",
     "pandas>=2.3.3",
-    "pyarrow>=19.0.0",
-    "nrel-pysam>=7.1.0",
     "pvlib>=0.14.0,<0.16",
-    "pymoo>=0.6.1.6",
     "rainflow>=3.2.0",
-    "requests-cache>=1.2.1",
-    "timezonefinder>=8.2.1",
+    "scipy>=1.14",
 ]
 
 [project.urls]
@@ -43,7 +34,36 @@ Repository = "https://github.com/Str4vinci/breos"
 breos = "breos.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "ruff>=0.15"]
+cec-fit = ["nrel-pysam>=7.1.0"]
+fast = ["numba>=0.63.1"]
+plots = ["matplotlib>=3.10.8"]
+optimization = ["pymoo>=0.6.1.6"]
+weather = [
+    "openmeteo-requests>=1.7.4",
+    "requests-cache>=1.2.1",
+    "timezonefinder>=8.2.1",
+]
+validation = [
+    "openpyxl>=3.1.0",
+    "pyarrow>=19.0.0",
+]
+location-tools = [
+    "geopy>=2.4.1",
+    "timezonefinder>=8.2.1",
+]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.15",
+    "matplotlib>=3.10.8",
+    "numba>=0.63.1",
+    "openpyxl>=3.1.0",
+    "openmeteo-requests>=1.7.4",
+    "pyarrow>=19.0.0",
+    "nrel-pysam>=7.1.0",
+    "pymoo>=0.6.1.6",
+    "requests-cache>=1.2.1",
+    "timezonefinder>=8.2.1",
+]
 docs = [
     "sphinx>=8.1",
     "pydata-sphinx-theme>=0.16",

--- a/uv.lock
+++ b/uv.lock
@@ -104,26 +104,29 @@ name = "breos"
 version = "0.2.3"
 source = { editable = "." }
 dependencies = [
-    { name = "geopy" },
-    { name = "joblib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pvlib" },
+    { name = "rainflow" },
+    { name = "scipy" },
+]
+
+[package.optional-dependencies]
+cec-fit = [
+    { name = "nrel-pysam" },
+]
+dev = [
     { name = "matplotlib" },
     { name = "nrel-pysam" },
     { name = "numba" },
     { name = "openmeteo-requests" },
     { name = "openpyxl" },
-    { name = "pandas" },
-    { name = "pvlib" },
     { name = "pyarrow" },
     { name = "pymoo" },
-    { name = "rainflow" },
-    { name = "requests-cache" },
-    { name = "timezonefinder" },
-]
-
-[package.optional-dependencies]
-dev = [
     { name = "pytest" },
+    { name = "requests-cache" },
     { name = "ruff" },
+    { name = "timezonefinder" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -135,33 +138,66 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
 ]
+fast = [
+    { name = "numba" },
+]
+location-tools = [
+    { name = "geopy" },
+    { name = "timezonefinder" },
+]
+optimization = [
+    { name = "pymoo" },
+]
+plots = [
+    { name = "matplotlib" },
+]
+validation = [
+    { name = "openpyxl" },
+    { name = "pyarrow" },
+]
+weather = [
+    { name = "openmeteo-requests" },
+    { name = "requests-cache" },
+    { name = "timezonefinder" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "geopy", specifier = ">=2.4.1" },
-    { name = "joblib", specifier = ">=1.5.3" },
-    { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "geopy", marker = "extra == 'location-tools'", specifier = ">=2.4.1" },
+    { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.8" },
+    { name = "matplotlib", marker = "extra == 'plots'", specifier = ">=3.10.8" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0" },
-    { name = "nrel-pysam", specifier = ">=7.1.0" },
-    { name = "numba", specifier = ">=0.63.1" },
-    { name = "openmeteo-requests", specifier = ">=1.7.4" },
-    { name = "openpyxl", specifier = ">=3.1.0" },
+    { name = "nrel-pysam", marker = "extra == 'cec-fit'", specifier = ">=7.1.0" },
+    { name = "nrel-pysam", marker = "extra == 'dev'", specifier = ">=7.1.0" },
+    { name = "numba", marker = "extra == 'dev'", specifier = ">=0.63.1" },
+    { name = "numba", marker = "extra == 'fast'", specifier = ">=0.63.1" },
+    { name = "numpy", specifier = ">=2.0" },
+    { name = "openmeteo-requests", marker = "extra == 'dev'", specifier = ">=1.7.4" },
+    { name = "openmeteo-requests", marker = "extra == 'weather'", specifier = ">=1.7.4" },
+    { name = "openpyxl", marker = "extra == 'dev'", specifier = ">=3.1.0" },
+    { name = "openpyxl", marker = "extra == 'validation'", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pvlib", specifier = ">=0.14.0,<0.16" },
-    { name = "pyarrow", specifier = ">=19.0.0" },
+    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=19.0.0" },
+    { name = "pyarrow", marker = "extra == 'validation'", specifier = ">=19.0.0" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = ">=0.16" },
-    { name = "pymoo", specifier = ">=0.6.1.6" },
+    { name = "pymoo", marker = "extra == 'dev'", specifier = ">=0.6.1.6" },
+    { name = "pymoo", marker = "extra == 'optimization'", specifier = ">=0.6.1.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rainflow", specifier = ">=3.2.0" },
-    { name = "requests-cache", specifier = ">=1.2.1" },
+    { name = "requests-cache", marker = "extra == 'dev'", specifier = ">=1.2.1" },
+    { name = "requests-cache", marker = "extra == 'weather'", specifier = ">=1.2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
+    { name = "scipy", specifier = ">=1.14" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.5" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
     { name = "sphinx-design", marker = "extra == 'docs'", specifier = ">=0.6" },
-    { name = "timezonefinder", specifier = ">=8.2.1" },
+    { name = "timezonefinder", marker = "extra == 'dev'", specifier = ">=8.2.1" },
+    { name = "timezonefinder", marker = "extra == 'location-tools'", specifier = ">=8.2.1" },
+    { name = "timezonefinder", marker = "extra == 'weather'", specifier = ">=8.2.1" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["cec-fit", "fast", "plots", "optimization", "weather", "validation", "location-tools", "dev", "docs"]
 
 [[package]]
 name = "cattrs"
@@ -773,15 +809,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Keep the default runtime dependency set focused on the core simulation stack: numpy, pandas, scipy, pvlib, and rainflow.
- Move heavier workflow dependencies into optional extras for CEC fitting, fast kernels, plotting, pymoo optimization, weather API access, validation formats, and location tooling.
- Update installation/API docs and changelog for the 0.2.4 packaging change.

## Verification
- uv lock
- uv run pytest -q
- uv run ruff check breos tests
- uv run ruff format --check breos tests
- uv run --no-dev python -c 'import breos; app = breos.App({"location":"porto","n_modules":2,"annual_consumption_kwh":1000,"battery_kwh":0}); app.simulate(); result = app.result(); assert result["pv_production_kwh"] > 0; print("ok")'
- uv build