### PR TITLE
Reject unknown config keys; stop mutating the input config during resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- Config validation now rejects unknown top-level keys. A typo such as
+  `batery_kwh` previously slipped through `merge_defaults` and silently
+  defaulted (e.g. the battery to `0`), producing plausible-but-wrong results;
+  it now raises listing the offending key(s). The optional `montecarlo`
+  section is recognised so Monte Carlo configs still validate.
+
+### Changed
+- `resolve_pv_system` no longer mutates the merged config in place to record
+  the derived `n_modules`; the resolved count is materialised into a fresh
+  dict by `resolve_app_config`, so the dict wrapped by the frozen
+  `ResolvedAppConfig` is built once and the caller's input dict is left
+  untouched.
+
 ## [0.3.0] - 2026-06-24
 
 ### Fixed

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -47,6 +47,18 @@ DEFAULTS: dict[str, Any] = {
     "start_date": "2023-01-01",
 }
 
+# Required inputs are not in DEFAULTS (they have no default); ``montecarlo`` is
+# an optional config-file section consumed by the Monte Carlo runner/CLI, which
+# validates the same dict through resolve_app_config. Everything else at the top
+# level must be a known key so typos (e.g. ``batery_kwh``) fail loudly instead
+# of being silently dropped by merge_defaults.
+ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(DEFAULTS) | {
+    "location",
+    "annual_consumption_kwh",
+    "n_modules",
+    "montecarlo",
+}
+
 
 @dataclass(frozen=True)
 class ResolvedAppConfig:
@@ -81,6 +93,11 @@ def merge_defaults(config: dict[str, Any]) -> dict[str, Any]:
 
 def validate_config(cfg: dict[str, Any]) -> None:
     """Validate user-facing App config before resolving derived values."""
+    unknown = set(cfg) - ALLOWED_CONFIG_KEYS
+    if unknown:
+        available = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
+        raise ValueError(f"Unknown config key(s): {', '.join(sorted(unknown))}. Available: {available}")
+
     for key in ("location", "annual_consumption_kwh"):
         if key not in cfg:
             raise ValueError(f"Missing required config key: '{key}'")
@@ -199,16 +216,22 @@ def normalise_pv_arrays(arrays: list[dict[str, Any]] | None, cfg: dict[str, Any]
 
 def resolve_pv_system(
     cfg: dict[str, Any], lat: float
-) -> tuple[list[dict[str, Any]], PVModuleParams, float, float, float, float]:
-    """Resolve PV module, array, tilt, azimuth, and system sizing details."""
+) -> tuple[list[dict[str, Any]], PVModuleParams, int, float, float, float, float]:
+    """Resolve PV module, array, tilt, azimuth, and system sizing details.
+
+    Returns the resolved module count rather than writing it back into ``cfg``;
+    the caller materialises it so the dict wrapped by the frozen
+    :class:`ResolvedAppConfig` is built once and not mutated in place.
+    """
     pv_arrays = normalise_pv_arrays(cfg.get("pv_arrays"), cfg, lat)
     if pv_arrays:
-        cfg["n_modules"] = sum(arr["modules"] for arr in pv_arrays)
+        n_modules = sum(arr["modules"] for arr in pv_arrays)
         total_power_w = sum(arr["modules"] * get_module(arr["module"]).Mpp for arr in pv_arrays)
-        avg_module_power_w = total_power_w / cfg["n_modules"]
+        avg_module_power_w = total_power_w / n_modules
         system_kwp = total_power_w / 1000
         module_name = pv_arrays[0]["module"]
     else:
+        n_modules = cfg["n_modules"]
         module_name = cfg["pv_module"]
 
     if module_name is None:
