### PR TITLE
Release 0.3.0 to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dev/
 !breos/data/rlp/*.csv
 .codex
 .claude/
+.DS_Store
 
 # Sphinx
 docs/_build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,84 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.3.0] - 2026-06-10
+
+### Fixed
+- **TMY timezone misalignment (results-changing):** `fetch_tmy_weather_data`
+  relabeled PVGIS's UTC-ordered rows with local-time labels, shifting
+  irradiance against the computed solar position by the location's UTC offset
+  (~1 h for Berlin, ~10 h for Melbourne; UTC+0 locations were unaffected).
+  Rows are now rolled to start at local midnight while each timestamp keeps
+  its correct UTC instant.
+- **Battery phantom export (results-changing):** when temperature derating or
+  daily SOH decline shrank `Emax` below the stored energy, the negative
+  charge room silently drained the battery into `Sell_To_Grid`. Stored energy
+  is now clamped into the derated window, mirroring the Numba kernel.
+- Load profiles are pinned to the location's wall clock instead of the UTC
+  clock, so H0 morning/evening peaks land at the correct local hours across
+  DST (previously ~1 h off in Iberia during summer).
+- `optimize_tilt`/`optimize_tilt_brent` reported "kWh" without accounting for
+  the timestep (4x off at 15-minute resolution; ranking was unaffected).
+- `BatteryConfig.initial_resistance_growth` was never read by
+  `simulate_energy_balance`; it now seeds the resistance state when the
+  continuation argument is not supplied.
+- `get_module_info` printed the efficiency fraction as a percent and crashed
+  on modules without efficiency metadata.
+- Removed three dead, shadowed plotting functions and an undefined
+  `MONTH_LABELS` reference that crashed the TMY-vs-historical monthly plot.
+
+### Added
+- Inverter AC clipping in the `App` energy pipeline: PV output, export, and
+  battery discharge now saturate at the AC rating implied by
+  `inverter_loading_ratio` — the same rating used for inverter CAPEX. DC
+  surplus above the rating still charges a DC-coupled battery
+  (`BatteryConfig.inverter_ac_capacity_w`, `None` = legacy uncapped model).
+- Configurable PVWatts system losses: `breos.solar.DEFAULT_PVWATTS_LOSSES`
+  (~14.1% combined) with a `loss_overrides` hook on the production functions
+  and a `pv_loss_overrides` App config key.
+- Battery operating parameters as App config keys: `battery_min_soc`,
+  `battery_max_soc`, `battery_eol_percentage`, and `battery_rte` (previously
+  hardcoded to 0.10/0.90/0.70/sqrt(0.95)).
+- `enable_resistance_fade` now feeds the resistance-derated round-trip
+  efficiency back into the energy loop (previously tracking-only).
+- Parity tests for the optional Numba kernels: the duplicated LFP derate
+  constants against `battery.lfp_capacity_factor`, and the energy-balance
+  kernel against the reference path under shared-model conditions.
 
 ### Changed
+- Cost defaults are single-sourced from the `CostParams` dataclass:
+  `cost_params_from_config` and the App preset fallbacks no longer carry
+  their own diverging literals (packaged presets are unaffected).
+- Config validation rejects out-of-range values at load time: negative
+  `battery_kwh`, top-level `tilt`/`azimuth`, `inverter_efficiency`,
+  `inverter_loading_ratio`, `projection_years`, `pv_degradation_rate`, and
+  the new battery keys.
+- PV-only App runs construct an explicit inverter model, so a configured
+  `inverter_efficiency` now applies without a battery (previously ignored).
+- Library progress messages (weather file discovery, saved files, CSV
+  conversions) go through `logging` under `breos.*` logger names instead of
+  unconditional `print()`. Functions with a `verbose` flag still print.
 - Slimmed the default runtime dependency set to the BREOS core simulation
   stack and moved heavier workflow packages behind extras: `plots`,
   `optimization`, `weather`, `fast`, `cec-fit`, `validation`, and
   `location-tools`.
 - The `dev` extra now installs optional feature dependencies so contributor
   test runs continue to cover optional paths.
+
+### Documentation
+- README documents the fixed PVWatts loss components, the inverter clipping
+  convention, the `weather/` working-directory override, the Open-Meteo
+  `.cache.sqlite` file, logging configuration, and the new config keys.
+- README describes the Numba kernels honestly as approximate standalone
+  screening engines that `breos.App` does not use; the module docstring
+  carries the same warning.
+- Clarified that the `bdew_h0` alias maps to the bundled demandlib
+  BDEW-H0-shaped profile `"1"`, distinct from the external BDEW H0 2025
+  dataset (profile `"7"`).
+- Replaced stream-of-consciousness working notes in `economics`,
+  `optimization`, `acc_sizer`, and `plotting` with factual comments, and
+  fixed mislabeled docstrings (`total_pv` is post-inverter AC; the Suntech
+  NOMT catalog entry documents its NMOT-condition rating).
 
 ## [0.2.3] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Changed
+- Slimmed the default runtime dependency set to the BREOS core simulation
+  stack and moved heavier workflow packages behind extras: `plots`,
+  `optimization`, `weather`, `fast`, `cec-fit`, `validation`, and
+  `location-tools`.
+- The `dev` extra now installs optional feature dependencies so contributor
+  test runs continue to cover optional paths.
+
 ## [0.2.3] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ A Python library for PV and battery energy-system simulation and optimization, d
 pip install "breos @ git+https://github.com/Str4vinci/breos.git@v0.2.3"
 ```
 
+Optional feature groups keep the default install focused on core PV +
+battery simulation:
+
+```bash
+pip install "breos[plots]"          # publication plots
+pip install "breos[optimization]"   # pymoo multi-objective sizing
+pip install "breos[weather]"        # Open-Meteo historical weather fetching
+pip install "breos[fast]"           # Numba kernels
+pip install "breos[validation]"     # Excel / Arrow validation workflows
+```
+
 PyPI publishing is planned for a future release. Until then, install the latest
 stable tag from GitHub, or install from source:
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ These modules may be released in the future or are available for academic collab
 
 BREOS uses [Open-Meteo](https://open-meteo.com/) for historical weather data. Open-Meteo is free for non-commercial use. For commercial applications, please review their [pricing and terms](https://open-meteo.com/en/pricing).
 
+Two working-directory conventions to be aware of:
+
+- A `weather/` directory in the current working directory is scanned before
+  any PVGIS fetch — a file matching the location preset name is used silently
+  instead of fetching. Remove or rename it to force a fresh fetch.
+- Historical Open-Meteo fetches cache responses in a `.cache.sqlite` file in
+  the current working directory (30-day expiry).
+
 Library modules report progress (file discovery, saved files, conversions)
 through the standard `logging` module under the `breos.*` logger names —
 enable them with `logging.basicConfig(level=logging.INFO)` or silence them

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ All keys except `location`, `annual_consumption_kwh`, and either `n_modules` or 
 | `emissions_country` | `None` | Country code for CO2 calculations (`"PT"`, `"DE"`, `"ES"`, ...) |
 | `pv_degradation_rate` | `0.005` | Annual PV degradation (0.5%) |
 | `calendar_model` | `"naumann_lam_field_calibrated"` | Battery calendar aging model |
+| `battery_min_soc` | `0.10` | Battery SOC floor (fraction of usable capacity) |
+| `battery_max_soc` | `0.90` | Battery SOC ceiling |
+| `battery_eol_percentage` | `0.70` | SOH fraction that triggers battery replacement |
+| `battery_rte` | `None` | Battery round-trip efficiency, split evenly across charge/discharge (`None` = 0.95) |
 | `dc_coupled` | `True` | DC-coupled / hybrid inverter |
 | `inverter_efficiency` | `0.96` | Inverter efficiency |
 | `inverter_loading_ratio` | `1.25` | DC/AC oversizing ratio; also sets the inverter AC rating that clips production |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Python library for PV and battery energy-system simulation and optimization, d
 
 - **Weather data**: Fetch TMY data from PVGIS/NSRDB and historical data from Open-Meteo. Support for hourly and 15-minute resolutions with Makima interpolation.
 - **PV production**: DC and AC power calculations using pvlib, with built-in module database and inverter presets.
-- **Battery simulation**: Energy balance with Numba-accelerated kernels. Calendar and cycle aging models (Naumann 2020, Lam 2025) with field-calibrated LFP parameters.
+- **Battery simulation**: Energy balance with calendar and cycle aging models (Naumann 2020, Lam 2025) and field-calibrated LFP parameters. Optional approximate Numba kernels for fast standalone screening studies.
 - **Economics**: NPV, LCOE, breakeven analysis, and cost projections with configurable tariffs and inflation.
 - **Optimization**: Multi-objective (grid independence, NPV, ZEB ratio) system sizing using pymoo (NSGA-II). Tilt/azimuth optimization via grid search or Brent's method.
 - **Emissions**: CO2 savings calculations and projections.
@@ -30,7 +30,7 @@ battery simulation:
 pip install "breos[plots]"          # publication plots
 pip install "breos[optimization]"   # pymoo multi-objective sizing
 pip install "breos[weather]"        # Open-Meteo historical weather fetching
-pip install "breos[fast]"           # Numba kernels
+pip install "breos[fast]"           # Approximate Numba screening kernels (not used by App)
 pip install "breos[validation]"     # Excel / Arrow validation workflows
 ```
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,21 @@ All keys except `location`, `annual_consumption_kwh`, and either `n_modules` or 
 | `calendar_model` | `"naumann_lam_field_calibrated"` | Battery calendar aging model |
 | `dc_coupled` | `True` | DC-coupled / hybrid inverter |
 | `inverter_efficiency` | `0.96` | Inverter efficiency |
-| `inverter_loading_ratio` | `1.25` | DC/AC oversizing ratio |
+| `inverter_loading_ratio` | `1.25` | DC/AC oversizing ratio; also sets the inverter AC rating that clips production |
+| `pv_loss_overrides` | `None` | Per-component overrides (percent) for the fixed PVWatts system losses, e.g. `{"shading": 0.0}` |
+
+### Modeling conventions
+
+- **System losses**: every DC production calculation applies pvlib's PVWatts
+  losses with BREOS defaults of soiling 2%, shading 3%, mismatch 2%, wiring 2%,
+  connections 0.5%, LID 1.5%, nameplate 1%, and availability 3% — about 14.1%
+  combined (`breos.solar.DEFAULT_PVWATTS_LOSSES`). Age-based degradation is
+  added separately per simulation year. Override individual components with
+  `pv_loss_overrides` (App) or `loss_overrides` (solar functions).
+- **Inverter**: the energy balance applies a flat `inverter_efficiency` and
+  clips AC output (PV and battery discharge combined) at the inverter rating
+  implied by `inverter_loading_ratio` — the same rating used for inverter
+  CAPEX. DC surplus above the rating can still charge a DC-coupled battery.
 
 ## Result
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ These modules may be released in the future or are available for academic collab
 
 BREOS uses [Open-Meteo](https://open-meteo.com/) for historical weather data. Open-Meteo is free for non-commercial use. For commercial applications, please review their [pricing and terms](https://open-meteo.com/en/pricing).
 
+Library modules report progress (file discovery, saved files, conversions)
+through the standard `logging` module under the `breos.*` logger names —
+enable them with `logging.basicConfig(level=logging.INFO)` or silence them
+per module. Functions with a `verbose` flag still print to stdout when asked.
+
 ## Load Profile Data Note
 
 The public package bundles only demandlib-derived H0 example profiles. E-REDES, REE, and direct BDEW CSVs are supported as user-provided files through `rlp_directory`, but are not redistributed in this repository because their public source terms do not clearly grant package redistribution rights. See [ATTRIBUTIONS.md](ATTRIBUTIONS.md) and [docs/legal/load-profile-data.md](docs/legal/load-profile-data.md).

--- a/breos/acc.py
+++ b/breos/acc.py
@@ -12,12 +12,15 @@ Supported Sharing Coefficients:
 Includes optimization capabilities to find ideal coefficients.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from scipy.optimize import minimize
+
+logger = logging.getLogger(__name__)
 
 
 def calculate_variable_coefficients(load_matrix: np.ndarray) -> np.ndarray:
@@ -291,4 +294,4 @@ def generate_acc_report(
             gain = r["Self_Sufficiency_%"] - baseline_ss
             f.write(f"  {r['Strategy']:>30}: {gain:+.2f}%\n")
 
-    print(f"Detailed report saved to: {report_path}")
+    logger.info("Detailed report saved to: %s", report_path)

--- a/breos/acc_sizer.py
+++ b/breos/acc_sizer.py
@@ -52,13 +52,10 @@ def run_acc_sizer_logic(config: Dict[str, Any], verbose: bool = True) -> pd.Data
 
     # 2. Pre-Calculate Unit PV Production (1 Module PER ARRAY) ----------------
     # We will assume we scale all arrays proportionally.
-    # Eg. if Array1 has 1 mod, Array2 has 1 mod.
-    # If user wants different ratios, they should specificy distinct arrays.
-    # For sizing, we'll define "System Size" as Total Modules, distributed evenly or as per config ratios?
-    # Simple approach: Keep the RATIO of modules in 'pv_arrays' constant, and scale the multiplier.
-
-    # Let's calculate the DC output of the "Base Config" defined in JSON
-    # And then sweep multipliers [0.1, 0.2 ... 5.0]
+    # "System size" is the total module count: the per-array module ratio
+    # from the base config is kept constant and scaled by a multiplier, so
+    # callers wanting different ratios define distinct arrays. The base DC
+    # curve is computed once and reused across the multiplier sweep.
 
     if verbose:
         print("Calculating Base PV Production...")
@@ -128,14 +125,10 @@ def run_acc_sizer_logic(config: Dict[str, Any], verbose: bool = True) -> pd.Data
         total_import = metrics["total_import"] / 1000.0
         total_export = metrics["total_export"] / 1000.0
 
-        # Financials
-        # CAPEX: rough estimate
-        # Assuming simple cost model: Fixed + Per_Module
-        # We can use breos.economics if available or simple:
-        # Cost = N_Modules * Cost_Per_Mod + Inverter + Balance
-        # Let's use simple linear for sizer:
+        # Financials: the sizer uses a deliberately simple linear CAPEX
+        # model (EUR per kWp, assuming 550 W modules) rather than the full
+        # breos.economics breakdown — it only needs relative ranking.
         cost_per_kwp = costs_cfg.get("cost_per_kwp", 800)  # EUR
-        # Assume 550W modules
         kwp = n_modules_total * 0.550
         capex = kwp * cost_per_kwp
 

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from breos.economics import BATTERY_REPLACEMENT_COST_PER_KWH, CostParams, calculate_costs
+from breos.economics import CostParams, calculate_costs
 from breos.emissions import EmissionsParams
 from breos.pv_modules import MODULES, PVModuleParams, get_module
 from breos.resources import load_config_json
@@ -200,8 +200,14 @@ def resolve_tracking(cfg: dict[str, Any], lat: float) -> tuple[str, float]:
 
 
 def resolve_costs(cfg: dict[str, Any]) -> CostParams:
-    """Build CostParams from packaged presets, overrides, and financial defaults."""
+    """Build CostParams from packaged presets, overrides, and financial defaults.
+
+    Preset keys override the :class:`CostParams` dataclass defaults; a key
+    missing from a preset falls back to the same default used when no
+    preset is configured, so the two paths cannot diverge.
+    """
     params: dict[str, Any] = {}
+    defaults = CostParams()
 
     if cfg.get("cost_preset"):
         costs_db = load_json("costs.json")
@@ -211,19 +217,27 @@ def resolve_costs(cfg: dict[str, Any]) -> CostParams:
             raise ValueError(f"Unknown cost preset '{preset_key}'. Available: {available}")
         preset = costs_db[preset_key]
 
-        params["electricity_cost"] = preset.get("electricity_cost", 0.27)
-        params["electricity_sold_cost"] = preset.get("electricity_sold_cost", 0.06)
-        params["daily_power_cost"] = preset.get("daily_power_cost", 0.30)
-        params["module_cost_per_w"] = preset.get("module_cost_per_w", 0.125)
-        params["battery_cost_per_kwh"] = preset.get("storage_cost_per_kwh", BATTERY_REPLACEMENT_COST_PER_KWH)
-        params["inverter_cost_per_kw"] = preset.get("inverter_cost_per_kw_hybrid", 102.58)
-        params["inverter_cost_per_kw_nobatt"] = preset.get("inverter_cost_per_kw_simple", 48.37)
-        params["installation_cost_per_module"] = preset.get("installation_cost_per_module", 350.0)
-        params["battery_installation_cost"] = preset.get("installation_cost_battery", 350.0)
-        params["maintenance_cost_per_panel"] = preset.get("maintenance_cost_per_panel", 0.0)
-        params["maintenance_cost_fixed"] = preset.get("maintenance_cost", 50.0)
-        params["other_cost_per_module"] = preset.get("other_cost_per_module", 0.0)
-        params["other_cost_fixed"] = preset.get("other_costs", 50.0)
+        params["electricity_cost"] = preset.get("electricity_cost", defaults.electricity_cost)
+        params["electricity_sold_cost"] = preset.get("electricity_sold_cost", defaults.electricity_sold_cost)
+        params["daily_power_cost"] = preset.get("daily_power_cost", defaults.daily_power_cost)
+        params["module_cost_per_w"] = preset.get("module_cost_per_w", defaults.module_cost_per_w)
+        params["battery_cost_per_kwh"] = preset.get("storage_cost_per_kwh", defaults.battery_cost_per_kwh)
+        params["inverter_cost_per_kw"] = preset.get("inverter_cost_per_kw_hybrid", defaults.inverter_cost_per_kw)
+        params["inverter_cost_per_kw_nobatt"] = preset.get(
+            "inverter_cost_per_kw_simple", defaults.inverter_cost_per_kw_nobatt
+        )
+        params["installation_cost_per_module"] = preset.get(
+            "installation_cost_per_module", defaults.installation_cost_per_module
+        )
+        params["battery_installation_cost"] = preset.get(
+            "installation_cost_battery", defaults.battery_installation_cost
+        )
+        params["maintenance_cost_per_panel"] = preset.get(
+            "maintenance_cost_per_panel", defaults.maintenance_cost_per_panel
+        )
+        params["maintenance_cost_fixed"] = preset.get("maintenance_cost", defaults.maintenance_cost_fixed)
+        params["other_cost_per_module"] = preset.get("other_cost_per_module", defaults.other_cost_per_module)
+        params["other_cost_fixed"] = preset.get("other_costs", defaults.other_cost_fixed)
 
     params["dc_ac_ratio"] = cfg["inverter_loading_ratio"]
     params.setdefault("inflation_rate", cfg["inflation_rate"])

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -116,6 +116,22 @@ def validate_config(cfg: dict[str, Any]) -> None:
                 raise ValueError(f"'pv_arrays[{i}].azimuth' must be between 0 and 360")
     if cfg["annual_consumption_kwh"] <= 0:
         raise ValueError("'annual_consumption_kwh' must be > 0")
+    if cfg["battery_kwh"] < 0:
+        raise ValueError("'battery_kwh' must be >= 0")
+    tilt = cfg.get("tilt")
+    if tilt is not None and not 0 <= tilt <= 90:
+        raise ValueError("'tilt' must be between 0 and 90")
+    azimuth = cfg.get("azimuth")
+    if azimuth is not None and not 0 <= azimuth <= 360:
+        raise ValueError("'azimuth' must be between 0 and 360")
+    if not 0 < cfg["inverter_efficiency"] <= 1:
+        raise ValueError("'inverter_efficiency' must be between 0 (exclusive) and 1 (inclusive)")
+    if cfg["inverter_loading_ratio"] <= 0:
+        raise ValueError("'inverter_loading_ratio' must be > 0")
+    if cfg["projection_years"] < 1:
+        raise ValueError("'projection_years' must be >= 1")
+    if not 0 <= cfg["pv_degradation_rate"] < 1:
+        raise ValueError("'pv_degradation_rate' must be between 0 (inclusive) and 1 (exclusive)")
     if cfg["resolution"] not in ("h", "15min"):
         raise ValueError("'resolution' must be 'h' or '15min'")
     overrides = cfg.get("pv_loss_overrides")

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -36,6 +36,10 @@ DEFAULTS: dict[str, Any] = {
     "emissions_country": None,
     "pv_degradation_rate": 0.005,
     "calendar_model": "naumann_lam_field_calibrated",
+    "battery_min_soc": 0.10,
+    "battery_max_soc": 0.90,
+    "battery_eol_percentage": 0.70,
+    "battery_rte": None,
     "dc_coupled": True,
     "inverter_efficiency": 0.96,
     "inverter_loading_ratio": 1.25,
@@ -121,6 +125,12 @@ def validate_config(cfg: dict[str, Any]) -> None:
         for name, value in overrides.items():
             if not isinstance(value, (int, float)) or not 0 <= value <= 100:
                 raise ValueError(f"'pv_loss_overrides[{name!r}]' must be a percentage between 0 and 100")
+    if not 0 <= cfg["battery_min_soc"] < cfg["battery_max_soc"] <= 1:
+        raise ValueError("'battery_min_soc' and 'battery_max_soc' must satisfy 0 <= min < max <= 1")
+    if not 0 < cfg["battery_eol_percentage"] < 1:
+        raise ValueError("'battery_eol_percentage' must be between 0 and 1 (exclusive)")
+    if cfg["battery_rte"] is not None and not 0 < cfg["battery_rte"] <= 1:
+        raise ValueError("'battery_rte' must be between 0 (exclusive) and 1 (inclusive)")
 
 
 def resolve_location(cfg: dict[str, Any]) -> tuple[float, float, str, str | None]:

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -39,6 +39,7 @@ DEFAULTS: dict[str, Any] = {
     "dc_coupled": True,
     "inverter_efficiency": 0.96,
     "inverter_loading_ratio": 1.25,
+    "pv_loss_overrides": None,
     "start_date": "2023-01-01",
 }
 
@@ -113,6 +114,13 @@ def validate_config(cfg: dict[str, Any]) -> None:
         raise ValueError("'annual_consumption_kwh' must be > 0")
     if cfg["resolution"] not in ("h", "15min"):
         raise ValueError("'resolution' must be 'h' or '15min'")
+    overrides = cfg.get("pv_loss_overrides")
+    if overrides is not None:
+        if not isinstance(overrides, dict):
+            raise TypeError("'pv_loss_overrides' must be a dict of loss component percentages")
+        for name, value in overrides.items():
+            if not isinstance(value, (int, float)) or not 0 <= value <= 100:
+                raise ValueError(f"'pv_loss_overrides[{name!r}]' must be a percentage between 0 and 100")
 
 
 def resolve_location(cfg: dict[str, Any]) -> tuple[float, float, str, str | None]:

--- a/breos/app_inputs.py
+++ b/breos/app_inputs.py
@@ -66,7 +66,13 @@ def load_weather_for_simulation(
     deps: AppRuntimeDependencies,
     weather_dir: Path | None = None,
 ) -> pd.DataFrame:
-    """Load TMY weather, falling back to PVGIS fetch."""
+    """Load TMY weather, falling back to PVGIS fetch.
+
+    When ``weather_dir`` is not given, a ``weather/`` directory in the
+    current working directory is scanned first: a file matching the
+    location preset key takes precedence over the PVGIS fetch. Remove or
+    rename the directory (or its files) to force a fresh fetch.
+    """
     weather = None
     weather_path = weather_dir or Path.cwd() / "weather"
 

--- a/breos/app_inputs.py
+++ b/breos/app_inputs.py
@@ -97,6 +97,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
     """Build undegraded system-level DC production for one simulation year."""
     location = Location(resolved.lat, resolved.lon, tz=resolved.timezone)
     freq = cfg["resolution"]
+    loss_overrides = cfg["pv_loss_overrides"]
 
     if resolved.pv_arrays:
         return calculate_multi_array_production(
@@ -104,6 +105,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             location=location,
             arrays=resolved.pv_arrays,
             freq=freq,
+            loss_overrides=loss_overrides,
         )
 
     if resolved.tracking == "fixed":
@@ -115,6 +117,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             n_modules=1,
             pv_params=resolved.pv_params,
             freq=freq,
+            loss_overrides=loss_overrides,
         )
     else:
         dc_1mod = calculate_pv_production_dc_tracking(
@@ -131,6 +134,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             dual_axis_max_tilt=cfg["dual_axis_max_tilt"],
             pv_params=resolved.pv_params,
             freq=freq,
+            loss_overrides=loss_overrides,
         )
     return dc_1mod * cfg["n_modules"]
 

--- a/breos/app_inputs.py
+++ b/breos/app_inputs.py
@@ -135,8 +135,15 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
     return dc_1mod * cfg["n_modules"]
 
 
-def load_consumption_profile(cfg: dict[str, Any], deps: AppRuntimeDependencies) -> pd.Series:
-    """Load and scale the configured demand profile."""
+def load_consumption_profile(
+    cfg: dict[str, Any], deps: AppRuntimeDependencies, timezone: str | None = None
+) -> pd.Series:
+    """Load and scale the configured demand profile.
+
+    Profile rows describe household behavior at legal clock time, so the
+    location timezone pins them to local wall clock; the simulation aligns
+    load and PV by UTC instant.
+    """
     return deps.load_profile(
         profile_type=cfg["load_profile"],
         annual_consumption_kwh=cfg["annual_consumption_kwh"],
@@ -144,7 +151,7 @@ def load_consumption_profile(cfg: dict[str, Any], deps: AppRuntimeDependencies) 
         freq=cfg["resolution"],
         num_years=1,
         rlp_directory=cfg["rlp_directory"],
-        timezone="UTC",
+        timezone=timezone or "UTC",
     )
 
 
@@ -156,7 +163,7 @@ def prepare_simulation_inputs(
     start_year = int(cfg["start_date"][:4])
     weather = load_weather_for_simulation(resolved, freq, start_year, deps)
     dc_system_base = build_dc_system_base(cfg, resolved, weather)
-    load_data = load_consumption_profile(cfg, deps)
+    load_data = load_consumption_profile(cfg, deps, timezone=resolved.timezone)
     temperature_series = deps.build_battery_temperature_series(
         "weather",
         index=dc_system_base.index,

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -158,7 +158,7 @@ def simulate_energy_balance(
     Returns:
         Tuple of:
         - results_df: Detailed timestep results
-        - total_pv: Total PV DC production (Wh)
+        - total_pv: Total PV AC production after inverter efficiency (Wh)
         - summary_df: Summary statistics
         - replacement_cost: Total battery replacement cost
         - n_replacements: Number of battery replacements
@@ -233,6 +233,9 @@ def simulate_energy_balance(
     Battery_SOH = battery_config.initial_soh
     Battery_Energy_Wh = battery_config.nominal_energy_wh * battery_soh_decimal * battery_config.max_soc
 
+    # Degradation day-windows are positional (fixed steps_per_day), not
+    # calendar-based: DST days and trailing partial days shift/skip windows
+    # by design; the Numba kernels share the convention.
     soc_absolute_buffer = np.empty(steps_per_day, dtype=np.float64)
     soc_buf_idx = 0
     fec_cum = initial_fec

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -90,7 +90,9 @@ class BatteryConfig:
     enable_replacement: bool = True
     replacement_cost: Optional[float] = None  # Auto-computed from cost per kWh if not set
     calendar_model: str = "naumann_lam_field_calibrated"  # Current field-calibrated fit (canonical name)
-    # Resistance fade tracking
+    # Resistance fade (opt-in): grows internal resistance daily and derates
+    # the charge/discharge efficiencies in the energy loop so the effective
+    # round-trip efficiency declines as the battery ages.
     enable_resistance_fade: bool = False  # Enable Naumann resistance growth model
     initial_resistance_growth: float = 0.0  # Initial relative resistance growth (fraction, 0=new)
     # Thermal model
@@ -235,7 +237,20 @@ def simulate_energy_balance(
     soc_buf_idx = 0
     fec_cum = initial_fec
     cumulative_cal_seconds = initial_calendar_seconds
-    resistance_growth = initial_resistance_growth
+    # The function argument is the multi-year continuation seam (used by the
+    # App's year loop); when left at its default the battery's configured
+    # starting resistance applies.
+    resistance_growth = (
+        initial_resistance_growth if initial_resistance_growth > 0.0 else battery_config.initial_resistance_growth
+    )
+    # Charge/discharge efficiencies, derated by resistance growth when the
+    # fade model is enabled; updated after each daily degradation step.
+    eff_charge = battery_config.charge_efficiency
+    eff_discharge = battery_config.discharge_efficiency
+    if battery_config.enable_resistance_fade and resistance_growth > 0.0:
+        _rte_derate = math.sqrt(1.0 + resistance_growth)
+        eff_charge /= _rte_derate
+        eff_discharge /= _rte_derate
     n_replacements = 0
     total_replacement_cost = 0.0
     cumulative_cycle_deg = initial_cumulative_cycle_deg
@@ -322,8 +337,8 @@ def simulate_energy_balance(
 
                 # Charge battery with surplus DC (no inverter loss)
                 charge_room = max(0.0, Emax - Battery_Energy_Wh)
-                charge_in = min(surplus_dc, charge_room / battery_config.charge_efficiency)
-                Battery_Energy_Wh += charge_in * battery_config.charge_efficiency
+                charge_in = min(surplus_dc, charge_room / eff_charge)
+                Battery_Energy_Wh += charge_in * eff_charge
 
                 # Export remainder (DC -> AC) within the inverter headroom
                 # left after serving the load; the rest is curtailed
@@ -337,7 +352,7 @@ def simulate_energy_balance(
                 available = Battery_Energy_Wh - Emin
                 if available > 0:
                     # Battery discharge: DC -> AC
-                    eff_total = battery_config.discharge_efficiency * battery_config.inverter_efficiency
+                    eff_total = eff_discharge * battery_config.inverter_efficiency
                     # How much DC do we need to draw to provide 'deficit' AC?
                     # Battery discharge shares the inverter AC rating with PV.
                     dc_needed = deficit / eff_total if eff_total > 0 else deficit
@@ -366,8 +381,8 @@ def simulate_energy_balance(
                 T_ambient,
                 charge_power_w,
                 discharge_power_w,
-                battery_config.charge_efficiency,
-                battery_config.discharge_efficiency,
+                eff_charge,
+                eff_discharge,
                 battery_config.thermal_resistance_kw,
             )
         T_cell_day_sum += T_cell
@@ -472,9 +487,13 @@ def simulate_energy_balance(
                 cumulative_resistance_cycle += dR_cycle
                 cumulative_resistance_calendar += dR_calendar
 
-                effective_rte = (battery_config.charge_efficiency * battery_config.discharge_efficiency) / (
-                    1.0 + resistance_growth
-                )
+                # Feed the resistance penalty back into the energy loop,
+                # split evenly across charge and discharge so their product
+                # equals the effective round-trip efficiency.
+                _rte_derate = math.sqrt(1.0 + resistance_growth)
+                eff_charge = battery_config.charge_efficiency / _rte_derate
+                eff_discharge = battery_config.discharge_efficiency / _rte_derate
+                effective_rte = eff_charge * eff_discharge
 
             # Battery replacement check
             if battery_config.enable_replacement and battery_soh_decimal <= battery_config.eol_percentage:
@@ -483,6 +502,8 @@ def simulate_energy_balance(
                 fec_cum = 0.0
                 cumulative_cal_seconds = 0.0
                 resistance_growth = 0.0
+                eff_charge = battery_config.charge_efficiency
+                eff_discharge = battery_config.discharge_efficiency
                 Battery_Energy_Wh = battery_config.nominal_energy_wh * battery_config.max_soc
                 n_replacements += 1
                 total_replacement_cost += battery_config.replacement_cost

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -286,9 +286,13 @@ def simulate_energy_balance(
             Emax = usable_cap * battery_config.max_soc * f_cap
             Emin = usable_cap * battery_config.min_soc * f_cap
 
-            # Apply standby loss (scaled by timestep)
+            # Apply standby loss (scaled by timestep) and clamp stored energy
+            # into the temperature-derated window, mirroring the Numba kernel.
+            # Without the upper clamp, Emax shrinking below the stored energy
+            # (cold-temperature derate, daily SOH decline) made charge_room
+            # negative and silently drained the battery into Sell_To_Grid.
             standby_loss = battery_config.standby_loss_wh * hours_per_step
-            Battery_Energy_Wh = max(Emin, Battery_Energy_Wh - standby_loss)
+            Battery_Energy_Wh = min(Emax, max(Emin, Battery_Energy_Wh - standby_loss))
 
             # Convert PV DC to AC for comparison with load
             pv_ac = pv_dc_power * battery_config.inverter_efficiency
@@ -307,7 +311,7 @@ def simulate_energy_balance(
                 surplus_dc = pv_dc_power - dc_to_load
 
                 # Charge battery with surplus DC (no inverter loss)
-                charge_room = Emax - Battery_Energy_Wh
+                charge_room = max(0.0, Emax - Battery_Energy_Wh)
                 charge_in = min(surplus_dc, charge_room / battery_config.charge_efficiency)
                 Battery_Energy_Wh += charge_in * battery_config.charge_efficiency
 

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -307,7 +307,12 @@ def simulate_energy_balance(
         charge_in = discharge_out = 0.0
 
         if has_battery:
-            # Calculate usable capacity with temperature derating
+            # Calculate usable capacity with temperature derating. f_cap is
+            # computed from the ambient/indoor temperature at step start; the
+            # lumped thermal model warms T_cell later in the step, so aging
+            # sees the warmed cell while derating sees the environment. This
+            # is intentional: usable capacity is set by the pack's state
+            # before this step's charge/discharge self-heating.
             usable_cap = battery_config.nominal_energy_wh * battery_soh_decimal
             f_cap = _cap_factor_fn(T_cell)
             Emax = usable_cap * battery_config.max_soc * f_cap

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -98,6 +98,9 @@ class BatteryConfig:
     # DC-coupled system (hybrid inverter) settings
     dc_coupled: bool = True  # True = hybrid inverter (DC-coupled battery)
     inverter_efficiency: float = 0.96  # Inverter efficiency (for DC→AC conversion)
+    # Inverter AC rating (W) shared by PV and battery discharge; AC output is
+    # clipped to this each step. None disables clipping (legacy behavior).
+    inverter_ac_capacity_w: Optional[float] = None
     # Battery chemistry
     battery_type: str = "lfp"  # Battery chemistry type
 
@@ -267,6 +270,12 @@ def simulate_energy_balance(
     has_battery = battery_config.nominal_energy_wh > 1 and (battery_config.max_soc - battery_config.min_soc) > 0
     # Bind capacity factor function once
     _cap_factor_fn = lfp_capacity_factor
+    # Inverter AC cap per step (Wh); None keeps the legacy uncapped model
+    cap_wh = (
+        battery_config.inverter_ac_capacity_w * hours_per_step
+        if battery_config.inverter_ac_capacity_w is not None
+        else float("inf")
+    )
 
     for i in range(n_steps):
         step_time = rng[i]
@@ -294,8 +303,9 @@ def simulate_energy_balance(
             standby_loss = battery_config.standby_loss_wh * hours_per_step
             Battery_Energy_Wh = min(Emax, max(Emin, Battery_Energy_Wh - standby_loss))
 
-            # Convert PV DC to AC for comparison with load
-            pv_ac = pv_dc_power * battery_config.inverter_efficiency
+            # Convert PV DC to AC for comparison with load (clipped at the
+            # inverter AC rating; excess DC can still charge the battery)
+            pv_ac = min(pv_dc_power * battery_config.inverter_efficiency, cap_wh)
 
             # Energy flows:
             # Load is in AC terms
@@ -315,9 +325,10 @@ def simulate_energy_balance(
                 charge_in = min(surplus_dc, charge_room / battery_config.charge_efficiency)
                 Battery_Energy_Wh += charge_in * battery_config.charge_efficiency
 
-                # Export remainder (DC -> AC)
+                # Export remainder (DC -> AC) within the inverter headroom
+                # left after serving the load; the rest is curtailed
                 remaining_dc = surplus_dc - charge_in
-                Sell = remaining_dc * battery_config.inverter_efficiency
+                Sell = min(remaining_dc * battery_config.inverter_efficiency, cap_wh - load)
 
             else:  # Deficit: PV insufficient, need battery or grid
                 deficit = load - pv_ac  # AC deficit
@@ -328,8 +339,10 @@ def simulate_energy_balance(
                     # Battery discharge: DC -> AC
                     eff_total = battery_config.discharge_efficiency * battery_config.inverter_efficiency
                     # How much DC do we need to draw to provide 'deficit' AC?
+                    # Battery discharge shares the inverter AC rating with PV.
                     dc_needed = deficit / eff_total if eff_total > 0 else deficit
-                    draw = min(available, dc_needed)
+                    draw_cap = (cap_wh - pv_ac) / eff_total if eff_total > 0 else 0.0
+                    draw = min(available, dc_needed, draw_cap)
                     Battery_Energy_Wh -= draw
                     delivered_ac = draw * eff_total
                     discharge_out = draw
@@ -337,8 +350,8 @@ def simulate_energy_balance(
                 else:
                     Import = deficit
         else:
-            # No battery: simple DC to AC for load
-            pv_ac = pv_dc_power * battery_config.inverter_efficiency
+            # No battery: simple DC to AC for load (clipped at the AC rating)
+            pv_ac = min(pv_dc_power * battery_config.inverter_efficiency, cap_wh)
             if pv_ac >= load:
                 Sell = pv_ac - load
             else:

--- a/breos/economics.py
+++ b/breos/economics.py
@@ -64,41 +64,50 @@ def cost_params_from_config(
     costs_config: Optional[Dict[str, Any]] = None,
     financials_config: Optional[Dict[str, Any]] = None,
 ) -> CostParams:
-    """Build :class:`CostParams` from BREOS cost and financial config keys."""
+    """Build :class:`CostParams` from BREOS cost and financial config keys.
+
+    Missing keys fall back to the :class:`CostParams` dataclass defaults, so
+    the config and direct-construction paths cannot diverge.
+    """
     costs_config = costs_config or {}
     financials_config = financials_config or {}
+    defaults = CostParams()
 
     return CostParams(
         electricity_cost=costs_config.get(
             "electricity_cost",
-            financials_config.get("electricity_cost", 0.27),
+            financials_config.get("electricity_cost", defaults.electricity_cost),
         ),
         electricity_sold_cost=costs_config.get(
             "electricity_sold_cost",
-            financials_config.get("electricity_sold_cost", 0.06),
+            financials_config.get("electricity_sold_cost", defaults.electricity_sold_cost),
         ),
-        daily_power_cost=costs_config.get("daily_power_cost", 0.30),
-        module_cost_per_w=costs_config.get("module_cost_per_w", 0.125),
-        battery_cost_per_kwh=costs_config.get("storage_cost_per_kwh", BATTERY_REPLACEMENT_COST_PER_KWH),
-        dc_ac_ratio=costs_config.get("dc_ac_ratio", 1.25),
-        inverter_cost_per_kw=costs_config.get("inverter_cost_per_kw_hybrid", 102.58),
-        inverter_cost_per_kw_nobatt=costs_config.get("inverter_cost_per_kw_simple", 48.37),
-        installation_cost_per_module=costs_config.get("installation_cost_per_module", 350.0),
-        battery_installation_cost=costs_config.get("installation_cost_battery", 350.0),
-        other_cost_per_module=costs_config.get("other_cost_per_module", 0.0),
-        other_cost_fixed=costs_config.get("other_costs", 0.0),
-        maintenance_cost_per_panel=costs_config.get("maintenance_cost_per_panel", 0.0),
-        maintenance_cost_fixed=costs_config.get("maintenance_cost", 0.0),
-        operation_cost=costs_config.get("operation_cost", 0.0),
-        tes_cost_per_kwh_th=costs_config.get("tes_cost_per_kwh_th", 0.0),
-        heat_pump_cost_per_kw_th=costs_config.get("heat_pump_cost_per_kw_th", 0.0),
-        hp_maintenance_annual=costs_config.get("hp_maintenance_annual", 0.0),
-        gas_cost_per_kwh=costs_config.get("gas_cost_per_kwh", 0.0),
-        tes_installation_cost=costs_config.get("tes_installation_cost", 0.0),
-        inflation_rate=financials_config.get("inflation_rate", 0.02),
-        sell_price_inflation=financials_config.get("sell_price_inflation", 0.0),
-        discount_rate=financials_config.get("discount_rate", 0.0),
-        pv_degradation_rate=financials_config.get("pv_degradation_rate", 0.005),
+        daily_power_cost=costs_config.get("daily_power_cost", defaults.daily_power_cost),
+        module_cost_per_w=costs_config.get("module_cost_per_w", defaults.module_cost_per_w),
+        battery_cost_per_kwh=costs_config.get("storage_cost_per_kwh", defaults.battery_cost_per_kwh),
+        dc_ac_ratio=costs_config.get("dc_ac_ratio", defaults.dc_ac_ratio),
+        inverter_cost_per_kw=costs_config.get("inverter_cost_per_kw_hybrid", defaults.inverter_cost_per_kw),
+        inverter_cost_per_kw_nobatt=costs_config.get(
+            "inverter_cost_per_kw_simple", defaults.inverter_cost_per_kw_nobatt
+        ),
+        installation_cost_per_module=costs_config.get(
+            "installation_cost_per_module", defaults.installation_cost_per_module
+        ),
+        battery_installation_cost=costs_config.get("installation_cost_battery", defaults.battery_installation_cost),
+        other_cost_per_module=costs_config.get("other_cost_per_module", defaults.other_cost_per_module),
+        other_cost_fixed=costs_config.get("other_costs", defaults.other_cost_fixed),
+        maintenance_cost_per_panel=costs_config.get("maintenance_cost_per_panel", defaults.maintenance_cost_per_panel),
+        maintenance_cost_fixed=costs_config.get("maintenance_cost", defaults.maintenance_cost_fixed),
+        operation_cost=costs_config.get("operation_cost", defaults.operation_cost),
+        tes_cost_per_kwh_th=costs_config.get("tes_cost_per_kwh_th", defaults.tes_cost_per_kwh_th),
+        heat_pump_cost_per_kw_th=costs_config.get("heat_pump_cost_per_kw_th", defaults.heat_pump_cost_per_kw_th),
+        hp_maintenance_annual=costs_config.get("hp_maintenance_annual", defaults.hp_maintenance_annual),
+        gas_cost_per_kwh=costs_config.get("gas_cost_per_kwh", defaults.gas_cost_per_kwh),
+        tes_installation_cost=costs_config.get("tes_installation_cost", defaults.tes_installation_cost),
+        inflation_rate=financials_config.get("inflation_rate", defaults.inflation_rate),
+        sell_price_inflation=financials_config.get("sell_price_inflation", defaults.sell_price_inflation),
+        discount_rate=financials_config.get("discount_rate", defaults.discount_rate),
+        pv_degradation_rate=financials_config.get("pv_degradation_rate", defaults.pv_degradation_rate),
     )
 
 

--- a/breos/economics.py
+++ b/breos/economics.py
@@ -442,52 +442,24 @@ def cost_analysis_projection(
 
     proj["Cost_System_Cumulative"] = costs["total_initial_cost"] + proj["Cost_System_Annual"].cumsum()
 
-    # Battery replacement
-    # 1. From simulation results (dynamic)
-    # We use the yearly_replacement calculated from the FIRST year results as base?
-    # NO. The simulation results ONLY cover the simulated period.
-    # If this is a PROJECTION (single year -> 20 years), we don't have simulated results for future years.
-    # However, if this is a MULTIYEAR simulation, results_df has all years.
-
-    # Let's check if we have data for all years in the projection
-    # If results_df has data for year Y, we should use it.
-
-    # Actually, cost_analysis_projection logic currently takes the FIRST year and projects it.
-    # It assumes single year simulation.
-    # If it is multiyear, 'yearly' dataframe above will have multiple rows.
-
-    # Logic update:
-    # If 'yearly' has data for the specific projection year, use actuals.
-    # If not (projection derived from first year), we assume no replacement in first year implies no replacement?
-    # Or we follow the standard logic.
-
-    # For replacement cost specifically:
-    # If we are in multiyear simulation mode, `results_df` contains all events.
-    # yearly_replacement has the sum for each year.
-
-    # Add a column for replacement cost to `proj`
+    # Battery replacement, taken from simulated years where available.
+    # Simulation results only cover the simulated period: the App's
+    # multi-year loop provides per-year replacement events for every
+    # projection year, while a single-year run provides at most year 1 and
+    # leaves later projection years without replacement costs.
     proj["Cost_Replacement"] = 0.0
 
-    # Map available replacement data from simulation to the projection
-    # yearly_replacement index is Year (e.g. 2023, 2024...)
-    # proj['Year'] is relative year (1, 2, 3...)
-    # We need to align them.
-
-    # Get the start year from the data
+    # yearly_replacement is indexed by calendar year; proj['Year'] is the
+    # relative year (1, 2, ...), so align via the simulation start year.
     start_year = df["Year"].min()
 
     for relative_year in proj["Year"]:
         actual_year = start_year + relative_year - 1
         if actual_year in yearly_replacement.index:
-            # We have simulated data for this year
             cost = yearly_replacement.loc[actual_year, "Replacement_Cost"]
-            # Apply inflation if it wasn't already encompassed in the simulation?
-            # The simulation outputs nominal cost at time of replacement?
-            # Usually simulation just outputs the base cost value. We should apply inflation here.
+            # The simulation logs replacement at the base (year-1) cost
+            # input, so inflate to the replacement year here.
             inflation_factor = (1 + inflation_rate) ** (relative_year - 1)
-            # Actually, check if simulation output `Replacement_Cost` is real or nominal.
-            # In `battery.py`, we log `battery_config.replacement_cost`. This is likely the base cost input.
-            # So yes, we need to inflate it.
             proj.loc[proj["Year"] == relative_year, "Cost_Replacement"] += cost * inflation_factor
 
     # Add to annual system cost

--- a/breos/load_profiles.py
+++ b/breos/load_profiles.py
@@ -50,6 +50,10 @@ PROFILE_NAMES = {
     "8": "REE 2026 - 2.0TD (external file required)",
 }
 
+# Note: "bdew_h0" maps to the bundled demandlib profile "1", which
+# implements the BDEW H0 standard shape. Profile "7" is the externally
+# published BDEW H0 2025 file and must be supplied via rlp_directory —
+# request it explicitly as "7" if that exact dataset is needed.
 PROFILE_ALIASES = {
     "default": "1",
     "demandlib_h0": "1",

--- a/breos/load_profiles.py
+++ b/breos/load_profiles.py
@@ -93,7 +93,11 @@ def load_profile(
         num_years: Number of years to generate
         rlp_directory: Directory containing RLP files. When omitted, BREOS
             uses only redistributable packaged profiles.
-        timezone: Timezone for the index (default: 'UTC' to match TMY data)
+        timezone: Timezone for the index. Profile rows are wall-clock local
+            behavior (H0 morning/evening peaks), so pass the location's
+            timezone to pin them to local time; the simulation aligns load
+            and PV by UTC instant. The 'UTC' default keeps the legacy
+            UTC-clock convention for callers without a location.
 
     Returns:
         DataFrame with 'Electrical Consumption [W]' column and DatetimeIndex
@@ -149,12 +153,13 @@ def load_profile(
     with path_context as csv_file:
         df = _load_profile_csv(Path(csv_file), profile_type)
 
-    # Create datetime index for one year
+    # Create a naive wall-clock index for one year; rows describe household
+    # behavior at local clock time and are pinned to the timezone afterwards
     start_year = int(start_date[:4])
     hours_in_year = 8760  # Non-leap year
     steps_per_hour = 4 if native_freq == "15min" else 1
 
-    new_index = pd.date_range(start=start_date, periods=hours_in_year * steps_per_hour, freq=native_freq, tz=timezone)
+    new_index = pd.date_range(start=start_date, periods=hours_in_year * steps_per_hour, freq=native_freq)
 
     # Adjust if profile has different length
     if len(df) < len(new_index):
@@ -170,9 +175,12 @@ def load_profile(
     # Scale to target consumption
     scale_to_annual_consumption(df, annual_consumption_kwh)
 
-    # Extend to multiple years if needed
+    # Extend to multiple years if needed (on the naive wall-clock index, so
+    # each year is localized at its own DST transition dates below)
     if num_years > 1:
         df = _extend_to_years(df, start_year, num_years)
+
+    df = _localize_wall_clock_index(df, timezone, native_freq)
 
     # Resample if needed (hourly to 15-min)
     if freq in ("15min", "15T") and native_freq == "h":
@@ -181,6 +189,29 @@ def load_profile(
         df = df.resample("h").mean()
 
     return df
+
+
+def _localize_wall_clock_index(df: pd.DataFrame, timezone: Optional[str], freq: str) -> pd.DataFrame:
+    """Pin naive wall-clock profile rows to a timezone's legal time.
+
+    Household behavior follows the legal clock, so each row keeps its
+    wall-clock label. In a DST-observing timezone the spring-forward hour
+    does not exist (its rows are dropped) and the fall-back hour occurs
+    twice (the rows cover the standard-time occurrence; the DST instants
+    are forward-filled), keeping the result evenly spaced in absolute time.
+    """
+    localized = df.copy()
+    if timezone is None or timezone == "UTC":
+        localized.index = localized.index.tz_localize("UTC")
+        return localized
+
+    idx = localized.index.tz_localize(timezone, nonexistent="shift_forward", ambiguous=False)
+    localized.index = idx
+    localized = localized[~localized.index.duplicated(keep="last")]
+    full = pd.date_range(localized.index[0], localized.index[-1], freq=freq)
+    localized = localized.reindex(full).ffill()
+    localized.index.name = "DateTime"
+    return localized
 
 
 def _load_profile_csv(csv_file: Path, profile_type: str) -> pd.DataFrame:

--- a/breos/numba_kernels.py
+++ b/breos/numba_kernels.py
@@ -5,6 +5,16 @@ This module provides JIT-compiled versions of hot loops for:
 - Energy balance simulation
 - SOC tracking
 - Degradation updates
+
+WARNING: these kernels are APPROXIMATE standalone engines with no
+production callers — ``breos.App`` and ``simulate_energy_balance`` always
+use the reference Python path in ``battery.py``. The kernels differ from
+the reference model: no inverter conversion losses or AC clipping, a
+segment-based depth-of-cycle proxy instead of rainflow counting, and no
+replacement logic. Do not mix kernel outputs with reference-path results
+in published numbers. The LFP temperature derate
+(``_lfp_capacity_factor_numba``) is parity-tested against
+``battery.lfp_capacity_factor``.
 """
 
 from typing import Tuple

--- a/breos/optimization.py
+++ b/breos/optimization.py
@@ -555,11 +555,8 @@ try:
             self.results_dir = results_dir
 
             self.location = config["location"]
-            # Ideally passed as pvlib Location, but if dict, construct it?
-            # For now assume caller passes data and logic handles location construction if needed
-            # Actually calculate_pv_production needs Location object.
-            # We'll construct it in _evaluate or pass it in.
-            # Better to pass it in or construct once.
+            # config['location'] is a plain dict; the pvlib Location that
+            # calculate_pv_production_dc needs is constructed once here.
             from pvlib.location import Location
 
             self.loc_obj = Location(

--- a/breos/optimization.py
+++ b/breos/optimization.py
@@ -85,7 +85,7 @@ def optimize_tilt(
 
     for tilt in tilts:
         try:
-            ac_power = calculate_pv_production_dc(
+            dc_power = calculate_pv_production_dc(
                 weather_data=weather_data,
                 location=location,
                 tilt=tilt,
@@ -95,7 +95,7 @@ def optimize_tilt(
                 freq=freq,
                 verbose=False,
             )
-            total_production = ac_power.sum() / 1000  # kWh
+            total_production = dc_power.sum() * get_hours_per_step(freq) / 1000  # kWh (DC)
             results.append({"tilt": tilt, "production_kwh": total_production})
 
             if verbose:
@@ -160,7 +160,7 @@ def optimize_tilt_brent(
     def objective(tilt):
         iterations[0] += 1
         try:
-            ac_power = calculate_pv_production_dc(
+            dc_power = calculate_pv_production_dc(
                 weather_data=weather_data,
                 location=location,
                 tilt=tilt,
@@ -170,7 +170,8 @@ def optimize_tilt_brent(
                 freq=freq,
                 verbose=False,
             )
-            production = -ac_power.sum() / 1000  # Negative for minimization
+            # Negative kWh (DC) for minimization
+            production = -dc_power.sum() * get_hours_per_step(freq) / 1000
 
             if verbose:
                 print(f"  Iteration {iterations[0]}: tilt={tilt:.2f}°, production={-production:.1f} kWh")

--- a/breos/plotting.py
+++ b/breos/plotting.py
@@ -2162,9 +2162,8 @@ def plot_acc_sizing_sweep(results_df: pd.DataFrame, results_directory: str, scen
     ax2 = ax1.twinx()
     color2 = "tab:red"
     ax2.set_ylabel("Payback Period (Years)", color=color2, fontsize=12)
-    # Filter out infinite payback for plotting if necessary, but typically sizer limits range
-    # Clamp large values for valid display? Or log scale?
-    # Let's plot raw but perhaps limit Y to reasonable max if distinct outlier exists
+    # Payback is plotted raw; the sizer bounds the sweep range, so infinite
+    # or outlier payback values are not specially clamped here.
     y2 = results_df["Payback_Years"]
     ax2.plot(x, y2, color=color2, marker="s", linestyle="--", label="Payback")
     ax2.tick_params(axis="y", labelcolor=color2)

--- a/breos/plotting.py
+++ b/breos/plotting.py
@@ -14,6 +14,8 @@ from typing import List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
 # Plotting imports with backend handling
 try:
     import matplotlib
@@ -291,16 +293,13 @@ def degradation_plots(degradation_df: pd.DataFrame, results_directory: str) -> N
     if "Year" in degradation_df.columns and degradation_df["Year"].nunique() > 1:
         # Multi-year: use day index (sequential)
         x = np.arange(len(degradation_df))  # Day index (0, 1, 2, ...)
-        x_label = "Days"
         x_years = x / 365.0  # Convert to years for tick labels
         use_years_axis = True
     elif "Datetime" in degradation_df.columns:
         x = pd.to_datetime(degradation_df["Datetime"])
-        x_label = None  # Use default date formatting
         use_years_axis = False
     else:
         x = degradation_df.index
-        x_label = None
         use_years_axis = False
 
     # 1. SOH over time
@@ -722,7 +721,7 @@ def plot_cell_temperature(
     min_by_month = min_by_month.reindex(months, fill_value=0.0)
     max_by_month = max_by_month.reindex(months, fill_value=0.0)
 
-    month_names = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    month_names = MONTH_LABELS
 
     fig, ax = plt.subplots(figsize=(12, 5))
     ax.fill_between(months, min_by_month.values, max_by_month.values, alpha=0.25, color="red", label="Min–Max range")
@@ -1145,7 +1144,7 @@ def plot_monthly_balance(results_df: pd.DataFrame, results_directory: str) -> No
     monthly_avg = monthly_avg.reindex(np.arange(1, 13), fill_value=0.0)
 
     months = np.arange(1, 13)
-    month_names = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    month_names = MONTH_LABELS
 
     fig, ax = plt.subplots(figsize=(12, 6))
 
@@ -1245,7 +1244,7 @@ def plot_montecarlo_simulation(
 
         # Filter for rows that actually have the break-even flag set to True
         # This ensures we get a row where break_even_year is populated
-        successful_rows = df[df["break_even_achieved"] == True]
+        successful_rows = df[df["break_even_achieved"].fillna(False).astype(bool)]
 
         # Get unique runs from these rows
         success_df = successful_rows.drop_duplicates("run_number")
@@ -1295,7 +1294,6 @@ def plot_breakeven_distribution(
 
     # Stats box
     achieved = len(breakeven_steps)
-    not_achieved = total_runs - achieved
     mean_val = np.mean(breakeven_steps)
     median_val = np.median(breakeven_steps)
     std_val = np.std(breakeven_steps)
@@ -1585,218 +1583,6 @@ def plot_montecarlo_grid_independence_distribution(
     plt.close()
 
 
-def plot_tariff_comparison(
-    results_df: pd.DataFrame,
-    tou_periods: "TOUPeriods",
-    prices_list: List[Tuple[str, "TOUPrices"]],
-    results_directory: str,
-    scenario_name: str = "",
-) -> None:
-    """
-    Plot comparison of yearly net costs under different tariff schemes.
-
-    Args:
-        results_df: Simulation results
-        tou_periods: TOUPeriods object to determine peak/off-peak
-        prices_list: List of (name, TOUPrices object) tuples
-        results_directory: Output directory
-        scenario_name: Optional suffix
-    """
-    _check_matplotlib()
-
-    os.makedirs(results_directory, exist_ok=True)
-    suffix = f"_{scenario_name}" if scenario_name else ""
-
-    if "Datetime" not in results_df.columns and not isinstance(results_df.index, pd.DatetimeIndex):
-        print("Error: results_df needs Datetime index or column")
-        return
-
-    df = results_df.copy()
-    if "Datetime" in df.columns:
-        df["Datetime"] = pd.to_datetime(df["Datetime"])
-        df.set_index("Datetime", inplace=True)
-
-    # Calculate costs for each tariff
-    costs = []
-    names = []
-
-    # Needs flow columns
-    if "Import_From_Grid" not in df.columns or "Sell_To_Grid" not in df.columns:
-        print("Error: Import/Sell columns missing")
-        return
-
-    # Calculate hours per step (safe approximation from frequency if not 1h)
-    # Better: get step size from index
-    # Assuming constant step size
-    dt_hours = (df.index[1] - df.index[0]).total_seconds() / 3600.0 if len(df) > 1 else 1.0
-
-    # Pre-calculate period names for the index to speed up
-    # We can use the cycle from tou_periods
-    period_names = [tou_periods.get_period(t) for t in df.index]
-    df["TOU_Period"] = period_names
-
-    for name, price_obj in prices_list:
-        total_import_cost = 0.0
-        total_revenue = 0.0
-
-        # Vectorized calculation
-        if hasattr(price_obj, "simple_tariff") and name.lower() == "simple":
-            # Simple tariff: one price for import
-            import_cost = df["Import_From_Grid"].sum() * dt_hours * price_obj.simple_tariff
-        else:
-            # TOU calculation
-            # Map period names to prices in price_obj
-            # period_names are 'peak', 'mid_peak', ...
-            # We create a series of prices aligned with index
-
-            # Create a mapping dict
-            p_map = {
-                "peak": price_obj.peak,
-                "mid_peak": price_obj.mid_peak,
-                "off_peak": price_obj.off_peak,
-                "super_off_peak": price_obj.super_off_peak,
-            }
-
-            price_series = df["TOU_Period"].map(p_map)
-
-            # Calculate import cost
-            import_cost = (df["Import_From_Grid"] * dt_hours * price_series).sum()
-
-        # Export (Fixed sell price usually, or could be indexed too?)
-        # Assuming simple sell_price for now
-        revenue = df["Sell_To_Grid"].sum() * dt_hours * price_obj.sell_price
-
-        net_cost = (import_cost - revenue) / 1000.0  # Convert to k€? No, keep in €
-        costs.append(net_cost)
-        names.append(name)
-
-    # Plot
-    fig, ax = plt.subplots(figsize=(10, 6))
-
-    bars = ax.bar(names, costs, color="steelblue", alpha=0.8, edgecolor="black")
-
-    ax.set_ylabel("Yearly Net Electricity Cost (€)", fontsize=12)
-    # ax.set_title('Tariff Regime Comparison', fontsize=14)
-    ax.grid(True, alpha=0.3, axis="y")
-
-    # Add labels
-    for bar in bars:
-        height = bar.get_height()
-        ax.text(
-            bar.get_x() + bar.get_width() / 2.0,
-            height,
-            f"€{height:.2f}",
-            ha="center",
-            va="bottom",
-            fontsize=11,
-            fontweight="bold",
-        )
-
-    plt.tight_layout()
-    plt.savefig(f"{results_directory}/tariff_comparison{suffix}.png", dpi=300)
-    plt.close()
-
-
-def plot_optimization_results_3d(
-    df: pd.DataFrame,
-    results_dir: str,
-    x_col: str = "Grid_Independence_%",
-    y_col: str = "NPV_Eur",
-    z_col: str = "ZEB_Ratio",
-    filename: str = "pareto_front_3d.png",
-) -> None:
-    """
-    Create a 3D scatter plot of optimization results.
-
-    Args:
-        df: DataFrame containing the results
-        results_dir: Directory to save the plot
-        x_col: Column name for X axis (Grid Independence)
-        y_col: Column name for Y axis (NPV)
-        z_col: Column name for Z axis (ZEB Ratio)
-        filename: Output filename
-    """
-    _check_matplotlib()
-    from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
-
-    os.makedirs(results_dir, exist_ok=True)
-
-    # Check columns exist
-    missing = [col for col in [x_col, y_col, z_col] if col not in df.columns]
-    if missing:
-        print(f"Warning: Missing columns for 3D plot: {missing}")
-        return
-
-    try:
-        fig = plt.figure(figsize=(12, 10))
-        ax = fig.add_subplot(111, projection="3d")
-
-        # Scatte plot
-        # Color by Z axis (ZEB Ratio) for extra clarity
-        sc = ax.scatter(
-            df[x_col],
-            df[y_col],
-            df[z_col],
-            c=df[z_col],
-            cmap="viridis",
-            s=80,
-            alpha=0.8,
-            edgecolor="black",
-            linewidth=0.5,
-        )
-
-        ax.set_xlabel(x_col.replace("_", " "))
-        ax.set_ylabel(y_col.replace("_", " "))
-        ax.set_zlabel(z_col.replace("_", " "))
-
-        # Add colorbar
-        plt.colorbar(sc, ax=ax, label=z_col.replace("_", " "), shrink=0.6)
-
-        # Title
-        # ax.set_title('Multi-Objective Optimization Surface')
-
-        plt.tight_layout()
-        plt.savefig(os.path.join(results_dir, filename), dpi=300)
-        plt.close()
-        print(f"3D Plot saved to {os.path.join(results_dir, filename)}")
-
-    except Exception as e:
-        print(f"Error creating 3D plot: {e}")
-
-
-def plot_optimization_results_2d(
-    df: pd.DataFrame,
-    results_dir: str,
-    x_col: str = "Grid_Independence_%",
-    y_col: str = "NPV_Eur",
-    z_col: str = "ZEB_Ratio",
-    filename: str = "pareto_front.png",
-) -> None:
-    """
-    Create a 2D scatter plot of optimization results.
-    """
-    _check_matplotlib()
-
-    os.makedirs(results_dir, exist_ok=True)
-
-    try:
-        plt.figure(figsize=(10, 6))
-        sc = plt.scatter(df[x_col], df[y_col], c=df[z_col], cmap="viridis", s=100, alpha=0.8)
-        plt.colorbar(sc, label=z_col.replace("_", " "))
-        plt.xlabel(x_col.replace("_", " ").replace("%", "(%)"))
-        plt.ylabel("Net Present Value (€)")
-        # plt.title('Pareto Front: Financials vs Independence') # Removed per user request
-        plt.grid(True, alpha=0.3)
-
-        filepath = os.path.join(results_dir, filename)
-        plt.savefig(filepath)
-        plt.close()
-        print(f"2D Plot saved to {filepath}")
-
-    except Exception as e:
-        print(f"Error creating 2D plot: {e}")
-
-
 def plot_tariff_comparison_manual(
     regimes: List[str],
     vals_sys: List[float],
@@ -1895,7 +1681,6 @@ def plot_tariff_comparison(results_df: pd.DataFrame, results_directory: str, sce
         bars = ax.bar(tariffs, values, color=colors, alpha=0.9, edgecolor="black", linewidth=0.6)
 
         # Add value labels (rounded to cents)
-        min_val = values.min()
         for bar, val in zip(bars, values):
             height = bar.get_height()
             label_text = f"€{val:.2f}"
@@ -2189,9 +1974,6 @@ def plot_acc_sizing_sweep(results_df: pd.DataFrame, results_directory: str, scen
     lines1, labels1 = ax1.get_legend_handles_labels()
     lines2, labels2 = ax2.get_legend_handles_labels()
     ax1.legend(lines1 + lines2, labels1 + labels2, loc="center right")
-
-    title = f"ACC Sizing Sweep{': ' + scenario_name if scenario_name else ''}"
-    # ax1.set_title(title)
 
     plt.tight_layout()
     plt.savefig(f"{results_directory}/acc_sizing_sweep{suffix}.png", dpi=300)
@@ -2797,8 +2579,8 @@ def plot_loo_cv_summary(
     width = 0.35
 
     fig, ax = plt.subplots(figsize=(10, 6))
-    bars_train = ax.bar(x - width / 2, train_rmses, width, color="#2196F3", alpha=0.85, label="Train RMSE")
-    bars_held = ax.bar(x + width / 2, held_out_rmses, width, color="#F44336", alpha=0.85, label="Held-out RMSE")
+    ax.bar(x - width / 2, train_rmses, width, color="#2196F3", alpha=0.85, label="Train RMSE")
+    ax.bar(x + width / 2, held_out_rmses, width, color="#F44336", alpha=0.85, label="Held-out RMSE")
 
     ax.axhline(
         y=mean_cv, color="#F44336", linestyle="--", linewidth=1.5, alpha=0.7, label=f"Mean CV RMSE ({mean_cv:.1f} pp)"

--- a/breos/pv_modules.py
+++ b/breos/pv_modules.py
@@ -35,21 +35,24 @@ MODULES: Dict[str, PVModuleParams] = {
         Voc=49.88,  # V - Open circuit voltage
         Isc=14.01,  # A - Short circuit current
         celltype="monoSi",
-        Module_Efficiency=0.213,  # % - Module Efficiency
+        Module_Efficiency=0.213,  # fraction - Module Efficiency (21.3 %)
         T_Pmax_pct=-0.36,  # %/°C - Power temperature coefficient
         T_Voc_pct=-0.304,  # %/°C - Voltage temperature coefficient
         T_Isc_pct=0.05,  # %/°C - Current temperature coefficient
         N_Cells=6 * 24,  # 144 cells
         Name="Suntech_STP550S-C72/Vmh",
     ),
+    # NMOT-condition variant of the STP550S: same physical 550 W module, but
+    # rated at Nominal Module Operating Temperature (800 W/m2, 20 degC
+    # ambient), hence Mpp=415 under the 550-family key.
     "Suntech_STP550S_NOMT": PVModuleParams(
-        Mpp=415,  # W - Maximum Power Point
+        Mpp=415,  # W - Maximum Power Point at NMOT (550 W at STC)
         Vmp=38.9,  # V - Voltage at MPP
         Imp=10.67,  # A - Current at MPP
         Voc=46.9,  # V - Open circuit voltage
         Isc=11.22,  # A - Short circuit current
         celltype="monoSi",
-        Module_Efficiency=0.213,  # % - Module Efficiency
+        Module_Efficiency=0.213,  # fraction - Module Efficiency (21.3 %)
         T_Pmax_pct=-0.36,  # %/°C - Power temperature coefficient
         T_Voc_pct=-0.304,  # %/°C - Voltage temperature coefficient
         T_Isc_pct=0.05,  # %/°C - Current temperature coefficient
@@ -178,7 +181,7 @@ Cell Type:  {m.celltype}
 Cells:      {m.N_Cells}
 T_Pmax:     {m.T_Pmax_pct} %/°C
 Name:       {m.Name}
-Efficiency: {m.Module_Efficiency} %
+Efficiency: {f"{m.Module_Efficiency * 100:.1f} %" if m.Module_Efficiency is not None else "n/a"}
 """
 
 

--- a/breos/runners/app.py
+++ b/breos/runners/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -69,18 +70,26 @@ def run_app_simulation(
         dc_power = inputs.dc_system_base * pv_degradation_factor
 
         if has_battery:
+            batt_kwargs: dict[str, Any] = {}
+            if cfg["battery_rte"] is not None:
+                # Split the round-trip efficiency evenly across charge and
+                # discharge, matching the BatteryConfig default convention.
+                one_way = math.sqrt(cfg["battery_rte"])
+                batt_kwargs["charge_efficiency"] = one_way
+                batt_kwargs["discharge_efficiency"] = one_way
             batt_cfg = BatteryConfig(
                 nominal_energy_wh=battery_wh,
                 initial_soh=current_soh,
-                eol_percentage=0.70,
-                max_soc=0.90,
-                min_soc=0.10,
+                eol_percentage=cfg["battery_eol_percentage"],
+                max_soc=cfg["battery_max_soc"],
+                min_soc=cfg["battery_min_soc"],
                 dc_coupled=cfg["dc_coupled"],
                 inverter_efficiency=cfg["inverter_efficiency"],
                 inverter_ac_capacity_w=inverter_ac_capacity_w,
                 enable_replacement=True,
                 replacement_cost=replacement_cost,
                 calendar_model=cfg["calendar_model"],
+                **batt_kwargs,
             )
         else:
             # PV-only runs still flow through the same inverter model so the

--- a/breos/runners/app.py
+++ b/breos/runners/app.py
@@ -47,6 +47,12 @@ def run_app_simulation(
 
     replacement_cost = resolved.cost_params.battery_cost_per_kwh * battery_kwh
 
+    # Size the inverter AC rating the same way CAPEX does (economics
+    # calculate_costs), so the paid-for inverter also clips production.
+    pv_peak_w = cfg["n_modules"] * resolved.avg_module_power_w
+    loading_ratio = cfg["inverter_loading_ratio"]
+    inverter_ac_capacity_w = pv_peak_w / loading_ratio if loading_ratio and loading_ratio > 0 else None
+
     cumulative_fec = 0.0
     cumulative_cal_seconds = 0.0
     cumulative_resistance_growth = 0.0
@@ -71,12 +77,19 @@ def run_app_simulation(
                 min_soc=0.10,
                 dc_coupled=cfg["dc_coupled"],
                 inverter_efficiency=cfg["inverter_efficiency"],
+                inverter_ac_capacity_w=inverter_ac_capacity_w,
                 enable_replacement=True,
                 replacement_cost=replacement_cost,
                 calendar_model=cfg["calendar_model"],
             )
         else:
-            batt_cfg = None
+            # PV-only runs still flow through the same inverter model so the
+            # configured efficiency and AC clipping apply consistently.
+            batt_cfg = BatteryConfig(
+                nominal_energy_wh=0,
+                inverter_efficiency=cfg["inverter_efficiency"],
+                inverter_ac_capacity_w=inverter_ac_capacity_w,
+            )
 
         results_df, total_pv, _summary_df, year_rep_cost, year_n_rep, degradation_df = simulate_energy_balance(
             pv_dc=dc_power,

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -20,6 +20,21 @@ from breos.utils import get_hours_per_step
 # Module-level cache for CEC model parameters (depends only on module specs, not weather)
 _cec_param_cache: Dict[tuple, tuple] = {}
 
+# System loss components (percent) applied to every DC production calculation
+# via pvlib's pvwatts_losses. Combined multiplicatively they total ~14.1%
+# (age-based degradation is added separately per simulation year).
+DEFAULT_PVWATTS_LOSSES: Dict[str, float] = {
+    "soiling": 2.0,
+    "shading": 3.0,
+    "snow": 0.0,
+    "mismatch": 2.0,
+    "wiring": 2.0,
+    "connections": 0.5,
+    "lid": 1.5,
+    "nameplate_rating": 1.0,
+    "availability": 3.0,
+}
+
 
 @dataclass
 class PVModuleParams:
@@ -155,11 +170,22 @@ def _dc_from_poa(
     degradation_rate: float = 0.0,
     current_year: Optional[int] = None,
     start_year: Optional[int] = None,
+    loss_overrides: Optional[Dict[str, float]] = None,
 ) -> pd.Series:
     """Run CEC single-diode + pvwatts loss model and scale to array.
 
-    Shared between fixed-tilt and tracking DC paths.
+    Shared between fixed-tilt and tracking DC paths. System losses default
+    to DEFAULT_PVWATTS_LOSSES; ``loss_overrides`` replaces individual
+    components (percent).
     """
+    loss_components = dict(DEFAULT_PVWATTS_LOSSES)
+    if loss_overrides:
+        unknown = set(loss_overrides) - set(DEFAULT_PVWATTS_LOSSES)
+        if unknown:
+            valid = ", ".join(sorted(DEFAULT_PVWATTS_LOSSES))
+            raise ValueError(f"Unknown loss component(s) {sorted(unknown)}. Valid components: {valid}")
+        loss_components.update(loss_overrides)
+
     I_L_ref, I_o_ref, R_s, R_sh_ref, a_ref, Adjust = _get_cec_params(pv_params)
 
     with warnings.catch_warnings():
@@ -176,16 +202,8 @@ def _dc_from_poa(
         age_degradation_factor = 0.0
 
     total_losses_percent = pvlib.pvsystem.pvwatts_losses(
-        soiling=2,
-        shading=3,
-        snow=0,
-        mismatch=2,
-        wiring=2,
-        connections=0.5,
-        lid=1.5,
-        nameplate_rating=1,
         age=age_degradation_factor,
-        availability=3,
+        **loss_components,
     )
 
     p_mp = mpp["p_mp"] if isinstance(mpp, dict) else mpp.p_mp
@@ -205,6 +223,7 @@ def calculate_pv_production_dc(
     current_year: Optional[int] = None,
     start_year: Optional[int] = None,
     verbose: bool = False,
+    loss_overrides: Optional[Dict[str, float]] = None,
 ) -> pd.Series:
     """
     Calculate PV DC production from weather data (fixed-tilt array).
@@ -215,6 +234,12 @@ def calculate_pv_production_dc(
     For DC-coupled battery systems:
     - Use DC output directly for battery charging (apply only charge efficiency)
     - Use dc_to_ac() for power going to AC loads or grid
+
+    System losses: DEFAULT_PVWATTS_LOSSES (~14.1% combined: soiling 2,
+    shading 3, mismatch 2, wiring 2, connections 0.5, LID 1.5, nameplate 1,
+    availability 3) are always applied via pvlib's pvwatts_losses; inverter
+    conversion is NOT included here. Pass ``loss_overrides`` to change
+    individual components (percent), e.g. ``{"shading": 0.0}``.
 
     Args:
         weather_data: DataFrame with weather variables (must include ghi/dni/dhi or shortwave_radiation)
@@ -250,6 +275,7 @@ def calculate_pv_production_dc(
         degradation_rate=degradation_rate,
         current_year=current_year,
         start_year=start_year,
+        loss_overrides=loss_overrides,
     )
 
     if verbose:
@@ -277,6 +303,7 @@ def calculate_pv_production_dc_tracking(
     current_year: Optional[int] = None,
     start_year: Optional[int] = None,
     verbose: bool = False,
+    loss_overrides: Optional[Dict[str, float]] = None,
 ) -> pd.Series:
     """
     Calculate PV DC production for a tracking array (single- or dual-axis).
@@ -356,6 +383,7 @@ def calculate_pv_production_dc_tracking(
         degradation_rate=degradation_rate,
         current_year=current_year,
         start_year=start_year,
+        loss_overrides=loss_overrides,
     )
 
     if verbose:
@@ -630,6 +658,7 @@ def calculate_multi_array_production(
     current_year: Optional[int] = None,
     start_year: Optional[int] = None,
     verbose: bool = False,
+    loss_overrides: Optional[Dict[str, float]] = None,
 ) -> pd.Series:
     """
     Calculate combined DC production from multiple PV arrays.
@@ -690,6 +719,7 @@ def calculate_multi_array_production(
                 current_year=current_year,
                 start_year=start_year,
                 verbose=False,
+                loss_overrides=loss_overrides,
             )
         elif tracking in ("single_axis", "dual_axis"):
             if verbose:
@@ -720,6 +750,7 @@ def calculate_multi_array_production(
                 current_year=current_year,
                 start_year=start_year,
                 verbose=False,
+                loss_overrides=loss_overrides,
             )
         else:
             raise ValueError(

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -53,7 +53,7 @@ class PVModuleParams:
     N_Cells: int  # Number of cells (eg 6*24 or 144)
 
     Name: Optional[str] = None  # Metadata: specific module model name
-    Module_Efficiency: Optional[float] = None  # Metadata: module efficiency % (not used in calc)
+    Module_Efficiency: Optional[float] = None  # Metadata: module efficiency fraction, e.g. 0.213 (not used in calc)
     celltype: str = "monoSi"
 
     alpha_sc_abs: Optional[float] = None  # A/°C - if provided, overrides T_Isc_pct conversion

--- a/breos/weather.py
+++ b/breos/weather.py
@@ -7,6 +7,7 @@ This module handles:
 - Converting between hourly and 15-minute resolutions using Makima interpolation
 """
 
+import logging
 import os
 import re
 from datetime import timedelta
@@ -19,6 +20,8 @@ from pvlib.location import Location
 from scipy.interpolate import Akima1DInterpolator
 
 from breos.utils import safe_path_slug
+
+logger = logging.getLogger(__name__)
 
 # Optional imports for API calls
 try:
@@ -142,7 +145,7 @@ def load_weather(
     best = candidates[0]
     filepath = best["filepath"]
 
-    print(f"   Found local weather file: {filepath}")
+    logger.info("Found local weather file: %s", filepath)
 
     df = pd.read_csv(filepath, index_col=0, parse_dates=True)
 
@@ -167,7 +170,7 @@ def load_weather(
         if file_start < start_year or file_end > end_year:
             mask = (df.index.year >= start_year) & (df.index.year <= end_year)
             df = df.loc[mask]
-            print(f"   Subset to {start_year}-{end_year} ({len(df)} rows)")
+            logger.info("Subset to %s-%s (%d rows)", start_year, end_year, len(df))
 
     return df
 
@@ -256,7 +259,7 @@ def fetch_tmy_weather_data(
             filename = f"weather/tmy_data_{sample_year if sample_year else 'original'}_{freq}.csv"
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         tmy_data.to_csv(filename)
-        print(f"Saved TMY data to {filename}")
+        logger.info("Saved TMY data to %s", filename)
 
     return tmy_data, metadata
 
@@ -370,7 +373,7 @@ def fetch_weather_data(
         filename = os.path.join(output_dir, f"{loc_slug}_historical_{start_year}_{end_year}_openmeteo.csv")
         os.makedirs(output_dir, exist_ok=True)
         hourly_dataframe.to_csv(filename)
-        print(f"Saved weather data to {filename}")
+        logger.info("Saved weather data to %s", filename)
 
     return hourly_dataframe
 
@@ -609,14 +612,18 @@ def csv_15min_to_hourly(
 
         hourly_df.to_csv(output_file_name, index=False)
 
-        print(f"Successfully converted {input_file_name} to hourly data")
-        print(f"Output saved to: {output_file_name}")
-        print(f"Original shape: {df.shape} -> Hourly shape: {hourly_df.shape}")
+        logger.info(
+            "Converted %s to hourly data at %s (%s -> %s)",
+            input_file_name,
+            output_file_name,
+            df.shape,
+            hourly_df.shape,
+        )
 
         return hourly_df
 
     except Exception as e:
-        print(f"Error processing file: {e}")
+        logger.error("Error processing file: %s", e)
         return None
 
 
@@ -659,14 +666,18 @@ def csv_hourly_to_15min(
         df_15min = df_15min.reset_index().rename(columns={"index": datetime_column})
         df_15min.to_csv(output_file_name, index=False)
 
-        print(f"Successfully converted {input_file_name} to 15-min data (Makima)")
-        print(f"Output saved to: {output_file_name}")
-        print(f"Original shape: {df.shape} -> 15-min shape: {df_15min.shape}")
+        logger.info(
+            "Converted %s to 15-min data (Makima) at %s (%s -> %s)",
+            input_file_name,
+            output_file_name,
+            df.shape,
+            df_15min.shape,
+        )
 
         return df_15min
 
     except Exception as e:
-        print(f"Error processing file: {e}")
+        logger.error("Error processing file: %s", e)
         return None
 
 
@@ -723,7 +734,7 @@ def select_random_year_and_replace_datetime(csv_file_path: str, target_year: int
     # Validate against the data's own step size instead of assuming hourly data.
     expected_rows = _derive_steps_per_year(selected_year_data["date"])
     if len(selected_year_data) != expected_rows:
-        print(f"Warning: Year {selected_year} has {len(selected_year_data)} rows, expected {expected_rows}")
+        logger.warning("Year %s has %d rows, expected %d", selected_year, len(selected_year_data), expected_rows)
 
     # Replace year in datetime
     year_diff = target_year - selected_year
@@ -855,7 +866,7 @@ def fetch_tmy_nsrdb(
         filename = f"weather/{loc_slug}_tmy_{vintage}_nsrdb.csv"
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         df.to_csv(filename)
-        print(f"Saved NSRDB data to {filename}")
+        logger.info("Saved NSRDB data to %s", filename)
 
     return df, metadata
 

--- a/breos/weather.py
+++ b/breos/weather.py
@@ -296,6 +296,11 @@ def fetch_weather_data(
 
     Raises:
         ImportError: If openmeteo_requests is not installed
+
+    Note:
+        Responses are cached in a ``.cache.sqlite`` file created in the
+        current working directory (30-day expiry). Delete it to force
+        fresh API responses.
     """
     if not HAS_OPENMETEO:
         raise ImportError(

--- a/breos/weather.py
+++ b/breos/weather.py
@@ -188,26 +188,21 @@ def fetch_tmy_weather_data(
         longitude: Longitude of the location
         sample_year: Year to use for index (default: 2025). Set to None to keep original TMY index.
         freq: Frequency for output data ('h' for hourly, '15min' for 15-minute)
-        timezone: Timezone string. Auto-detected if None.
+        timezone: Timezone string used to determine the location's whole-hour
+            UTC offset (offset taken at Jan 1 of sample_year, i.e. standard
+            time for northern-hemisphere locations). Auto-detected if None.
         save_to_file: Whether to save the data to CSV
 
     Returns:
-        Tuple of (tmy_data DataFrame, metadata dict)
+        Tuple of (tmy_data DataFrame, metadata dict). When sample_year is set,
+        the index is fixed-offset local time starting at local midnight of
+        Jan 1; rows are rolled (not relabeled) so each timestamp remains the
+        correct UTC instant for its irradiance values.
 
     Raises:
         ValueError: If sample_year is a leap year (TMY has 8760 hours)
     """
-    tmy_data, metadata = pvlib.iotools.get_pvgis_tmy(
-        latitude,
-        longitude,
-        outputformat="json",
-        usehorizon=True,
-        map_variables=True,
-        url="https://re.jrc.ec.europa.eu/api/v5_3/",
-        timeout=120,
-    )
-
-    # Reindex to sample year if requested
+    roll_utc_offset = None
     if sample_year is not None:
         # Check for leap year
         if sample_year % 4 == 0 and (sample_year % 100 != 0 or sample_year % 400 == 0):
@@ -220,10 +215,24 @@ def fetch_tmy_weather_data(
             tf = TimezoneFinder()
             timezone = tf.timezone_at(lat=latitude, lng=longitude)
 
-        new_index = pd.date_range(
-            start=f"{sample_year}-01-01 00:00", end=f"{sample_year}-12-31 23:00", freq="h", tz=timezone
-        )
-        tmy_data.index = new_index
+        utc_offset = pd.Timestamp(f"{sample_year}-01-01", tz=timezone).utcoffset()
+        roll_utc_offset = round(utc_offset.total_seconds() / 3600)
+
+    # PVGIS returns UTC-ordered rows. roll_utc_offset/coerce_year make pvlib
+    # roll the data so the series starts at local midnight of sample_year
+    # while keeping each row's timestamp the correct UTC instant — never
+    # relabel the UTC-ordered rows with local-time labels.
+    tmy_data, metadata = pvlib.iotools.get_pvgis_tmy(
+        latitude,
+        longitude,
+        outputformat="json",
+        usehorizon=True,
+        map_variables=True,
+        url="https://re.jrc.ec.europa.eu/api/v5_3/",
+        timeout=120,
+        roll_utc_offset=roll_utc_offset,
+        coerce_year=sample_year,
+    )
 
     # Resample to 15-min if requested
     if freq in ("15min", "15T", "15m"):

--- a/docs/api/generated/breos.battery.BatteryConfig.rst
+++ b/docs/api/generated/breos.battery.BatteryConfig.rst
@@ -33,6 +33,7 @@
       ~BatteryConfig.eol_percentage
       ~BatteryConfig.initial_resistance_growth
       ~BatteryConfig.initial_soh
+      ~BatteryConfig.inverter_ac_capacity_w
       ~BatteryConfig.inverter_efficiency
       ~BatteryConfig.max_soc
       ~BatteryConfig.min_soc

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -5,6 +5,9 @@ method handles smooth one-dimensional problems (tilt); NSGA-II via
 [pymoo](https://pymoo.org/) handles multi-objective sizing (PV count vs
 battery vs cost vs grid independence).
 
+Install `breos[optimization]` to use pymoo-backed multi-objective classes.
+The one-dimensional helpers use the core scientific stack.
+
 ## Tilt
 
 ```{eval-rst}

--- a/docs/api/weather.md
+++ b/docs/api/weather.md
@@ -3,6 +3,9 @@
 Sources, loaders, and resampling utilities for solar irradiance and
 temperature time series.
 
+Local weather loading and PVGIS/NSRDB TMY helpers use the core install.
+Open-Meteo historical fetching requires `breos[weather]`.
+
 ## Loading from local files
 
 ```{eval-rst}

--- a/docs/architecture/third-party-wrapping.md
+++ b/docs/architecture/third-party-wrapping.md
@@ -9,7 +9,7 @@
 BREOS imports several third-party libraries directly throughout the package
 (`pvlib`, `pandas`, `numpy`, `scipy`, `numba`, `rainflow`, `geopy`,
 `openmeteo-requests`, `timezonefinder`, `nrel-pysam`, `pymoo`,
-`requests-cache`, `joblib`, `matplotlib`, `openpyxl`).
+`requests-cache`, `matplotlib`, `openpyxl`).
 
 Direct usage means those libraries co-own the BREOS public API. When they
 change — and `pvlib` in particular has historically broken APIs across
@@ -112,7 +112,7 @@ signatures.
 - `nrel-pysam` → `breos.adapters.sam_model` (if/when used beyond optional
   paths).
 - `pymoo` → `breos.adapters.multi_objective` (used in `optimization.py`).
-- `openpyxl` → encapsulated inside `breos.io` already; keep as-is.
+- `openpyxl`, `pyarrow` → keep in validation/export-specific paths.
 
 ### Out of scope: pandas and numpy
 
@@ -129,8 +129,9 @@ If we later want stronger schema guarantees, introduce typed wrappers at
 specific boundaries (e.g. a `WeatherFrame` dataclass that validates
 columns) rather than a global abstraction.
 
-`matplotlib` is also kept direct — `plotting.py` is intentionally an
-output module, not a load-bearing core dependency.
+`matplotlib` is also kept direct inside `plotting.py`, but it is packaged as
+an optional `plots` extra because plotting is not a load-bearing core
+dependency.
 
 ## Migration mechanics
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,10 +19,25 @@ cd breos
 pip install -e .
 ```
 
+## Optional features
+
+The base install includes the core simulation stack. Install extras for
+workflows that need heavier optional packages:
+
+```bash
+pip install -e ".[plots]"          # matplotlib plotting helpers
+pip install -e ".[optimization]"   # pymoo multi-objective sizing
+pip install -e ".[weather]"        # Open-Meteo historical weather fetching
+pip install -e ".[fast]"           # Numba kernels
+pip install -e ".[validation]"     # Excel / Arrow validation workflows
+pip install -e ".[location-tools]" # geocoding and timezone lookup helpers
+```
+
 ## Development install
 
 If you plan to contribute, install with the dev extras for testing and
-linting:
+linting. The dev extra also installs BREOS's optional feature dependencies so
+the full local test suite can exercise optional paths:
 
 ```bash
 pip install -e ".[dev]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "breos/__init__.py" = ["F401", "F811"]   # re-exports and shadowed imports
 "tests/*" = ["F811"]                      # pytest fixtures
-"breos/plotting.py" = ["F841", "F811", "F821", "E712"]  # large viz module with WIP code
 "tools/*" = ["E402"]                      # CLI scripts insert PROJECT_ROOT before imports
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "breos"
-version = "0.2.3"
+version = "0.3.0"
 description = "Python library for PV and battery energy-system simulation and optimization"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,20 +19,11 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "geopy>=2.4.1",
-    "joblib>=1.5.3",
-    "matplotlib>=3.10.8",
-    "numba>=0.63.1",
-    "openpyxl>=3.1.0",
-    "openmeteo-requests>=1.7.4",
+    "numpy>=2.0",
     "pandas>=2.3.3",
-    "pyarrow>=19.0.0",
-    "nrel-pysam>=7.1.0",
     "pvlib>=0.14.0,<0.16",
-    "pymoo>=0.6.1.6",
     "rainflow>=3.2.0",
-    "requests-cache>=1.2.1",
-    "timezonefinder>=8.2.1",
+    "scipy>=1.14",
 ]
 
 [project.urls]
@@ -43,7 +34,36 @@ Repository = "https://github.com/Str4vinci/breos"
 breos = "breos.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "ruff>=0.15"]
+cec-fit = ["nrel-pysam>=7.1.0"]
+fast = ["numba>=0.63.1"]
+plots = ["matplotlib>=3.10.8"]
+optimization = ["pymoo>=0.6.1.6"]
+weather = [
+    "openmeteo-requests>=1.7.4",
+    "requests-cache>=1.2.1",
+    "timezonefinder>=8.2.1",
+]
+validation = [
+    "openpyxl>=3.1.0",
+    "pyarrow>=19.0.0",
+]
+location-tools = [
+    "geopy>=2.4.1",
+    "timezonefinder>=8.2.1",
+]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.15",
+    "matplotlib>=3.10.8",
+    "numba>=0.63.1",
+    "openpyxl>=3.1.0",
+    "openmeteo-requests>=1.7.4",
+    "pyarrow>=19.0.0",
+    "nrel-pysam>=7.1.0",
+    "pymoo>=0.6.1.6",
+    "requests-cache>=1.2.1",
+    "timezonefinder>=8.2.1",
+]
 docs = [
     "sphinx>=8.1",
     "pydata-sphinx-theme>=0.16",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -112,6 +112,25 @@ class TestAppValidation:
 
         assert seen["rlp_directory"] == str(tmp_path)
 
+    def test_smaller_inverter_clips_app_production(self, _patch_weather):
+        def _run(loading_ratio):
+            app = App(
+                {
+                    "location": "porto",
+                    "n_modules": 6,
+                    "annual_consumption_kwh": 3000,
+                    "projection_years": 1,
+                    "inverter_loading_ratio": loading_ratio,
+                }
+            )
+            app.simulate()
+            return app.result()["pv_production_kwh"]
+
+        # A heavily undersized inverter (high DC/AC ratio) must clip yield;
+        # before 0.3.0 the App paid clipping-sized inverter CAPEX while
+        # production was never clipped.
+        assert _run(3.0) < _run(1.0)
+
     def test_simulate_localizes_load_to_location_timezone(self, _patch_weather, monkeypatch):
         seen = {}
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,6 +55,28 @@ class TestAppValidation:
         with pytest.raises(ValueError, match="latitude"):
             App({"location": {"longitude": -8.6}, "n_modules": 10, "annual_consumption_kwh": 4000})
 
+    def test_invalid_pv_loss_overrides_value(self):
+        with pytest.raises(ValueError, match="pv_loss_overrides"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "pv_loss_overrides": {"shading": 200},
+                }
+            )
+
+    def test_invalid_pv_loss_overrides_type(self):
+        with pytest.raises(TypeError, match="pv_loss_overrides"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "pv_loss_overrides": 5.0,
+                }
+            )
+
     def test_custom_location_valid(self):
         app = App(
             {
@@ -111,6 +133,25 @@ class TestAppValidation:
         app.simulate()
 
         assert seen["rlp_directory"] == str(tmp_path)
+
+    def test_pv_loss_overrides_increase_production(self, _patch_weather):
+        def _run(overrides):
+            app = App(
+                {
+                    "location": "porto",
+                    "n_modules": 6,
+                    "annual_consumption_kwh": 3000,
+                    "projection_years": 1,
+                    "pv_loss_overrides": overrides,
+                }
+            )
+            app.simulate()
+            return app.result()["pv_production_kwh"]
+
+        base = _run(None)
+        no_shading = _run({"shading": 0.0})
+
+        assert no_shading == pytest.approx(base / 0.97, rel=1e-6)
 
     def test_smaller_inverter_clips_app_production(self, _patch_weather):
         def _run(loading_ratio):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -112,6 +112,34 @@ class TestAppValidation:
 
         assert seen["rlp_directory"] == str(tmp_path)
 
+    def test_simulate_localizes_load_to_location_timezone(self, _patch_weather, monkeypatch):
+        seen = {}
+
+        def _fake_load_profile(**kwargs):
+            seen["timezone"] = kwargs["timezone"]
+            return real_load_profile(
+                profile_type="1",
+                annual_consumption_kwh=kwargs["annual_consumption_kwh"],
+                start_date=kwargs["start_date"],
+                freq=kwargs["freq"],
+                num_years=kwargs["num_years"],
+                timezone=kwargs["timezone"],
+            )
+
+        monkeypatch.setattr(app_module, "load_profile", _fake_load_profile)
+
+        app = App(
+            {
+                "location": "porto",
+                "n_modules": 1,
+                "annual_consumption_kwh": 1000,
+                "projection_years": 1,
+            }
+        )
+        app.simulate()
+
+        assert seen["timezone"] == "Europe/Lisbon"
+
 
 # ---------------------------------------------------------------------------
 # Simulation (with monkeypatched weather)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,6 +55,36 @@ class TestAppValidation:
         with pytest.raises(ValueError, match="latitude"):
             App({"location": {"longitude": -8.6}, "n_modules": 10, "annual_consumption_kwh": 4000})
 
+    def test_invalid_negative_battery_kwh(self):
+        # A negative battery must not silently reduce CAPEX
+        with pytest.raises(ValueError, match="battery_kwh"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "battery_kwh": -5})
+
+    def test_invalid_top_level_tilt(self):
+        with pytest.raises(ValueError, match="tilt"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "tilt": 120})
+
+    def test_invalid_top_level_azimuth(self):
+        with pytest.raises(ValueError, match="azimuth"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "azimuth": 400})
+
+    def test_invalid_inverter_efficiency(self):
+        with pytest.raises(ValueError, match="inverter_efficiency"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "inverter_efficiency": 1.5})
+
+    def test_invalid_inverter_loading_ratio(self):
+        with pytest.raises(ValueError, match="inverter_loading_ratio"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "inverter_loading_ratio": 0})
+
+    def test_invalid_projection_years(self):
+        # Must fail at config load, not with a late RuntimeError mid-simulation
+        with pytest.raises(ValueError, match="projection_years"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "projection_years": 0})
+
+    def test_invalid_pv_degradation_rate(self):
+        with pytest.raises(ValueError, match="pv_degradation_rate"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "pv_degradation_rate": 1.5})
+
     def test_invalid_battery_soc_window(self):
         with pytest.raises(ValueError, match="battery_min_soc"):
             App(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,6 +55,40 @@ class TestAppValidation:
         with pytest.raises(ValueError, match="latitude"):
             App({"location": {"longitude": -8.6}, "n_modules": 10, "annual_consumption_kwh": 4000})
 
+    def test_invalid_battery_soc_window(self):
+        with pytest.raises(ValueError, match="battery_min_soc"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "battery_min_soc": 0.9,
+                    "battery_max_soc": 0.2,
+                }
+            )
+
+    def test_invalid_battery_rte(self):
+        with pytest.raises(ValueError, match="battery_rte"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "battery_rte": 1.5,
+                }
+            )
+
+    def test_invalid_battery_eol(self):
+        with pytest.raises(ValueError, match="battery_eol_percentage"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "battery_eol_percentage": 0.0,
+                }
+            )
+
     def test_invalid_pv_loss_overrides_value(self):
         with pytest.raises(ValueError, match="pv_loss_overrides"):
             App(
@@ -133,6 +167,28 @@ class TestAppValidation:
         app.simulate()
 
         assert seen["rlp_directory"] == str(tmp_path)
+
+    def test_battery_soc_window_reaches_simulation(self, _patch_weather):
+        def _run(**extra):
+            app = App(
+                {
+                    "location": "porto",
+                    "n_modules": 6,
+                    "annual_consumption_kwh": 3000,
+                    "battery_kwh": 5.0,
+                    "projection_years": 1,
+                    **extra,
+                }
+            )
+            app.simulate()
+            return app
+
+        default_gi = _run().result()["grid_independence_pct"]
+        narrow_gi = _run(battery_min_soc=0.45, battery_max_soc=0.55).result()["grid_independence_pct"]
+
+        # A 10% SOC window stores a tenth of the energy of the default
+        # 10-90% window, so grid independence must drop
+        assert narrow_gi < default_gi
 
     def test_pv_loss_overrides_increase_production(self, _patch_weather):
         def _run(overrides):

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -110,6 +110,36 @@ class TestSimulateEnergyBalance:
         assert len(results_df) == 48
         assert summary_df["Total Load [kWh]"].iloc[0] == pytest.approx(48.0)
 
+    def test_resistance_fade_derates_energy_loop_efficiency(self):
+        # enable_resistance_fade must feed the effective RTE back into the
+        # charge/discharge flows, not just record it: with substantial
+        # resistance growth the same scenario delivers less battery energy.
+        idx = pd.date_range("2025-01-01 00:00", periods=24, freq="h", tz="UTC")
+        pv = pd.Series([0.0] * 8 + [2000.0] * 8 + [0.0] * 8, index=idx)
+        houseload = pd.DataFrame({"Load": [800.0] * 8 + [0.0] * 8 + [800.0] * 8}, index=idx)
+
+        def _run(**kwargs):
+            config = BatteryConfig(
+                nominal_energy_wh=5000,
+                standby_loss_wh=0.0,
+                enable_replacement=False,
+                **kwargs,
+            )
+            results_df, *_ = simulate_energy_balance(
+                pv_dc=pv,
+                houseload=houseload,
+                battery_config=config,
+                freq="h",
+                temperature_series=pd.Series(25.0, index=idx),
+            )
+            return results_df["Import_From_Grid"].sum()
+
+        import_base = _run()
+        import_faded = _run(enable_resistance_fade=True, initial_resistance_growth=1.0)
+
+        # 1.0 relative resistance growth halves the round-trip efficiency
+        assert import_faded > import_base
+
     def test_inverter_ac_capacity_clips_pv_and_export(self):
         idx = pd.date_range("2025-01-01 00:00", periods=4, freq="h", tz="UTC")
         pv_dc = pd.Series([0.0, 2000.0, 3000.0, 1000.0], index=idx)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -110,6 +110,49 @@ class TestSimulateEnergyBalance:
         assert len(results_df) == 48
         assert summary_df["Total Load [kWh]"].iloc[0] == pytest.approx(48.0)
 
+    def test_inverter_ac_capacity_clips_pv_and_export(self):
+        idx = pd.date_range("2025-01-01 00:00", periods=4, freq="h", tz="UTC")
+        pv_dc = pd.Series([0.0, 2000.0, 3000.0, 1000.0], index=idx)
+        houseload = pd.DataFrame({"Load": 500.0}, index=idx)
+        config = BatteryConfig(nominal_energy_wh=0, inverter_ac_capacity_w=1000.0)
+
+        results_df, total_pv, *_ = simulate_energy_balance(
+            pv_dc=pv_dc, houseload=houseload, battery_config=config, freq="h"
+        )
+
+        # AC production saturates at the inverter rating
+        assert results_df["PV_Production"].max() == pytest.approx(1000.0)
+        # Export uses the headroom left after serving the load
+        assert results_df["Sell_To_Grid"].max() == pytest.approx(500.0)
+        # total_pv sums the clipped AC production
+        assert total_pv == pytest.approx(1000.0 + 1000.0 + 960.0)
+
+    def test_battery_shares_inverter_cap_and_charges_from_clipped_dc(self):
+        idx = pd.date_range("2025-01-01 00:00", periods=2, freq="h", tz="UTC")
+        pv_dc = pd.Series([0.0, 3000.0], index=idx)
+        houseload = pd.DataFrame({"Load": [2000.0, 0.0]}, index=idx)
+        config = BatteryConfig(
+            nominal_energy_wh=2000,
+            inverter_ac_capacity_w=1000.0,
+            standby_loss_wh=0.0,
+            enable_replacement=False,
+        )
+
+        results_df, *_ = simulate_energy_balance(
+            pv_dc=pv_dc,
+            houseload=houseload,
+            battery_config=config,
+            freq="h",
+            temperature_series=pd.Series(25.0, index=idx),
+        )
+
+        # Hour 0: battery discharge AC is capped at the rating; the rest imports
+        assert results_df["Import_From_Grid"].iloc[0] == pytest.approx(1000.0)
+        # Hour 1: DC surplus above the AC cap still charges the DC-coupled
+        # battery back to full, while export clips at the rating
+        assert results_df["Battery_Energy"].iloc[1] == pytest.approx(1800.0)
+        assert results_df["Sell_To_Grid"].iloc[1] == pytest.approx(1000.0)
+
     def test_cold_derate_cannot_sell_energy_pv_never_produced(self):
         # A full battery whose temperature drops sees Emax shrink below its
         # stored energy (lfp cold derate). charge_room went negative and the

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -110,6 +110,33 @@ class TestSimulateEnergyBalance:
         assert len(results_df) == 48
         assert summary_df["Total Load [kWh]"].iloc[0] == pytest.approx(48.0)
 
+    def test_cold_derate_cannot_sell_energy_pv_never_produced(self):
+        # A full battery whose temperature drops sees Emax shrink below its
+        # stored energy (lfp cold derate). charge_room went negative and the
+        # battery silently drained into Sell_To_Grid: 100 Wh of PV exported
+        # ~539 Wh in the first cold hour. Export must never exceed PV AC.
+        idx = pd.date_range("2025-01-01 00:00", periods=6, freq="h", tz="UTC")
+        pv_dc = pd.Series(100.0, index=idx)
+        houseload = pd.DataFrame({"Load": 0.0}, index=idx)
+        config = BatteryConfig(nominal_energy_wh=10000, battery_type="lfp")
+        temperature = pd.Series([25.0, 25.0, 0.0, 0.0, 0.0, 0.0], index=idx)
+
+        results_df, *_ = simulate_energy_balance(
+            pv_dc=pv_dc,
+            houseload=houseload,
+            battery_config=config,
+            temperature_series=temperature,
+            freq="h",
+        )
+
+        pv_ac_max = 100.0 * config.inverter_efficiency
+        assert results_df["Sell_To_Grid"].max() <= pv_ac_max + 1e-9
+        # Stored energy is clamped into the temperature-derated window
+        from breos.battery import lfp_capacity_factor
+
+        emax_cold = 10000 * config.max_soc * lfp_capacity_factor(0.0)
+        assert results_df["Battery_Energy"].iloc[-1] <= emax_cold + 1e-9
+
 
 class TestIndoorTemperatureModel:
     def test_output_shape(self):

--- a/tests/test_economics.py
+++ b/tests/test_economics.py
@@ -2,8 +2,37 @@
 
 import pytest
 
-from breos.economics import CostParams, calculate_costs, calculate_lcoe, find_payback_year
+from breos.economics import CostParams, calculate_costs, calculate_lcoe, cost_params_from_config, find_payback_year
 from breos.optimization import calculate_financials
+
+
+class TestCostDefaultsSingleSource:
+    def test_cost_params_from_config_empty_matches_dataclass_defaults(self):
+        # Missing config keys must fall back to the CostParams defaults, so
+        # config-driven and direct-construction paths cannot diverge.
+        assert cost_params_from_config({}, {}) == CostParams()
+
+    def test_resolve_costs_preset_fallbacks_match_dataclass_defaults(self, monkeypatch):
+        from breos import app_config
+
+        monkeypatch.setattr(app_config, "load_json", lambda name: {"minimal": {}})
+        cfg = {
+            "cost_preset": "minimal",
+            "inverter_loading_ratio": 1.25,
+            "inflation_rate": 0.02,
+            "discount_rate": 0.0,
+            "pv_degradation_rate": 0.005,
+        }
+
+        params = app_config.resolve_costs(cfg)
+
+        # A preset that omits every key behaves exactly like no preset
+        assert params == CostParams(
+            dc_ac_ratio=1.25,
+            inflation_rate=0.02,
+            discount_rate=0.0,
+            pv_degradation_rate=0.005,
+        )
 
 
 class TestCalculateCosts:

--- a/tests/test_golden_outputs.py
+++ b/tests/test_golden_outputs.py
@@ -53,11 +53,11 @@ def test_simulate_energy_balance_battery_golden_output():
         {
             "Total PV [kWh]": 22.272,
             "Total Load [kWh]": 36.0,
-            "Sell [kWh]": 7.042558969772534,
-            "Import [kWh]": 19.04936863644225,
-            "Import [%]": 52.91491287900625,
-            "Grid Independence [%]": 47.08508712099375,
-            "Final SOH [%]": 99.7669719903168,
+            "Sell [kWh]": 7.0425545297401175,
+            "Import [kWh]": 19.064139530204148,
+            "Import [%]": 52.955943139455975,
+            "Grid Independence [%]": 47.044056860544025,
+            "Final SOH [%]": 99.76712171800783,
             "N_Replacements": 0,
             "Replacement_Cost": 0.0,
         },
@@ -66,7 +66,7 @@ def test_simulate_energy_balance_battery_golden_output():
     assert replacement_cost == pytest.approx(0.0)
     assert n_replacements == 0
     assert len(degradation_df) == 2
-    assert results_df["Battery_Energy"].iloc[-1] == pytest.approx(297.7074191036577)
+    assert results_df["Battery_Energy"].iloc[-1] == pytest.approx(297.70796832641753)
 
 
 def test_simulate_energy_balance_15min_golden_output():

--- a/tests/test_load_profiles.py
+++ b/tests/test_load_profiles.py
@@ -31,6 +31,38 @@ def test_load_profile_accepts_aliases_and_15t_frequency():
     assert annual_kwh == pytest.approx(1000)
 
 
+def test_load_profile_pins_rows_to_local_wall_clock_across_dst():
+    # Household behavior follows the legal clock, so a localized profile must
+    # keep each row's wall-clock label year-round (UTC instants shift by the
+    # DST offset) — an instant-spaced index would only shift the start.
+    utc_prof = load_profile("1", 5000, freq="h", timezone="UTC").iloc[:, 0]
+    loc_prof = load_profile("1", 5000, freq="h", timezone="Europe/Berlin").iloc[:, 0]
+
+    idx = loc_prof.index
+    assert len(loc_prof) == 8760
+    assert idx.is_unique and idx.is_monotonic_increasing
+    assert idx[0] == pd.Timestamp("2025-01-01 00:00", tz="Europe/Berlin")
+    # Evenly spaced in absolute time despite the DST transitions
+    assert len(idx.to_series().diff().dropna().unique()) == 1
+    # Energy preserved (one dropped spring-forward row, one forward-fill)
+    assert float(loc_prof.sum()) / 1000.0 == pytest.approx(5000.0, abs=5.0)
+
+    # Same wall-clock pattern as the UTC profile in winter AND summer
+    for day in ("2025-01-15", "2025-07-15"):
+        np.testing.assert_allclose(loc_prof[day].to_numpy(), utc_prof[day].to_numpy())
+    # Local-calendar DST days have 23 and 25 wall-clock hours
+    assert len(loc_prof["2025-03-30"]) == 23
+    assert len(loc_prof["2025-10-26"]) == 25
+
+
+def test_load_profile_utc_default_keeps_legacy_convention():
+    profile = load_profile("1", 1000, freq="h")
+
+    assert str(profile.index.tz) == "UTC"
+    assert profile.index[0] == pd.Timestamp("2025-01-01 00:00", tz="UTC")
+    assert len(profile) == 8760
+
+
 def test_non_bundled_profile_requires_external_directory():
     with pytest.raises(ValueError, match="not bundled"):
         load_profile("eredes_btn_c", 1000)

--- a/tests/test_numba_kernels.py
+++ b/tests/test_numba_kernels.py
@@ -1,0 +1,61 @@
+"""Parity tests for the optional Numba kernels (breos[fast])."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("numba")
+
+
+def test_lfp_capacity_factor_parity_with_python_reference():
+    # The kernel hand-duplicates the LFP derate constants from constants.py;
+    # pin them against the reference implementation across both derate
+    # branches, including sub-zero temperatures and the 0.5 floor.
+    from breos.battery import lfp_capacity_factor
+    from breos.numba_kernels import _lfp_capacity_factor_numba
+
+    for temp in np.linspace(-60.0, 50.0, 221):
+        assert _lfp_capacity_factor_numba(float(temp)) == pytest.approx(lfp_capacity_factor(float(temp)), abs=1e-12)
+
+
+def test_energy_balance_kernel_matches_reference_where_models_coincide():
+    # The kernel omits inverter conversion; with unity inverter efficiency,
+    # 25 degC, and a single day (no degradation step applied to stored
+    # results), it must reproduce the reference energy balance exactly.
+    from breos.battery import BatteryConfig, simulate_energy_balance
+    from breos.numba_kernels import energy_balance_kernel
+
+    idx = pd.date_range("2025-01-01 00:00", periods=24, freq="h", tz="UTC")
+    pv = np.array([0.0] * 7 + [500.0, 1500.0, 2500.0, 3000.0, 2800.0, 2000.0, 1200.0, 400.0] + [0.0] * 9)
+    load = np.array([600.0] * 6 + [900.0] * 3 + [700.0] * 8 + [1100.0] * 5 + [800.0] * 2)
+
+    config = BatteryConfig(
+        nominal_energy_wh=5000,
+        inverter_efficiency=1.0,
+        standby_loss_wh=5.0,
+        enable_replacement=False,
+    )
+    results_df, *_ = simulate_energy_balance(
+        pv_dc=pd.Series(pv, index=idx),
+        houseload=pd.DataFrame({"Load": load}, index=idx),
+        battery_config=config,
+        freq="h",
+        temperature_series=pd.Series(25.0, index=idx),
+    )
+
+    import_wh, sell_wh, battery_wh, _soc_norm, _soc_abs = energy_balance_kernel(
+        pv,
+        load,
+        5000.0,
+        config.max_soc,
+        config.min_soc,
+        config.charge_efficiency,
+        config.discharge_efficiency,
+        5.0,
+        1.0,
+        1.0,
+    )
+
+    np.testing.assert_allclose(results_df["Import_From_Grid"].to_numpy(), import_wh, atol=1e-9)
+    np.testing.assert_allclose(results_df["Sell_To_Grid"].to_numpy(), sell_wh, atol=1e-9)
+    np.testing.assert_allclose(results_df["Battery_Energy"].to_numpy(), battery_wh, atol=1e-9)

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -66,6 +66,35 @@ class TestPVProduction:
         )
         assert dc_5.sum() == pytest.approx(dc_1.sum() * 5, rel=0.001)
 
+    def test_loss_overrides_change_production(self, synthetic_weather, porto_location, pv_params):
+        kwargs = dict(
+            weather_data=synthetic_weather,
+            location=porto_location,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=pv_params,
+            freq="h",
+        )
+        base = calculate_pv_production_dc(**kwargs)
+        no_shading = calculate_pv_production_dc(**kwargs, loss_overrides={"shading": 0.0})
+
+        # Removing the 3% shading loss scales production by 1/0.97
+        assert no_shading.sum() == pytest.approx(base.sum() / 0.97, rel=1e-6)
+
+    def test_loss_overrides_reject_unknown_component(self, synthetic_weather, porto_location, pv_params):
+        with pytest.raises(ValueError, match="Unknown loss component"):
+            calculate_pv_production_dc(
+                weather_data=synthetic_weather,
+                location=porto_location,
+                tilt=35,
+                surface_azimuth=180,
+                n_modules=1,
+                pv_params=pv_params,
+                freq="h",
+                loss_overrides={"typo_component": 1.0},
+            )
+
     def test_zero_ghi_zero_production(self, porto_location, pv_params):
         # Night-time weather: all irradiance = 0
         idx = pd.date_range("2023-01-01", periods=24, freq="h", tz="UTC")

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,5 +1,6 @@
 """Tests for weather and weather-derived helpers."""
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -74,6 +75,67 @@ def test_fetch_tmy_weather_accepts_hourly_frequency_alias(monkeypatch):
     weather, _metadata = fetch_tmy_weather_data(41.0, -8.0, sample_year=None, freq="H")
 
     assert len(weather) == 1
+
+
+def test_fetch_tmy_keeps_utc_instants_for_non_utc_location(monkeypatch):
+    # PVGIS serves UTC-ordered rows; synthetic GHI peaks at 11:00 UTC
+    # (solar noon near Berlin's longitude). The fetch must roll the data
+    # to local midnight without breaking each row's UTC instant — the old
+    # relabeling bug shifted irradiance against solar position by the
+    # location's full UTC offset.
+    from pvlib.iotools.pvgis import _coerce_and_roll_tmy
+
+    utc_idx = pd.date_range("1990-01-01", periods=8760, freq="h", tz="UTC")
+    ghi = np.where(
+        utc_idx.hour == 11,
+        800.0,
+        np.where(np.abs(utc_idx.hour - 11) <= 3, 300.0, 0.0),
+    )
+    raw = pd.DataFrame({"ghi": ghi, "temp_air": 10.0}, index=utc_idx)
+
+    def fake_get_pvgis_tmy(latitude, longitude, *args, roll_utc_offset=None, coerce_year=1990, **kwargs):
+        data = raw.copy()
+        if not (roll_utc_offset is None and coerce_year is None):
+            data = _coerce_and_roll_tmy(data, roll_utc_offset, coerce_year or 1990)
+        return data, {"inputs": {}}
+
+    monkeypatch.setattr("breos.weather.pvlib.iotools.get_pvgis_tmy", fake_get_pvgis_tmy)
+
+    tmy_data, _ = fetch_tmy_weather_data(
+        latitude=52.52,
+        longitude=13.405,
+        sample_year=2025,
+        timezone="Europe/Berlin",
+    )
+
+    assert len(tmy_data) == 8760
+    # Series starts at local midnight of the sample year (UTC+1 standard time)
+    assert tmy_data.index[0] == pd.Timestamp("2025-01-01 00:00", tz="Etc/GMT-1")
+    # Parsed back as UTC instants (as the pipeline does), the GHI peak must
+    # stay at 11:00 UTC; the relabeling bug moved it to 10:00 UTC.
+    utc_hours = tmy_data.index.tz_convert("UTC").hour
+    peak_utc_hour = tmy_data.groupby(utc_hours)["ghi"].mean().idxmax()
+    assert peak_utc_hour == 11
+    # On the local clock the mean-GHI peak lands at midday, not the UTC peak.
+    peak_local_hour = tmy_data.groupby(tmy_data.index.hour)["ghi"].mean().idxmax()
+    assert 11 <= peak_local_hour <= 15
+
+
+def test_fetch_tmy_without_sample_year_keeps_original_index(monkeypatch):
+    tmy = pd.DataFrame({"ghi": [0.0]}, index=pd.date_range("2009-01-01 00:00", periods=1, freq="h", tz="UTC"))
+    captured = {}
+
+    def fake_get_pvgis_tmy(*args, **kwargs):
+        captured.update(kwargs)
+        return tmy.copy(), {}
+
+    monkeypatch.setattr("breos.weather.pvlib.iotools.get_pvgis_tmy", fake_get_pvgis_tmy)
+
+    weather, _metadata = fetch_tmy_weather_data(41.0, -8.0, sample_year=None)
+
+    assert captured["roll_utc_offset"] is None
+    assert captured["coerce_year"] is None
+    assert weather.index[0] == tmy.index[0]
 
 
 def test_read_epw_accepts_15t_frequency_alias(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -104,26 +104,29 @@ name = "breos"
 version = "0.2.3"
 source = { editable = "." }
 dependencies = [
-    { name = "geopy" },
-    { name = "joblib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pvlib" },
+    { name = "rainflow" },
+    { name = "scipy" },
+]
+
+[package.optional-dependencies]
+cec-fit = [
+    { name = "nrel-pysam" },
+]
+dev = [
     { name = "matplotlib" },
     { name = "nrel-pysam" },
     { name = "numba" },
     { name = "openmeteo-requests" },
     { name = "openpyxl" },
-    { name = "pandas" },
-    { name = "pvlib" },
     { name = "pyarrow" },
     { name = "pymoo" },
-    { name = "rainflow" },
-    { name = "requests-cache" },
-    { name = "timezonefinder" },
-]
-
-[package.optional-dependencies]
-dev = [
     { name = "pytest" },
+    { name = "requests-cache" },
     { name = "ruff" },
+    { name = "timezonefinder" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -135,33 +138,66 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
 ]
+fast = [
+    { name = "numba" },
+]
+location-tools = [
+    { name = "geopy" },
+    { name = "timezonefinder" },
+]
+optimization = [
+    { name = "pymoo" },
+]
+plots = [
+    { name = "matplotlib" },
+]
+validation = [
+    { name = "openpyxl" },
+    { name = "pyarrow" },
+]
+weather = [
+    { name = "openmeteo-requests" },
+    { name = "requests-cache" },
+    { name = "timezonefinder" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "geopy", specifier = ">=2.4.1" },
-    { name = "joblib", specifier = ">=1.5.3" },
-    { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "geopy", marker = "extra == 'location-tools'", specifier = ">=2.4.1" },
+    { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.8" },
+    { name = "matplotlib", marker = "extra == 'plots'", specifier = ">=3.10.8" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0" },
-    { name = "nrel-pysam", specifier = ">=7.1.0" },
-    { name = "numba", specifier = ">=0.63.1" },
-    { name = "openmeteo-requests", specifier = ">=1.7.4" },
-    { name = "openpyxl", specifier = ">=3.1.0" },
+    { name = "nrel-pysam", marker = "extra == 'cec-fit'", specifier = ">=7.1.0" },
+    { name = "nrel-pysam", marker = "extra == 'dev'", specifier = ">=7.1.0" },
+    { name = "numba", marker = "extra == 'dev'", specifier = ">=0.63.1" },
+    { name = "numba", marker = "extra == 'fast'", specifier = ">=0.63.1" },
+    { name = "numpy", specifier = ">=2.0" },
+    { name = "openmeteo-requests", marker = "extra == 'dev'", specifier = ">=1.7.4" },
+    { name = "openmeteo-requests", marker = "extra == 'weather'", specifier = ">=1.7.4" },
+    { name = "openpyxl", marker = "extra == 'dev'", specifier = ">=3.1.0" },
+    { name = "openpyxl", marker = "extra == 'validation'", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pvlib", specifier = ">=0.14.0,<0.16" },
-    { name = "pyarrow", specifier = ">=19.0.0" },
+    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=19.0.0" },
+    { name = "pyarrow", marker = "extra == 'validation'", specifier = ">=19.0.0" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = ">=0.16" },
-    { name = "pymoo", specifier = ">=0.6.1.6" },
+    { name = "pymoo", marker = "extra == 'dev'", specifier = ">=0.6.1.6" },
+    { name = "pymoo", marker = "extra == 'optimization'", specifier = ">=0.6.1.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "rainflow", specifier = ">=3.2.0" },
-    { name = "requests-cache", specifier = ">=1.2.1" },
+    { name = "requests-cache", marker = "extra == 'dev'", specifier = ">=1.2.1" },
+    { name = "requests-cache", marker = "extra == 'weather'", specifier = ">=1.2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
+    { name = "scipy", specifier = ">=1.14" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=2.5" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
     { name = "sphinx-design", marker = "extra == 'docs'", specifier = ">=0.6" },
-    { name = "timezonefinder", specifier = ">=8.2.1" },
+    { name = "timezonefinder", marker = "extra == 'dev'", specifier = ">=8.2.1" },
+    { name = "timezonefinder", marker = "extra == 'location-tools'", specifier = ">=8.2.1" },
+    { name = "timezonefinder", marker = "extra == 'weather'", specifier = ">=8.2.1" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["cec-fit", "fast", "plots", "optimization", "weather", "validation", "location-tools", "dev", "docs"]
 
 [[package]]
 name = "cattrs"
@@ -773,15 +809,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "breos"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Promotes BREOS 0.3.0 from develop to main after release PR #34.\n\nRelease highlights:\n- Fixes TMY timezone alignment for non-UTC locations.\n- Localizes load profiles to location wall clock, including DST transitions.\n- Clamps battery energy within the temperature-derated window to prevent phantom export.\n- Applies inverter AC clipping consistently in the App pipeline.\n- Documents/configures PVWatts losses, battery SOC/EOL/RTE parameters, and Numba kernel scope.\n- Consolidates cost defaults, improves validation/logging, and updates release metadata.\n\nChecks already passed on #34: Python 3.11, 3.12, and 3.13 test jobs. Local gates also passed: ruff check, ruff format --check, pytest -q (177 passed), uv build, tools/verify_release_artifacts.py, and Sphinx HTML docs build.