### PR TITLE
Configurable sky-diffusion transposition model, ground albedo, and Perez coefficients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   (extraterrestrial DNI, relative airmass) are derived internally. The default
   `isotropic` reproduces prior results bit-for-bit. Per-array overrides are
   supported in `pv_arrays`.
+- Configurable ground reflectance and Perez coefficients to drive those models
+  with real site information: `albedo` (0-1) or a named `surface_type`
+  (`"snow"`, `"sea"`, `"grass"`, ...) sets the ground-diffuse reflectance for
+  every model (previously fixed at pvlib's 0.25), and `model_perez` selects
+  the Perez coefficient set. All three are App config keys with matching
+  `--albedo` / `--surface-type` / `--perez-model` CLI flags and per-array
+  overrides; not setting them leaves the previous defaults unchanged.
 
 ## [0.3.0] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- Configurable sky-diffusion (transposition) model via a `transposition_model`
+  config key and `--transposition-model` / `--sky-model` CLI flag, threaded
+  through `calculate_pv_production_dc`, the tracking and multi-array variants,
+  and the `App` config surface. Supports `isotropic` (default), `klucher`,
+  `haydavies`, `reindl`, `king`, `perez`, and `perez-driesse` via pvlib's
+  `get_total_irradiance`; the extra inputs the anisotropic models need
+  (extraterrestrial DNI, relative airmass) are derived internally. The default
+  `isotropic` reproduces prior results bit-for-bit. Per-array overrides are
+  supported in `pv_arrays`.
+
 ## [0.3.0] - 2026-06-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ Only `location`, `annual_consumption_kwh`, and either `n_modules` or
 | `rlp_directory` | `None` | Directory containing licensed external RLP CSVs for non-bundled load profiles |
 
 See [docs/getting-started/configuration.md](docs/getting-started/configuration.md)
-for every option, including tracking, PV loss overrides, battery SOC limits,
-tariffs, inflation, and discounting.
+for every option, including tracking, the sky-diffusion (transposition) model,
+PV loss overrides, battery SOC limits, tariffs, inflation, and discounting.
 
 ### Modeling conventions
 
@@ -194,7 +194,9 @@ tariffs, inflation, and discounting.
   added separately per simulation year. Override individual components with
   `pv_loss_overrides` (App) or `loss_overrides` (solar functions).
 - **PV model background**: BREOS uses pvlib for solar position, irradiance
-  transposition, cell temperature, and PV performance model pieces. See
+  transposition, cell temperature, and PV performance model pieces. The
+  sky-diffusion transposition model is selectable via `transposition_model`
+  (default `isotropic`; see configuration docs). See
   [docs/resources.md](docs/resources.md) for pvlib and PV model references.
 - **Inverter**: the energy balance applies a flat `inverter_efficiency` and
   clips AC output (PV and battery discharge combined) at the inverter rating

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ PV loss overrides, battery SOC limits, tariffs, inflation, and discounting.
 - **PV model background**: BREOS uses pvlib for solar position, irradiance
   transposition, cell temperature, and PV performance model pieces. The
   sky-diffusion transposition model is selectable via `transposition_model`
-  (default `isotropic`; see configuration docs). See
+  (default `isotropic`), with `albedo`/`surface_type` for ground reflectance
+  and `model_perez` for the Perez coefficient set (see configuration docs). See
   [docs/resources.md](docs/resources.md) for pvlib and PV model references.
 - **Inverter**: the energy balance applies a flat `inverter_efficiency` and
   clips AC output (PV and battery discharge combined) at the inverter rating

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,9 +109,54 @@ Agent and contributor setup:
 
 ## Capability extensions
 
+### Full pvlib PV modeling behind a self-contained PV stage
+
+BREOS deliberately treats PV production as a *self-contained stage* with a single
+output contract: **(weather + system config) → a DC-power time series in watts**,
+summed to system level (or per-array for multi-array). Everything pvlib does —
+transposition, tracking, cell-temperature, IAM, spectral, bifacial rear-gain —
+lives *inside* that stage. The downstream chain (inverter/AC conversion, battery
+dispatch, economics, emissions, Monte Carlo, NSGA-II sizing) consumes only the DC
+series and must stay invariant as new physics is switched on. Keeping that
+boundary firm is what lets us progressively "turn on" more of pvlib without
+destabilising the rest of the engine.
+
+This is the functional, data-flow counterpart to "Wrap third-party modules behind
+adapters" ([#11](https://github.com/Str4vinci/breos/issues/11)) above: adapters
+own the *types* crossing the boundary; this item owns the *contract* that boundary
+guarantees.
+
+Principles:
+
+- One output contract: a watts DC `pd.Series` on the run's time index. A new
+  capability must not add new required inputs to any downstream stage.
+- New physics is opt-in and defaults to current behaviour, so existing configs
+  reproduce bit-for-bit (regression-test the example configs in
+  `configs/examples/`).
+- Each capability declares the *extra inputs* it needs and fails loudly (in the
+  existing "Unknown X. Available: ..." style) when a config selects a model whose
+  inputs are missing — never silently fall back to different physics.
+- Validate every new model against the current baseline on at least one reference
+  location and document the expected annual-yield delta.
+
+Capabilities to bring fully online, roughly in order (tracking is already wired
+end-to-end through `build_dc_system_base` and the multi-array path):
+
+- **Configurable transposition models** — see the dedicated item below (0.3.2).
+- **Bifacial rear-gain** — see the dedicated item below.
+- **Cell-temperature model choice** — `faiman` is currently hardcoded in
+  `_compute_effective_irradiance_and_cell_temp`; expose `sapm`, `pvsyst`, and
+  `noct_sam` with their parameter sets.
+- **IAM model choice** — `ashrae` is currently hardcoded; expose `martin_ruiz`,
+  `physical`, and the SAPM IAM.
+- **DC-side loss refinements** — optional time-series ohmic/soiling/snow models in
+  place of (parts of) the flat PVWatts loss stack, where inputs allow.
+- Non-goal: replacing the CEC single-diode core or the PVWatts loss model as the
+  defaults. This is about *optional* fidelity, not a new default engine.
+
 ### Configurable sky-diffusion (transposition) models
 
-**Target: 0.3.1.** BREOS currently hardcodes the isotropic sky-diffusion model
+**Target: 0.3.2.** BREOS currently hardcodes the isotropic sky-diffusion model
 when transposing GHI/DHI/DNI to plane-of-array irradiance (`model="isotropic"`
 in `solar._compute_effective_irradiance_and_cell_temp`). The isotropic model is
 simple and robust but underestimates POA on clear days; anisotropic models
@@ -129,7 +174,36 @@ select the model via config and the public production APIs.
   document the expected annual-yield differences (Perez vs isotropic can shift
   annual POA by a few percent).
 - Add a docs entry and a recipe showing how to switch models.
-- Non-goal: spectral or bifacial irradiance modeling.
+- Non-goal for this item: spectral irradiance modeling. Bifacial rear-gain is now
+  planned separately — see "Bifacial rear-gain modeling" below.
+
+### Bifacial rear-gain modeling
+
+Several catalog modules are labelled "Bifacial" but BREOS models them front-side
+only, so the label is currently cosmetic. pvlib *can* model rear irradiance — the
+gap is inputs, not capability. Add real rear-gain so a bifacial module's extra
+yield (typically ~5–15%, dominated by ground albedo and mounting height) is
+actually simulated. This is the first concrete new capability under "Full pvlib PV
+modeling" above.
+
+- **Module input ("unless the panel states it, we can't model it"):** add a
+  `bifaciality` factor (rear/front efficiency ratio, ~0.7–0.85 for TOPCon) to
+  `PVModuleParams` and the module catalog in `pv_modules.py`. Absent or zero ⇒
+  front-only, exactly as today.
+- **Site/array inputs:** ground `albedo` (the single biggest driver; ~0.2 grass to
+  ~0.6 snow/sand) and row geometry. Tracking arrays already carry `gcr`; fixed
+  arrays need the `infinite_shed` geometry (gcr, height, pitch).
+- **Model:** use `pvlib.bifacial.infinite_shed.get_irradiance` (pure pvlib, no new
+  dependencies). Prefer it over `pvlib.bifacial.pvfactors.*`, which drags in the
+  `pvfactors`/`shapely` stack — out of scope for the default install.
+- **Integration:** compute rear POA inside
+  `_compute_effective_irradiance_and_cell_temp` and blend
+  `effective_irradiance += bifaciality * poa_rear` before the CEC DC model. The
+  stage's output contract (DC-watts series) is unchanged, so nothing downstream
+  moves — the whole point of the self-contained PV stage above.
+- Validate against the front-only baseline (`bifaciality=0` must reproduce it
+  bit-for-bit) and document expected rear-gain deltas versus albedo and mounting
+  height.
 
 ### String-aware inverter validation and modeling
 

--- a/breos/app.py
+++ b/breos/app.py
@@ -44,8 +44,9 @@ class App:
         - ``annual_consumption_kwh`` - yearly electricity demand (float, > 0).
 
         Optional keys include battery size, PV arrays, module selection, load
-        profile, tracking, resolution, projection years, cost and emissions
-        presets, degradation, and inverter assumptions.
+        profile, tracking, sky-diffusion model (``transposition_model``),
+        resolution, projection years, cost and emissions presets, degradation,
+        and inverter assumptions.
     """
 
     def __init__(self, config: dict) -> None:

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -9,7 +9,14 @@ from breos.economics import CostParams, calculate_costs
 from breos.emissions import EmissionsParams
 from breos.pv_modules import MODULES, PVModuleParams, get_module
 from breos.resources import load_config_json
-from breos.solar import DEFAULT_TRANSPOSITION_MODEL, TRANSPOSITION_MODELS, estimate_optimal_tilt
+from breos.solar import (
+    DEFAULT_PEREZ_MODEL,
+    DEFAULT_TRANSPOSITION_MODEL,
+    PEREZ_MODELS,
+    SURFACE_TYPES,
+    TRANSPOSITION_MODELS,
+    estimate_optimal_tilt,
+)
 from breos.solar import default_azimuth as default_azimuth_fn
 
 DEFAULTS: dict[str, Any] = {
@@ -29,6 +36,9 @@ DEFAULTS: dict[str, Any] = {
     "cross_axis_tilt": 0.0,
     "dual_axis_max_tilt": 90.0,
     "transposition_model": DEFAULT_TRANSPOSITION_MODEL,
+    "albedo": None,
+    "surface_type": None,
+    "model_perez": DEFAULT_PEREZ_MODEL,
     "resolution": "h",
     "projection_years": 20,
     "cost_preset": None,
@@ -80,6 +90,35 @@ def merge_defaults(config: dict[str, Any]) -> dict[str, Any]:
     return {**DEFAULTS, **config}
 
 
+def _validate_sky_settings(
+    transposition_model: Any,
+    albedo: Any,
+    surface_type: Any,
+    model_perez: Any,
+    where: str = "",
+) -> None:
+    """Validate the sky-diffusion settings shared by the top level and arrays.
+
+    ``where`` prefixes the key name in error messages (e.g. ``pv_arrays[0]``);
+    ``None`` values are treated as "not set" and skipped, so per-array overrides
+    only validate the keys they actually provide.
+    """
+    prefix = f"{where}." if where else ""
+    if transposition_model is not None and str(transposition_model).strip().lower() not in TRANSPOSITION_MODELS:
+        valid = ", ".join(TRANSPOSITION_MODELS)
+        raise ValueError(f"'{prefix}transposition_model' must be one of: {valid}")
+    if albedo is not None and surface_type is not None:
+        raise ValueError(f"Set either '{prefix}albedo' or '{prefix}surface_type', not both.")
+    if albedo is not None and (not isinstance(albedo, (int, float)) or not 0 <= albedo <= 1):
+        raise ValueError(f"'{prefix}albedo' must be a number between 0 and 1")
+    if surface_type is not None and surface_type not in SURFACE_TYPES:
+        valid = ", ".join(SURFACE_TYPES)
+        raise ValueError(f"'{prefix}surface_type' must be one of: {valid}")
+    if model_perez is not None and model_perez not in PEREZ_MODELS:
+        valid = ", ".join(PEREZ_MODELS)
+        raise ValueError(f"'{prefix}model_perez' must be one of: {valid}")
+
+
 def validate_config(cfg: dict[str, Any]) -> None:
     """Validate user-facing App config before resolving derived values."""
     for key in ("location", "annual_consumption_kwh"):
@@ -115,10 +154,13 @@ def validate_config(cfg: dict[str, Any]) -> None:
                 raise ValueError(f"'pv_arrays[{i}].tilt' must be between 0 and 90")
             if azimuth is not None and not 0 <= azimuth <= 360:
                 raise ValueError(f"'pv_arrays[{i}].azimuth' must be between 0 and 360")
-            arr_model = arr.get("transposition_model")
-            if arr_model is not None and str(arr_model).strip().lower() not in TRANSPOSITION_MODELS:
-                valid = ", ".join(TRANSPOSITION_MODELS)
-                raise ValueError(f"'pv_arrays[{i}].transposition_model' must be one of: {valid}")
+            _validate_sky_settings(
+                arr.get("transposition_model"),
+                arr.get("albedo"),
+                arr.get("surface_type"),
+                arr.get("model_perez"),
+                where=f"pv_arrays[{i}]",
+            )
     if cfg["annual_consumption_kwh"] <= 0:
         raise ValueError("'annual_consumption_kwh' must be > 0")
     if cfg["battery_kwh"] < 0:
@@ -139,9 +181,7 @@ def validate_config(cfg: dict[str, Any]) -> None:
         raise ValueError("'pv_degradation_rate' must be between 0 (inclusive) and 1 (exclusive)")
     if cfg["resolution"] not in ("h", "15min"):
         raise ValueError("'resolution' must be 'h' or '15min'")
-    if str(cfg["transposition_model"]).strip().lower() not in TRANSPOSITION_MODELS:
-        valid = ", ".join(TRANSPOSITION_MODELS)
-        raise ValueError(f"'transposition_model' must be one of: {valid}")
+    _validate_sky_settings(cfg["transposition_model"], cfg["albedo"], cfg["surface_type"], cfg["model_perez"])
     overrides = cfg.get("pv_loss_overrides")
     if overrides is not None:
         if not isinstance(overrides, dict):
@@ -189,6 +229,9 @@ def normalise_pv_arrays(arrays: list[dict[str, Any]] | None, cfg: dict[str, Any]
         "cross_axis_tilt",
         "dual_axis_max_tilt",
         "transposition_model",
+        "albedo",
+        "surface_type",
+        "model_perez",
     )
 
     normalized: list[dict[str, Any]] = []

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -9,8 +9,8 @@ from breos.economics import CostParams, calculate_costs
 from breos.emissions import EmissionsParams
 from breos.pv_modules import MODULES, PVModuleParams, get_module
 from breos.resources import load_config_json
+from breos.solar import DEFAULT_TRANSPOSITION_MODEL, TRANSPOSITION_MODELS, estimate_optimal_tilt
 from breos.solar import default_azimuth as default_azimuth_fn
-from breos.solar import estimate_optimal_tilt
 
 DEFAULTS: dict[str, Any] = {
     "battery_kwh": 0.0,
@@ -28,6 +28,7 @@ DEFAULTS: dict[str, Any] = {
     "gcr": 0.35,
     "cross_axis_tilt": 0.0,
     "dual_axis_max_tilt": 90.0,
+    "transposition_model": DEFAULT_TRANSPOSITION_MODEL,
     "resolution": "h",
     "projection_years": 20,
     "cost_preset": None,
@@ -114,6 +115,10 @@ def validate_config(cfg: dict[str, Any]) -> None:
                 raise ValueError(f"'pv_arrays[{i}].tilt' must be between 0 and 90")
             if azimuth is not None and not 0 <= azimuth <= 360:
                 raise ValueError(f"'pv_arrays[{i}].azimuth' must be between 0 and 360")
+            arr_model = arr.get("transposition_model")
+            if arr_model is not None and str(arr_model).strip().lower() not in TRANSPOSITION_MODELS:
+                valid = ", ".join(TRANSPOSITION_MODELS)
+                raise ValueError(f"'pv_arrays[{i}].transposition_model' must be one of: {valid}")
     if cfg["annual_consumption_kwh"] <= 0:
         raise ValueError("'annual_consumption_kwh' must be > 0")
     if cfg["battery_kwh"] < 0:
@@ -134,6 +139,9 @@ def validate_config(cfg: dict[str, Any]) -> None:
         raise ValueError("'pv_degradation_rate' must be between 0 (inclusive) and 1 (exclusive)")
     if cfg["resolution"] not in ("h", "15min"):
         raise ValueError("'resolution' must be 'h' or '15min'")
+    if str(cfg["transposition_model"]).strip().lower() not in TRANSPOSITION_MODELS:
+        valid = ", ".join(TRANSPOSITION_MODELS)
+        raise ValueError(f"'transposition_model' must be one of: {valid}")
     overrides = cfg.get("pv_loss_overrides")
     if overrides is not None:
         if not isinstance(overrides, dict):
@@ -171,7 +179,7 @@ def normalise_pv_arrays(arrays: list[dict[str, Any]] | None, cfg: dict[str, Any]
     default_tilt = cfg.get("tilt") if cfg.get("tilt") is not None else estimate_optimal_tilt(lat)
     default_azimuth = cfg.get("azimuth") if cfg.get("azimuth") is not None else default_azimuth_fn(lat)
 
-    tracking_passthrough_keys = (
+    passthrough_keys = (
         "tracking",
         "axis_tilt",
         "axis_azimuth",
@@ -180,6 +188,7 @@ def normalise_pv_arrays(arrays: list[dict[str, Any]] | None, cfg: dict[str, Any]
         "gcr",
         "cross_axis_tilt",
         "dual_axis_max_tilt",
+        "transposition_model",
     )
 
     normalized: list[dict[str, Any]] = []
@@ -190,7 +199,7 @@ def normalise_pv_arrays(arrays: list[dict[str, Any]] | None, cfg: dict[str, Any]
             "tilt": float(arr.get("tilt", default_tilt)),
             "azimuth": float(arr.get("azimuth", default_azimuth)),
         }
-        for key in tracking_passthrough_keys:
+        for key in passthrough_keys:
             if key in arr:
                 entry[key] = arr[key]
         normalized.append(entry)

--- a/breos/app_inputs.py
+++ b/breos/app_inputs.py
@@ -105,7 +105,12 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
     location = Location(resolved.lat, resolved.lon, tz=resolved.timezone)
     freq = cfg["resolution"]
     loss_overrides = cfg["pv_loss_overrides"]
-    transposition_model = cfg["transposition_model"]
+    sky_kwargs = {
+        "transposition_model": cfg["transposition_model"],
+        "albedo": cfg["albedo"],
+        "surface_type": cfg["surface_type"],
+        "model_perez": cfg["model_perez"],
+    }
 
     if resolved.pv_arrays:
         return calculate_multi_array_production(
@@ -114,7 +119,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             arrays=resolved.pv_arrays,
             freq=freq,
             loss_overrides=loss_overrides,
-            transposition_model=transposition_model,
+            **sky_kwargs,
         )
 
     if resolved.tracking == "fixed":
@@ -127,7 +132,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             pv_params=resolved.pv_params,
             freq=freq,
             loss_overrides=loss_overrides,
-            transposition_model=transposition_model,
+            **sky_kwargs,
         )
     else:
         dc_1mod = calculate_pv_production_dc_tracking(
@@ -145,7 +150,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             pv_params=resolved.pv_params,
             freq=freq,
             loss_overrides=loss_overrides,
-            transposition_model=transposition_model,
+            **sky_kwargs,
         )
     return dc_1mod * cfg["n_modules"]
 

--- a/breos/app_inputs.py
+++ b/breos/app_inputs.py
@@ -105,6 +105,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
     location = Location(resolved.lat, resolved.lon, tz=resolved.timezone)
     freq = cfg["resolution"]
     loss_overrides = cfg["pv_loss_overrides"]
+    transposition_model = cfg["transposition_model"]
 
     if resolved.pv_arrays:
         return calculate_multi_array_production(
@@ -113,6 +114,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             arrays=resolved.pv_arrays,
             freq=freq,
             loss_overrides=loss_overrides,
+            transposition_model=transposition_model,
         )
 
     if resolved.tracking == "fixed":
@@ -125,6 +127,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             pv_params=resolved.pv_params,
             freq=freq,
             loss_overrides=loss_overrides,
+            transposition_model=transposition_model,
         )
     else:
         dc_1mod = calculate_pv_production_dc_tracking(
@@ -142,6 +145,7 @@ def build_dc_system_base(cfg: dict[str, Any], resolved: ResolvedAppConfig, weath
             pv_params=resolved.pv_params,
             freq=freq,
             loss_overrides=loss_overrides,
+            transposition_model=transposition_model,
         )
     return dc_1mod * cfg["n_modules"]
 

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -15,7 +15,7 @@ from breos.app_config import resolve_app_config
 from breos.load_profiles import PROFILE_ALIASES, PROFILE_NAMES
 from breos.pv_modules import MODULES
 from breos.resources import load_config_json
-from breos.solar import TRANSPOSITION_MODELS
+from breos.solar import PEREZ_MODELS, SURFACE_TYPES, TRANSPOSITION_MODELS
 
 
 def _package_version() -> str:
@@ -64,6 +64,9 @@ def _build_config(args: argparse.Namespace) -> dict[str, Any]:
     _add_override(overrides, "tilt", args.tilt)
     _add_override(overrides, "azimuth", args.azimuth)
     _add_override(overrides, "transposition_model", args.transposition_model)
+    _add_override(overrides, "albedo", args.albedo)
+    _add_override(overrides, "surface_type", args.surface_type)
+    _add_override(overrides, "model_perez", args.model_perez)
     _add_override(overrides, "resolution", args.resolution)
     _add_override(overrides, "projection_years", args.projection_years)
     _add_override(overrides, "inflation_rate", args.inflation_rate)
@@ -124,6 +127,9 @@ def _resolved_config_summary(config: dict[str, Any]) -> dict[str, Any]:
             "tilt": resolved.tilt,
             "azimuth": resolved.azimuth,
             "transposition_model": cfg["transposition_model"],
+            "albedo": cfg["albedo"],
+            "surface_type": cfg["surface_type"],
+            "model_perez": cfg["model_perez"],
             "pv_loss_overrides": cfg["pv_loss_overrides"],
         },
         "inverter": {
@@ -370,6 +376,20 @@ def build_parser() -> argparse.ArgumentParser:
         dest="transposition_model",
         choices=TRANSPOSITION_MODELS,
         help="Sky-diffusion model for POA transposition (default: isotropic).",
+    )
+    run.add_argument(
+        "--albedo", type=float, help="Ground reflectance 0-1 (default: pvlib 0.25). Excludes --surface-type."
+    )
+    run.add_argument(
+        "--surface-type",
+        choices=SURFACE_TYPES,
+        help="Named ground cover mapped to an albedo (alternative to --albedo).",
+    )
+    run.add_argument(
+        "--perez-model",
+        dest="model_perez",
+        choices=PEREZ_MODELS,
+        help="Perez coefficient set (only used with --transposition-model perez).",
     )
     run.add_argument("--resolution", choices=("h", "15min"), help="Simulation time resolution.")
     run.add_argument("--projection-years", type=int, help="Economic projection horizon.")

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -15,6 +15,7 @@ from breos.app_config import resolve_app_config
 from breos.load_profiles import PROFILE_ALIASES, PROFILE_NAMES
 from breos.pv_modules import MODULES
 from breos.resources import load_config_json
+from breos.solar import TRANSPOSITION_MODELS
 
 
 def _package_version() -> str:
@@ -62,6 +63,7 @@ def _build_config(args: argparse.Namespace) -> dict[str, Any]:
     _add_override(overrides, "rlp_directory", str(args.rlp_directory) if args.rlp_directory else None)
     _add_override(overrides, "tilt", args.tilt)
     _add_override(overrides, "azimuth", args.azimuth)
+    _add_override(overrides, "transposition_model", args.transposition_model)
     _add_override(overrides, "resolution", args.resolution)
     _add_override(overrides, "projection_years", args.projection_years)
     _add_override(overrides, "inflation_rate", args.inflation_rate)
@@ -121,6 +123,7 @@ def _resolved_config_summary(config: dict[str, Any]) -> dict[str, Any]:
             "arrays": resolved.pv_arrays or None,
             "tilt": resolved.tilt,
             "azimuth": resolved.azimuth,
+            "transposition_model": cfg["transposition_model"],
             "pv_loss_overrides": cfg["pv_loss_overrides"],
         },
         "inverter": {
@@ -361,6 +364,13 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--rlp-directory", type=Path, help="Directory containing licensed external RLP CSV files.")
     run.add_argument("--tilt", type=float, help="PV tilt angle in degrees.")
     run.add_argument("--azimuth", type=float, help="PV surface azimuth in degrees.")
+    run.add_argument(
+        "--transposition-model",
+        "--sky-model",
+        dest="transposition_model",
+        choices=TRANSPOSITION_MODELS,
+        help="Sky-diffusion model for POA transposition (default: isotropic).",
+    )
     run.add_argument("--resolution", choices=("h", "15min"), help="Simulation time resolution.")
     run.add_argument("--projection-years", type=int, help="Economic projection horizon.")
     run.add_argument("--inflation-rate", type=float, help="Annual electricity price inflation.")

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 import pvlib
+from pvlib.albedo import SURFACE_ALBEDOS
 from pvlib.location import Location
 
 from breos.utils import get_hours_per_step
@@ -51,6 +52,27 @@ TRANSPOSITION_MODELS = (
 )
 DEFAULT_TRANSPOSITION_MODEL = "isotropic"
 
+# Perez sky-diffusion coefficient sets accepted by pvlib's perez model. Only
+# used when ``transposition_model == "perez"``; the default matches pvlib.
+PEREZ_MODELS = (
+    "allsitescomposite1990",
+    "allsitescomposite1988",
+    "sandiacomposite1988",
+    "usacomposite1988",
+    "france1988",
+    "phoenix1988",
+    "elmonte1988",
+    "osage1988",
+    "albuquerque1988",
+    "capecanaveral1988",
+    "albany1988",
+)
+DEFAULT_PEREZ_MODEL = "allsitescomposite1990"
+
+# Named ground-cover types pvlib maps to a ground reflectance (albedo); an
+# alternative to supplying a numeric ``albedo`` directly.
+SURFACE_TYPES = tuple(sorted(SURFACE_ALBEDOS))
+
 
 def _resolve_transposition_model(model: str) -> str:
     """Normalise and validate a sky-diffusion transposition model name."""
@@ -59,6 +81,30 @@ def _resolve_transposition_model(model: str) -> str:
         valid = ", ".join(TRANSPOSITION_MODELS)
         raise ValueError(f"Unknown transposition model {model!r}. Valid models: {valid}")
     return normalised
+
+
+def _resolve_perez_model(model_perez: str) -> str:
+    """Validate the Perez coefficient set name."""
+    if model_perez not in PEREZ_MODELS:
+        valid = ", ".join(PEREZ_MODELS)
+        raise ValueError(f"Unknown Perez coefficient model {model_perez!r}. Valid models: {valid}")
+    return model_perez
+
+
+def _resolve_ground_reflectance(albedo, surface_type):
+    """Validate the ground-reflectance inputs and return ``(albedo, surface_type)``.
+
+    Accepts either a numeric ``albedo`` (0-1) or a named ``surface_type`` from
+    ``SURFACE_TYPES`` (which pvlib maps to an albedo), but not both.
+    """
+    if albedo is not None and surface_type is not None:
+        raise ValueError("Set either 'albedo' or 'surface_type', not both.")
+    if surface_type is not None and surface_type not in SURFACE_ALBEDOS:
+        valid = ", ".join(SURFACE_TYPES)
+        raise ValueError(f"Unknown surface_type {surface_type!r}. Valid types: {valid}")
+    if albedo is not None and not 0.0 <= albedo <= 1.0:
+        raise ValueError(f"albedo must be between 0 and 1, got {albedo!r}")
+    return albedo, surface_type
 
 
 @dataclass
@@ -123,6 +169,9 @@ def _compute_effective_irradiance_and_cell_temp(
     surface_tilt,
     surface_azimuth,
     transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
+    albedo: Optional[float] = None,
+    surface_type: Optional[str] = None,
+    model_perez: str = DEFAULT_PEREZ_MODEL,
 ):
     """Compute effective POA irradiance (with IAM) and cell temperature.
 
@@ -131,9 +180,15 @@ def _compute_effective_irradiance_and_cell_temp(
 
     ``transposition_model`` selects the sky-diffusion model (see
     ``TRANSPOSITION_MODELS``); the default ``"isotropic"`` reproduces prior
-    behaviour bit-for-bit.
+    behaviour bit-for-bit. ``albedo`` (0-1) or ``surface_type`` (see
+    ``SURFACE_TYPES``) sets the ground reflectance for the ground-diffuse
+    component; when neither is given pvlib's 0.25 default applies.
+    ``model_perez`` selects the Perez coefficient set (only used by the
+    ``"perez"`` model).
     """
     model = _resolve_transposition_model(transposition_model)
+    albedo, surface_type = _resolve_ground_reflectance(albedo, surface_type)
+    model_perez = _resolve_perez_model(model_perez)
     dni, ghi, dhi = _extract_irradiance(weather_aligned)
     temp_air, wind_speed = _extract_met_data(weather_aligned)
 
@@ -147,6 +202,14 @@ def _compute_effective_irradiance_and_cell_temp(
     dni_extra = pvlib.irradiance.get_extra_radiation(solarpos.index)
     airmass = pvlib.atmosphere.get_relative_airmass(solarpos.apparent_zenith)
 
+    # Only forward ground-reflectance overrides when set, so the default path
+    # keeps pvlib's built-in albedo and stays bit-for-bit identical.
+    ground_kwargs: Dict[str, Any] = {}
+    if albedo is not None:
+        ground_kwargs["albedo"] = albedo
+    if surface_type is not None:
+        ground_kwargs["surface_type"] = surface_type
+
     poa = pvlib.irradiance.get_total_irradiance(
         surface_tilt=surface_tilt,
         surface_azimuth=surface_azimuth,
@@ -158,6 +221,8 @@ def _compute_effective_irradiance_and_cell_temp(
         dni_extra=dni_extra,
         airmass=airmass,
         model=model,
+        model_perez=model_perez,
+        **ground_kwargs,
     )
 
     poa_direct = np.nan_to_num(poa["poa_direct"].values, nan=0.0)
@@ -265,6 +330,9 @@ def calculate_pv_production_dc(
     verbose: bool = False,
     loss_overrides: Optional[Dict[str, float]] = None,
     transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
+    albedo: Optional[float] = None,
+    surface_type: Optional[str] = None,
+    model_perez: str = DEFAULT_PEREZ_MODEL,
 ) -> pd.Series:
     """
     Calculate PV DC production from weather data (fixed-tilt array).
@@ -297,6 +365,13 @@ def calculate_pv_production_dc(
         loss_overrides: Per-component PVWatts loss overrides (percent)
         transposition_model: Sky-diffusion model for POA transposition
             (one of ``TRANSPOSITION_MODELS``); defaults to ``"isotropic"``.
+        albedo: Ground reflectance (0-1) for the ground-diffuse component;
+            ``None`` uses pvlib's 0.25 default. Mutually exclusive with
+            ``surface_type``.
+        surface_type: Named ground cover (one of ``SURFACE_TYPES``) mapped to
+            an albedo by pvlib; an alternative to ``albedo``.
+        model_perez: Perez coefficient set (one of ``PEREZ_MODELS``); only
+            used when ``transposition_model`` is ``"perez"``.
 
     Returns:
         pd.Series with DC power production in Watts (before inverter)
@@ -313,6 +388,9 @@ def calculate_pv_production_dc(
         surface_tilt=tilt,
         surface_azimuth=surface_azimuth,
         transposition_model=transposition_model,
+        albedo=albedo,
+        surface_type=surface_type,
+        model_perez=model_perez,
     )
     dc_power = _dc_from_poa(
         effective_irradiance,
@@ -353,6 +431,9 @@ def calculate_pv_production_dc_tracking(
     verbose: bool = False,
     loss_overrides: Optional[Dict[str, float]] = None,
     transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
+    albedo: Optional[float] = None,
+    surface_type: Optional[str] = None,
+    model_perez: str = DEFAULT_PEREZ_MODEL,
 ) -> pd.Series:
     """
     Calculate PV DC production for a tracking array (single- or dual-axis).
@@ -384,6 +465,13 @@ def calculate_pv_production_dc_tracking(
         loss_overrides: Per-component PVWatts loss overrides (percent).
         transposition_model: Sky-diffusion model for POA transposition
             (one of ``TRANSPOSITION_MODELS``); defaults to ``"isotropic"``.
+        albedo: Ground reflectance (0-1) for the ground-diffuse component;
+            ``None`` uses pvlib's 0.25 default. Mutually exclusive with
+            ``surface_type``.
+        surface_type: Named ground cover (one of ``SURFACE_TYPES``) mapped to
+            an albedo by pvlib; an alternative to ``albedo``.
+        model_perez: Perez coefficient set (one of ``PEREZ_MODELS``); only
+            used when ``transposition_model`` is ``"perez"``.
 
     Returns:
         pd.Series with DC power production in Watts (before inverter).
@@ -429,6 +517,9 @@ def calculate_pv_production_dc_tracking(
         surface_tilt=surface_tilt,
         surface_azimuth=surface_azimuth,
         transposition_model=transposition_model,
+        albedo=albedo,
+        surface_type=surface_type,
+        model_perez=model_perez,
     )
     dc_power = _dc_from_poa(
         effective_irradiance,
@@ -487,6 +578,9 @@ def calculate_pv_production_tmy(
     freq: str = "h",
     verbose: bool = True,
     transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
+    albedo: Optional[float] = None,
+    surface_type: Optional[str] = None,
+    model_perez: str = DEFAULT_PEREZ_MODEL,
 ) -> pd.Series:
     """
     Calculate PV DC production from TMY data.
@@ -517,6 +611,9 @@ def calculate_pv_production_tmy(
         degradation_rate=0.0,  # TMY doesn't include degradation
         verbose=verbose,
         transposition_model=transposition_model,
+        albedo=albedo,
+        surface_type=surface_type,
+        model_perez=model_perez,
     )
 
 
@@ -535,6 +632,9 @@ def calculate_pv_production_ac(
     inverter_efficiency: float = 0.96,
     verbose: bool = False,
     transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
+    albedo: Optional[float] = None,
+    surface_type: Optional[str] = None,
+    model_perez: str = DEFAULT_PEREZ_MODEL,
 ) -> pd.Series:
     """
     Calculate PV AC production from weather data.
@@ -578,6 +678,9 @@ def calculate_pv_production_ac(
         start_year=start_year,
         verbose=False,
         transposition_model=transposition_model,
+        albedo=albedo,
+        surface_type=surface_type,
+        model_perez=model_perez,
     )
 
     pv_peak_power_w = n_modules * pv_params.Mpp
@@ -720,6 +823,9 @@ def calculate_multi_array_production(
     verbose: bool = False,
     loss_overrides: Optional[Dict[str, float]] = None,
     transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
+    albedo: Optional[float] = None,
+    surface_type: Optional[str] = None,
+    model_perez: str = DEFAULT_PEREZ_MODEL,
 ) -> pd.Series:
     """
     Calculate combined DC production from multiple PV arrays.
@@ -734,8 +840,9 @@ def calculate_multi_array_production(
             use ``tilt`` and ``azimuth``. Single-axis arrays can also set
             ``axis_tilt``, ``axis_azimuth``, ``max_angle``, ``backtrack``,
             ``gcr``, and ``cross_axis_tilt``. Dual-axis arrays can set
-            ``dual_axis_max_tilt``. Any array may set ``transposition_model``
-            to override the function-level default for that array.
+            ``dual_axis_max_tilt``. Any array may also set
+            ``transposition_model``, ``albedo``/``surface_type``, or
+            ``model_perez`` to override the function-level defaults.
         freq: Time frequency ('h' or '15min')
         degradation_rate: Annual degradation rate
         current_year: Current simulation year
@@ -744,6 +851,11 @@ def calculate_multi_array_production(
         loss_overrides: Per-component PVWatts loss overrides (percent)
         transposition_model: Default sky-diffusion model for arrays that do
             not set their own (one of ``TRANSPOSITION_MODELS``).
+        albedo: Default ground reflectance (0-1); arrays may override with
+            their own ``albedo`` or ``surface_type``.
+        surface_type: Default named ground cover (one of ``SURFACE_TYPES``);
+            mutually exclusive with ``albedo``.
+        model_perez: Default Perez coefficient set (one of ``PEREZ_MODELS``).
 
     Returns:
         pd.Series with total DC power (watts)
@@ -765,6 +877,9 @@ def calculate_multi_array_production(
         pv_params = get_module(mod_name)
         tracking = arr.get("tracking", "fixed")
         arr_transposition = arr.get("transposition_model", transposition_model)
+        arr_albedo = arr.get("albedo", albedo)
+        arr_surface_type = arr.get("surface_type", surface_type)
+        arr_model_perez = arr.get("model_perez", model_perez)
 
         if tracking == "fixed":
             tilt = arr.get("tilt", 35)
@@ -787,6 +902,9 @@ def calculate_multi_array_production(
                 verbose=False,
                 loss_overrides=loss_overrides,
                 transposition_model=arr_transposition,
+                albedo=arr_albedo,
+                surface_type=arr_surface_type,
+                model_perez=arr_model_perez,
             )
         elif tracking in ("single_axis", "dual_axis"):
             if verbose:
@@ -819,6 +937,9 @@ def calculate_multi_array_production(
                 verbose=False,
                 loss_overrides=loss_overrides,
                 transposition_model=arr_transposition,
+                albedo=arr_albedo,
+                surface_type=arr_surface_type,
+                model_perez=arr_model_perez,
             )
         else:
             raise ValueError(

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -35,6 +35,31 @@ DEFAULT_PVWATTS_LOSSES: Dict[str, float] = {
     "availability": 3.0,
 }
 
+# Sky-diffusion (transposition) models for projecting GHI/DHI/DNI onto the
+# plane of array, as supported by pvlib.irradiance.get_total_irradiance.
+# ``isotropic`` is the simple, robust baseline (and the default); the
+# anisotropic models are more accurate on clear days but need extra inputs
+# (extraterrestrial DNI and, for the Perez variants, relative airmass).
+TRANSPOSITION_MODELS = (
+    "isotropic",
+    "klucher",
+    "haydavies",
+    "reindl",
+    "king",
+    "perez",
+    "perez-driesse",
+)
+DEFAULT_TRANSPOSITION_MODEL = "isotropic"
+
+
+def _resolve_transposition_model(model: str) -> str:
+    """Normalise and validate a sky-diffusion transposition model name."""
+    normalised = str(model).strip().lower()
+    if normalised not in TRANSPOSITION_MODELS:
+        valid = ", ".join(TRANSPOSITION_MODELS)
+        raise ValueError(f"Unknown transposition model {model!r}. Valid models: {valid}")
+    return normalised
+
 
 @dataclass
 class PVModuleParams:
@@ -97,17 +122,30 @@ def _compute_effective_irradiance_and_cell_temp(
     solarpos: pd.DataFrame,
     surface_tilt,
     surface_azimuth,
+    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
 ):
     """Compute effective POA irradiance (with IAM) and cell temperature.
 
     surface_tilt / surface_azimuth may be scalars (fixed) or per-timestep arrays/Series
     (tracking). Uses pvlib.irradiance.get_total_irradiance which is array-aware.
+
+    ``transposition_model`` selects the sky-diffusion model (see
+    ``TRANSPOSITION_MODELS``); the default ``"isotropic"`` reproduces prior
+    behaviour bit-for-bit.
     """
+    model = _resolve_transposition_model(transposition_model)
     dni, ghi, dhi = _extract_irradiance(weather_aligned)
     temp_air, wind_speed = _extract_met_data(weather_aligned)
 
     aoi = pvlib.irradiance.aoi(surface_tilt, surface_azimuth, solarpos.apparent_zenith, solarpos.azimuth)
     iam = pvlib.iam.ashrae(aoi)
+
+    # Hay-Davies, Reindl, and the Perez variants need extraterrestrial DNI; the
+    # Perez variants additionally need relative airmass. Isotropic, Klucher, and
+    # King ignore both, and passing them does not change the isotropic result,
+    # so computing them unconditionally keeps the call site simple.
+    dni_extra = pvlib.irradiance.get_extra_radiation(solarpos.index)
+    airmass = pvlib.atmosphere.get_relative_airmass(solarpos.apparent_zenith)
 
     poa = pvlib.irradiance.get_total_irradiance(
         surface_tilt=surface_tilt,
@@ -117,7 +155,9 @@ def _compute_effective_irradiance_and_cell_temp(
         dni=dni,
         ghi=ghi,
         dhi=dhi,
-        model="isotropic",
+        dni_extra=dni_extra,
+        airmass=airmass,
+        model=model,
     )
 
     poa_direct = np.nan_to_num(poa["poa_direct"].values, nan=0.0)
@@ -224,6 +264,7 @@ def calculate_pv_production_dc(
     start_year: Optional[int] = None,
     verbose: bool = False,
     loss_overrides: Optional[Dict[str, float]] = None,
+    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
 ) -> pd.Series:
     """
     Calculate PV DC production from weather data (fixed-tilt array).
@@ -253,6 +294,9 @@ def calculate_pv_production_dc(
         current_year: Current simulation year (for age-based degradation)
         start_year: Year system was installed (for age calculation)
         verbose: Whether to print production summary
+        loss_overrides: Per-component PVWatts loss overrides (percent)
+        transposition_model: Sky-diffusion model for POA transposition
+            (one of ``TRANSPOSITION_MODELS``); defaults to ``"isotropic"``.
 
     Returns:
         pd.Series with DC power production in Watts (before inverter)
@@ -264,7 +308,11 @@ def calculate_pv_production_dc(
 
     times, solarpos, weather_aligned = _prepare_solarpos_and_weather(weather_data, location, freq)
     effective_irradiance, temp_cell = _compute_effective_irradiance_and_cell_temp(
-        weather_aligned, solarpos, surface_tilt=tilt, surface_azimuth=surface_azimuth
+        weather_aligned,
+        solarpos,
+        surface_tilt=tilt,
+        surface_azimuth=surface_azimuth,
+        transposition_model=transposition_model,
     )
     dc_power = _dc_from_poa(
         effective_irradiance,
@@ -304,6 +352,7 @@ def calculate_pv_production_dc_tracking(
     start_year: Optional[int] = None,
     verbose: bool = False,
     loss_overrides: Optional[Dict[str, float]] = None,
+    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
 ) -> pd.Series:
     """
     Calculate PV DC production for a tracking array (single- or dual-axis).
@@ -332,6 +381,9 @@ def calculate_pv_production_dc_tracking(
         current_year: Current simulation year (for age-based degradation).
         start_year: Year system was installed.
         verbose: Whether to print production summary.
+        loss_overrides: Per-component PVWatts loss overrides (percent).
+        transposition_model: Sky-diffusion model for POA transposition
+            (one of ``TRANSPOSITION_MODELS``); defaults to ``"isotropic"``.
 
     Returns:
         pd.Series with DC power production in Watts (before inverter).
@@ -372,7 +424,11 @@ def calculate_pv_production_dc_tracking(
         surface_azimuth = np.where(below_horizon, axis_azimuth, surface_azimuth)
 
     effective_irradiance, temp_cell = _compute_effective_irradiance_and_cell_temp(
-        weather_aligned, solarpos, surface_tilt=surface_tilt, surface_azimuth=surface_azimuth
+        weather_aligned,
+        solarpos,
+        surface_tilt=surface_tilt,
+        surface_azimuth=surface_azimuth,
+        transposition_model=transposition_model,
     )
     dc_power = _dc_from_poa(
         effective_irradiance,
@@ -430,6 +486,7 @@ def calculate_pv_production_tmy(
     pv_params: Optional[PVModuleParams] = None,
     freq: str = "h",
     verbose: bool = True,
+    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
 ) -> pd.Series:
     """
     Calculate PV DC production from TMY data.
@@ -459,6 +516,7 @@ def calculate_pv_production_tmy(
         freq=freq,
         degradation_rate=0.0,  # TMY doesn't include degradation
         verbose=verbose,
+        transposition_model=transposition_model,
     )
 
 
@@ -476,6 +534,7 @@ def calculate_pv_production_ac(
     inverter_loading_ratio: float = 1.25,
     inverter_efficiency: float = 0.96,
     verbose: bool = False,
+    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
 ) -> pd.Series:
     """
     Calculate PV AC production from weather data.
@@ -518,6 +577,7 @@ def calculate_pv_production_ac(
         current_year=current_year,
         start_year=start_year,
         verbose=False,
+        transposition_model=transposition_model,
     )
 
     pv_peak_power_w = n_modules * pv_params.Mpp
@@ -659,6 +719,7 @@ def calculate_multi_array_production(
     start_year: Optional[int] = None,
     verbose: bool = False,
     loss_overrides: Optional[Dict[str, float]] = None,
+    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
 ) -> pd.Series:
     """
     Calculate combined DC production from multiple PV arrays.
@@ -673,12 +734,16 @@ def calculate_multi_array_production(
             use ``tilt`` and ``azimuth``. Single-axis arrays can also set
             ``axis_tilt``, ``axis_azimuth``, ``max_angle``, ``backtrack``,
             ``gcr``, and ``cross_axis_tilt``. Dual-axis arrays can set
-            ``dual_axis_max_tilt``.
+            ``dual_axis_max_tilt``. Any array may set ``transposition_model``
+            to override the function-level default for that array.
         freq: Time frequency ('h' or '15min')
         degradation_rate: Annual degradation rate
         current_year: Current simulation year
         start_year: Installation year
         verbose: Print summary
+        loss_overrides: Per-component PVWatts loss overrides (percent)
+        transposition_model: Default sky-diffusion model for arrays that do
+            not set their own (one of ``TRANSPOSITION_MODELS``).
 
     Returns:
         pd.Series with total DC power (watts)
@@ -699,6 +764,7 @@ def calculate_multi_array_production(
         mod_name = arr.get("module", "Generic_400W")
         pv_params = get_module(mod_name)
         tracking = arr.get("tracking", "fixed")
+        arr_transposition = arr.get("transposition_model", transposition_model)
 
         if tracking == "fixed":
             tilt = arr.get("tilt", 35)
@@ -720,6 +786,7 @@ def calculate_multi_array_production(
                 start_year=start_year,
                 verbose=False,
                 loss_overrides=loss_overrides,
+                transposition_model=arr_transposition,
             )
         elif tracking in ("single_axis", "dual_axis"):
             if verbose:
@@ -751,6 +818,7 @@ def calculate_multi_array_production(
                 start_year=start_year,
                 verbose=False,
                 loss_overrides=loss_overrides,
+                transposition_model=arr_transposition,
             )
         else:
             raise ValueError(

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -35,6 +35,7 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `gcr` | `0.35` | Ground coverage ratio for single-axis tracking |
 | `cross_axis_tilt` | `0.0` | Cross-axis terrain slope for single-axis tracking |
 | `dual_axis_max_tilt` | `90.0` | Maximum panel tilt for dual-axis tracking |
+| `transposition_model` | `"isotropic"` | Sky-diffusion model used to project GHI/DHI/DNI onto the plane of array (see [below](#sky-diffusion-transposition-model)) |
 | `resolution` | `"h"` | Time resolution (`"h"` or `"15min"`) |
 | `projection_years` | `20` | Economic projection horizon |
 | `cost_preset` | `None` | Cost preset key from packaged defaults |
@@ -143,6 +144,39 @@ breos.App({
 
 When `pv_arrays` is set, `n_modules` is computed from the array totals and
 any explicit `n_modules` key is ignored.
+
+Each array may also set its own `transposition_model`, overriding the
+top-level default for that array only.
+
+## Sky-diffusion (transposition) model
+
+To compute plane-of-array (POA) irradiance, BREOS transposes the horizontal
+irradiance components (GHI/DHI/DNI) onto the tilted module surface using a
+*sky-diffusion* (transposition) model. The default, `"isotropic"`, treats
+diffuse sky radiance as uniform — simple and robust, but it underestimates POA
+on clear days because it ignores circumsolar and horizon brightening.
+
+Anisotropic models capture those effects and are generally more accurate; over
+a full year, Perez can raise modeled POA by a few percent relative to
+isotropic at mid-latitude sites. Set `transposition_model` to any of:
+
+`isotropic` (default), `klucher`, `haydavies`, `reindl`, `king`, `perez`,
+`perez-driesse`.
+
+```python
+breos.App({
+    "location": "porto",
+    "n_modules": 10,
+    "annual_consumption_kwh": 4000,
+    "transposition_model": "perez",
+})
+```
+
+The extra inputs the anisotropic models need (extraterrestrial DNI and, for
+the Perez variants, relative airmass) are derived internally from the time
+index and solar position, so no additional weather columns are required. All
+models are provided by
+[`pvlib.irradiance.get_total_irradiance`](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.get_total_irradiance.html).
 
 ## Cost and emissions presets
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -36,6 +36,9 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `cross_axis_tilt` | `0.0` | Cross-axis terrain slope for single-axis tracking |
 | `dual_axis_max_tilt` | `90.0` | Maximum panel tilt for dual-axis tracking |
 | `transposition_model` | `"isotropic"` | Sky-diffusion model used to project GHI/DHI/DNI onto the plane of array (see [below](#sky-diffusion-transposition-model)) |
+| `albedo` | `None` | Ground reflectance (0-1) for the ground-diffuse component; `None` uses pvlib's 0.25 default. Mutually exclusive with `surface_type` |
+| `surface_type` | `None` | Named ground cover (e.g. `"snow"`, `"sea"`, `"grass"`) mapped to an albedo; an alternative to `albedo` |
+| `model_perez` | `"allsitescomposite1990"` | Perez coefficient set; only used when `transposition_model = "perez"` |
 | `resolution` | `"h"` | Time resolution (`"h"` or `"15min"`) |
 | `projection_years` | `20` | Economic projection horizon |
 | `cost_preset` | `None` | Cost preset key from packaged defaults |
@@ -177,6 +180,33 @@ the Perez variants, relative airmass) are derived internally from the time
 index and solar position, so no additional weather columns are required. All
 models are provided by
 [`pvlib.irradiance.get_total_irradiance`](https://pvlib-python.readthedocs.io/en/stable/reference/generated/pvlib.irradiance.get_total_irradiance.html).
+
+### Ground reflectance (albedo)
+
+Every transposition model adds a ground-reflected diffuse component, which
+depends on how reflective the ground around the array is. By default BREOS
+uses pvlib's 0.25 albedo. If you know your site, set it explicitly — either a
+numeric `albedo` (0-1) or a named `surface_type` that pvlib maps to an albedo
+(`"snow"` ≈ 0.65, `"sea"`, `"grass"`, `"sand"`, `"urban"`, …). Set one or the
+other, not both. A snowy or sandy foreground can add a few percent to annual
+POA on tilted arrays.
+
+```python
+breos.App({
+    "location": "berlin",
+    "n_modules": 10,
+    "annual_consumption_kwh": 4000,
+    "transposition_model": "perez",
+    "surface_type": "snow",     # or: "albedo": 0.65
+})
+```
+
+### Perez coefficient set
+
+The `perez` model uses an empirically fitted coefficient set. `model_perez`
+selects it (default `"allsitescomposite1990"`); the other sets are
+location/era-specific fits from the Perez papers and are only consulted when
+`transposition_model = "perez"`.
 
 ## Cost and emissions presets
 

--- a/docs/getting-started/recipes.md
+++ b/docs/getting-started/recipes.md
@@ -103,7 +103,12 @@ annual_consumption_kwh = 4000
 cost_preset = "residential_pt"
 emissions_country = "PT"
 transposition_model = "perez"
+surface_type = "grass"          # or a numeric albedo, e.g. albedo = 0.2
 ```
+
+`surface_type` (or a numeric `albedo`) sets the ground reflectance that feeds
+the ground-diffuse component; a snowy or sandy foreground (`"snow"`, `"sand"`)
+raises annual yield further. Leave both unset to keep pvlib's 0.25 default.
 
 From the CLI, the equivalent flag is `--transposition-model perez`
 (alias `--sky-model`).

--- a/docs/getting-started/recipes.md
+++ b/docs/getting-started/recipes.md
@@ -89,6 +89,25 @@ tilt = 10
 azimuth = 270   # west
 ```
 
+## Anisotropic sky-diffusion model
+
+The default `isotropic` transposition underestimates plane-of-array
+irradiance on clear days. Switch to an anisotropic model — here Perez — to
+capture circumsolar and horizon brightening. No extra weather inputs are
+needed; see [Sky-diffusion model](configuration.md#sky-diffusion-transposition-model):
+
+```toml
+location = "porto"
+n_modules = 10
+annual_consumption_kwh = 4000
+cost_preset = "residential_pt"
+emissions_country = "PT"
+transposition_model = "perez"
+```
+
+From the CLI, the equivalent flag is `--transposition-model perez`
+(alias `--sky-model`).
+
 ## 15-minute resolution
 
 Hourly weather is interpolated to 15-minute steps (Makima), and the bundled

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -68,6 +68,27 @@ class TestAppValidation:
         with pytest.raises(ValueError, match="azimuth"):
             App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "azimuth": 400})
 
+    def test_invalid_transposition_model(self):
+        with pytest.raises(ValueError, match="transposition_model"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "transposition_model": "not_a_model",
+                }
+            )
+
+    def test_invalid_per_array_transposition_model(self):
+        with pytest.raises(ValueError, match=r"pv_arrays\[0\].transposition_model"):
+            App(
+                {
+                    "location": "porto",
+                    "annual_consumption_kwh": 4000,
+                    "pv_arrays": [{"modules": 5, "transposition_model": "not_a_model"}],
+                }
+            )
+
     def test_invalid_inverter_efficiency(self):
         with pytest.raises(ValueError, match="inverter_efficiency"):
             App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "inverter_efficiency": 1.5})
@@ -219,6 +240,24 @@ class TestAppValidation:
         # A 10% SOC window stores a tenth of the energy of the default
         # 10-90% window, so grid independence must drop
         assert narrow_gi < default_gi
+
+    def test_transposition_model_reaches_simulation(self, _patch_weather):
+        def _run(model):
+            app = App(
+                {
+                    "location": "porto",
+                    "n_modules": 6,
+                    "annual_consumption_kwh": 3000,
+                    "projection_years": 1,
+                    "transposition_model": model,
+                }
+            )
+            app.simulate()
+            return app.result()["pv_production_kwh"]
+
+        # The model must flow all the way through App.simulate(); an
+        # anisotropic model yields a different PV total than isotropic.
+        assert _run("perez") != pytest.approx(_run("isotropic"))
 
     def test_pv_loss_overrides_increase_production(self, _patch_weather):
         def _run(overrides):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -89,6 +89,40 @@ class TestAppValidation:
                 }
             )
 
+    def test_invalid_albedo(self):
+        with pytest.raises(ValueError, match="albedo"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "albedo": 1.5})
+
+    def test_invalid_surface_type(self):
+        with pytest.raises(ValueError, match="surface_type"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "surface_type": "lava"})
+
+    def test_albedo_and_surface_type_conflict(self):
+        with pytest.raises(ValueError, match="either"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "albedo": 0.3,
+                    "surface_type": "snow",
+                }
+            )
+
+    def test_invalid_model_perez(self):
+        with pytest.raises(ValueError, match="model_perez"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "model_perez": "nope"})
+
+    def test_invalid_per_array_albedo(self):
+        with pytest.raises(ValueError, match=r"pv_arrays\[0\].albedo"):
+            App(
+                {
+                    "location": "porto",
+                    "annual_consumption_kwh": 4000,
+                    "pv_arrays": [{"modules": 5, "albedo": 9}],
+                }
+            )
+
     def test_invalid_inverter_efficiency(self):
         with pytest.raises(ValueError, match="inverter_efficiency"):
             App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "inverter_efficiency": 1.5})
@@ -258,6 +292,25 @@ class TestAppValidation:
         # The model must flow all the way through App.simulate(); an
         # anisotropic model yields a different PV total than isotropic.
         assert _run("perez") != pytest.approx(_run("isotropic"))
+
+    def test_albedo_reaches_simulation(self, _patch_weather):
+        def _run(**extra):
+            app = App(
+                {
+                    "location": "porto",
+                    "n_modules": 6,
+                    "annual_consumption_kwh": 3000,
+                    "projection_years": 1,
+                    **extra,
+                }
+            )
+            app.simulate()
+            return app.result()["pv_production_kwh"]
+
+        # A higher ground reflectance must raise PV production end-to-end.
+        assert _run(albedo=0.65) > _run()
+        # surface_type is an equivalent way to set the same albedo.
+        assert _run(surface_type="snow") == pytest.approx(_run(albedo=0.65))
 
     def test_pv_loss_overrides_increase_production(self, _patch_weather):
         def _run(overrides):

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -4,6 +4,8 @@ import pandas as pd
 import pytest
 
 from breos.solar import (
+    PEREZ_MODELS,
+    SURFACE_TYPES,
     TRANSPOSITION_MODELS,
     calculate_multi_array_production,
     calculate_pv_production_dc,
@@ -299,3 +301,80 @@ class TestTranspositionModel:
             transposition_model="isotropic",
         )
         assert per_array.sum() != pytest.approx(default_iso.sum())
+
+
+class TestGroundReflectance:
+    def _dc(self, weather, loc, pv_params, **kw):
+        return calculate_pv_production_dc(
+            weather_data=weather,
+            location=loc,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=pv_params,
+            freq="h",
+            **kw,
+        )
+
+    def test_default_albedo_unchanged(self, synthetic_weather, porto_location, pv_params):
+        # Not passing albedo must reproduce pvlib's 0.25 default exactly.
+        base = self._dc(synthetic_weather, porto_location, pv_params)
+        explicit = self._dc(synthetic_weather, porto_location, pv_params, albedo=0.25)
+        pd.testing.assert_series_equal(base, explicit)
+
+    def test_higher_albedo_raises_yield(self, synthetic_weather, porto_location, pv_params):
+        base = self._dc(synthetic_weather, porto_location, pv_params).sum()
+        snowy = self._dc(synthetic_weather, porto_location, pv_params, albedo=0.65).sum()
+        assert snowy > base
+
+    def test_surface_type_matches_equivalent_albedo(self, synthetic_weather, porto_location, pv_params):
+        # pvlib maps surface_type="snow" to albedo 0.65.
+        by_type = self._dc(synthetic_weather, porto_location, pv_params, surface_type="snow")
+        by_value = self._dc(synthetic_weather, porto_location, pv_params, albedo=0.65)
+        pd.testing.assert_series_equal(by_type, by_value)
+
+    def test_albedo_and_surface_type_conflict(self, synthetic_weather, porto_location, pv_params):
+        with pytest.raises(ValueError, match="either 'albedo' or 'surface_type'"):
+            self._dc(synthetic_weather, porto_location, pv_params, albedo=0.3, surface_type="snow")
+
+    def test_invalid_surface_type(self, synthetic_weather, porto_location, pv_params):
+        with pytest.raises(ValueError, match="Unknown surface_type"):
+            self._dc(synthetic_weather, porto_location, pv_params, surface_type="lava")
+
+    def test_albedo_out_of_range(self, synthetic_weather, porto_location, pv_params):
+        with pytest.raises(ValueError, match="albedo must be between 0 and 1"):
+            self._dc(synthetic_weather, porto_location, pv_params, albedo=1.5)
+
+    def test_all_surface_types_resolve(self, synthetic_weather, porto_location, pv_params):
+        for surface_type in SURFACE_TYPES:
+            dc = self._dc(synthetic_weather, porto_location, pv_params, surface_type=surface_type)
+            assert dc.sum() > 0, surface_type
+
+
+class TestPerezCoefficients:
+    def _perez(self, weather, loc, pv_params, model_perez):
+        return calculate_pv_production_dc(
+            weather_data=weather,
+            location=loc,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=pv_params,
+            freq="h",
+            transposition_model="perez",
+            model_perez=model_perez,
+        )
+
+    def test_coefficient_set_changes_result(self, synthetic_weather, porto_location, pv_params):
+        default = self._perez(synthetic_weather, porto_location, pv_params, "allsitescomposite1990")
+        france = self._perez(synthetic_weather, porto_location, pv_params, "france1988")
+        assert france.sum() != pytest.approx(default.sum())
+
+    def test_all_perez_sets_resolve(self, synthetic_weather, porto_location, pv_params):
+        for model_perez in PEREZ_MODELS:
+            dc = self._perez(synthetic_weather, porto_location, pv_params, model_perez)
+            assert dc.sum() > 0, model_perez
+
+    def test_invalid_perez_model(self, synthetic_weather, porto_location, pv_params):
+        with pytest.raises(ValueError, match="Unknown Perez coefficient model"):
+            self._perez(synthetic_weather, porto_location, pv_params, "not_a_set")

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from breos.solar import (
+    TRANSPOSITION_MODELS,
     calculate_multi_array_production,
     calculate_pv_production_dc,
     calculate_pv_production_dc_tracking,
@@ -238,3 +239,63 @@ class TestMultiArrayTracking:
                 arrays=arrays,
                 freq="h",
             )
+
+
+class TestTranspositionModel:
+    def _dc(self, weather, loc, pv_params, **kw):
+        return calculate_pv_production_dc(
+            weather_data=weather,
+            location=loc,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=pv_params,
+            freq="h",
+            **kw,
+        )
+
+    def test_default_matches_explicit_isotropic(self, synthetic_weather, porto_location, pv_params):
+        # The default must reproduce the prior isotropic result bit-for-bit.
+        default = self._dc(synthetic_weather, porto_location, pv_params)
+        isotropic = self._dc(synthetic_weather, porto_location, pv_params, transposition_model="isotropic")
+        pd.testing.assert_series_equal(default, isotropic)
+
+    def test_all_models_run_and_are_non_negative(self, synthetic_weather, porto_location, pv_params):
+        for model in TRANSPOSITION_MODELS:
+            dc = self._dc(synthetic_weather, porto_location, pv_params, transposition_model=model)
+            assert (dc >= -0.01).all(), model
+            assert dc.sum() > 0, model
+
+    def test_anisotropic_differs_from_isotropic(self, synthetic_weather, porto_location, pv_params):
+        # Anisotropic models raise clear-day POA, so annual energy should exceed isotropic.
+        isotropic = self._dc(synthetic_weather, porto_location, pv_params, transposition_model="isotropic").sum()
+        perez = self._dc(synthetic_weather, porto_location, pv_params, transposition_model="perez").sum()
+        assert perez > isotropic
+
+    def test_case_insensitive(self, synthetic_weather, porto_location, pv_params):
+        lower = self._dc(synthetic_weather, porto_location, pv_params, transposition_model="haydavies")
+        upper = self._dc(synthetic_weather, porto_location, pv_params, transposition_model="HayDavies")
+        pd.testing.assert_series_equal(lower, upper)
+
+    def test_invalid_model_raises(self, synthetic_weather, porto_location, pv_params):
+        with pytest.raises(ValueError, match="Unknown transposition model"):
+            self._dc(synthetic_weather, porto_location, pv_params, transposition_model="bogus")
+
+    def test_per_array_override(self, synthetic_weather, porto_location):
+        # A per-array transposition_model overrides the function-level default.
+        arrays = [{"modules": 50, "tilt": 30, "azimuth": 180, "transposition_model": "perez"}]
+        default_iso = calculate_multi_array_production(
+            weather_data=synthetic_weather,
+            location=porto_location,
+            arrays=[{"modules": 50, "tilt": 30, "azimuth": 180}],
+            freq="h",
+            transposition_model="isotropic",
+        )
+        per_array = calculate_multi_array_production(
+            weather_data=synthetic_weather,
+            location=porto_location,
+            arrays=arrays,
+            freq="h",
+            transposition_model="isotropic",
+        )
+        assert per_array.sum() != pytest.approx(default_iso.sum())


### PR DESCRIPTION
## Summary

Makes the sky-diffusion (transposition) model and its site-specific inputs configurable, instead of hardcoding the isotropic model with pvlib defaults. Targets the 0.3.2 roadmap item.

Two commits:

1. **Configurable transposition model** — a `transposition_model` option threaded through `calculate_pv_production_dc`, the tracking and multi-array variants, the TMY/AC wrappers, the `App` config surface, and the CLI (`--transposition-model` / `--sky-model`). Supports all seven models pvlib's `get_total_irradiance` dispatches to: `isotropic` (default), `klucher`, `haydavies`, `reindl`, `king`, `perez`, `perez-driesse`. The extra inputs the anisotropic models need (extraterrestrial DNI, relative airmass) are derived internally from the time index and solar position, so no new weather columns are required.

2. **Ground reflectance + Perez coefficients** — the optional site information those models can use, previously hardcoded:
   - `albedo` (0–1) or a named `surface_type` (`"snow"`, `"sea"`, `"grass"`, …) sets the ground reflectance for the ground-diffuse component used by every model (was fixed at pvlib's 0.25). The two are mutually exclusive.
   - `model_perez` selects the Perez coefficient set (used only by the `perez` model).
   - All three are App config keys with matching `--albedo` / `--surface-type` / `--perez-model` CLI flags and per-array overrides.

## Backward compatibility

The default path is **bit-for-bit unchanged**: `isotropic` is the default, `albedo` is unset (pvlib's 0.25 applies), and `model_perez` defaults to pvlib's own default. Verified empirically and guarded by tests (`test_default_matches_explicit_isotropic`, `test_default_albedo_unchanged`).

## Validation

Invalid model names, out-of-range albedo, unknown surface types, unknown Perez sets, and `albedo`+`surface_type` set together are all rejected at config-validation time (before any weather fetch). Per-array values are validated too.

## Tests

21 new tests in `test_solar.py` and `test_app.py` covering all models, ground reflectance (including `surface_type="snow"` exactly equalling `albedo=0.65`), Perez coefficient sets, end-to-end flow through `App.simulate()`, and validation. Full suite green, ruff clean.

## Docs

Config reference table + a "Sky-diffusion model" / ground-reflectance / Perez section, a recipe, README modeling-conventions note, and CHANGELOG `[Unreleased]`.