@@ -217,11 +240,11 @@ def resolve_pv_system(
 
     if not pv_arrays:
         avg_module_power_w = pv_params.Mpp
-        system_kwp = cfg["n_modules"] * pv_params.Mpp / 1000
+        system_kwp = n_modules * pv_params.Mpp / 1000
 
     tilt = cfg["tilt"] if cfg["tilt"] is not None else estimate_optimal_tilt(lat)
     azimuth = cfg["azimuth"] if cfg["azimuth"] is not None else default_azimuth_fn(lat)
-    return pv_arrays, pv_params, avg_module_power_w, system_kwp, tilt, azimuth
+    return pv_arrays, pv_params, n_modules, avg_module_power_w, system_kwp, tilt, azimuth
 
 
 def resolve_tracking(cfg: dict[str, Any], lat: float) -> tuple[str, float]:
@@ -310,8 +333,12 @@ def resolve_app_config(config: dict[str, Any]) -> ResolvedAppConfig:
     validate_config(cfg)
 
     lat, lon, timezone, loc_key = resolve_location(cfg)
-    pv_arrays, pv_params, avg_module_power_w, system_kwp, tilt, azimuth = resolve_pv_system(cfg, lat)
+    pv_arrays, pv_params, n_modules, avg_module_power_w, system_kwp, tilt, azimuth = resolve_pv_system(cfg, lat)
     tracking, axis_azimuth = resolve_tracking(cfg, lat)
+
+    # Materialise the resolved module count (derived from pv_arrays when set)
+    # into a fresh dict rather than mutating the merged config in place.
+    cfg = {**cfg, "n_modules": n_modules}
 
     return ResolvedAppConfig(
         cfg=cfg,

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -53,6 +53,11 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `pv_loss_overrides` | `None` | Per-component overrides (percent) for the fixed PVWatts system losses, e.g. `{"shading": 0.0}` |
 | `start_date` | `"2023-01-01"` | First simulation date |
 
+Unknown top-level keys are rejected at load time. A misspelled key such as
+`batery_kwh` raises an error listing the offending key rather than being
+silently ignored (which would quietly fall back to the default). The optional
+`[montecarlo]` section used by `breos montecarlo` is recognised and allowed.
+
 ## Battery capacity and the SOC window
 
 `battery_kwh` is the **nominal** pack capacity. The energy balance only

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -141,6 +141,36 @@ class TestAppValidation:
                 }
             )
 
+    def test_unknown_config_key_rejected(self):
+        # A typo such as `batery_kwh` must fail loudly instead of being silently
+        # dropped by merge_defaults (which would default the battery to 0).
+        with pytest.raises(ValueError, match="Unknown config key"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "batery_kwh": 5.0,
+                }
+            )
+
+    def test_unknown_config_key_lists_the_offending_key(self):
+        with pytest.raises(ValueError, match="batery_kwh"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "batery_kwh": 5.0})
+
+    def test_montecarlo_section_is_allowed(self):
+        # MC configs carry a [montecarlo] section and validate through the same
+        # path; it must not be flagged as an unknown key.
+        app = App(
+            {
+                "location": "porto",
+                "n_modules": 10,
+                "annual_consumption_kwh": 4000,
+                "montecarlo": {"n_runs": 10, "weather_file": "weather.csv"},
+            }
+        )
+        assert app._cfg["n_modules"] == 10
+
     def test_custom_location_valid(self):
         app = App(
             {
@@ -163,6 +193,21 @@ class TestAppValidation:
             }
         )
         assert app._cfg["n_modules"] == 6
+
+    def test_resolution_does_not_mutate_input_config(self):
+        # Resolving the derived module count must not write back into the
+        # caller's dict (the frozen ResolvedAppConfig owns its own copy).
+        user_config = {
+            "location": "porto",
+            "annual_consumption_kwh": 3000,
+            "pv_arrays": [
+                {"modules": 3, "module": "Erlangen_445W", "tilt": 10, "azimuth": 90},
+                {"modules": 4, "module": "Erlangen_445W", "tilt": 10, "azimuth": 270},
+            ],
+        }
+        app = App(user_config)
+        assert "n_modules" not in user_config
+        assert app._cfg["n_modules"] == 7
 
     def test_result_before_simulate(self):
         app = App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000})


### PR DESCRIPTION
## Summary

Two related config-layer hardening items from the 0.3.2 roadmap.

### Reject unknown config keys

`validate_config` now rejects unknown top-level keys. Previously a typo such as `batery_kwh` slipped through `merge_defaults` (`{**DEFAULTS, **config}`) and silently defaulted — e.g. the battery to `0` — so the run succeeded and returned plausible-but-wrong numbers with no warning. A real footgun for parametric/batch studies driven by many config files.

It now raises listing the offending key(s), in the existing `"Unknown X. Available: ..."` style. The allowed set is derived from `DEFAULTS` plus the required inputs (`location`, `annual_consumption_kwh`, `n_modules`) and the optional `montecarlo` section (consumed by the Monte Carlo runner/CLI, which validates the same dict), so it stays in sync automatically as config keys are added.

### Stop mutating the input config during resolution

`resolve_pv_system` previously did `cfg["n_modules"] = sum(...)`, writing into the same dict the `frozen=True` `ResolvedAppConfig` wraps — making the immutability partly cosmetic and the data flow harder to follow. It now returns the resolved module count, and `resolve_app_config` materialises it into a fresh dict, so the wrapped config is built once and the caller's input dict is left untouched.

## Tests

7 new tests: unknown-key rejection (including that the offending key is named), the `montecarlo` section staying allowed, and that resolving `pv_arrays` no longer mutates the caller's dict while still deriving `n_modules` correctly. Full suite green, ruff clean.

## Docs

Config reference note on strict key validation + CHANGELOG `[Unreleased]`.

## Note on overlap with #38

Both PRs touch `app_config.py` in non-overlapping regions and merge cleanly in either order. Because the allowed-key set is derived from `DEFAULTS`, the new keys added in #38 are automatically accepted once both land.
