### PR TITLE
Remove nrel-pysam: pure-scipy CEC 6-parameter fit (py3.14 unblock)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     env:
       UV_PYTHON: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dev/
 # Sphinx
 docs/_build/
 docs/api/generated/
+
+# Local-only working references (do not commit)
+pysam-removal.md

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -47,8 +47,6 @@ the authoritative license text. Core and optional dependencies currently include
 - **openmeteo-requests** — MIT
 - **pandas** — BSD 3-Clause
 - **pyarrow** — Apache 2.0
-- **NREL-PySAM** — BSD 3-Clause. Refer to the NREL-PySAM license and SAM
-  notices for bundled model details.
 - **pvlib** — BSD 3-Clause
 - **pymoo** — Apache 2.0
 - **rainflow** — MIT
@@ -65,8 +63,8 @@ documentation where the relevant models affect results.
 
 | Area | Used by | Credit / citation note |
 |------|---------|------------------------|
-| PV modelling | `breos/solar.py`, `breos/weather.py` | BREOS uses [pvlib python](https://pvlib-python.readthedocs.io/) for solar position, irradiance transposition, temperature, CEC/SAM-style module fitting, PVWatts losses, tracking, and inverter helpers. Cite pvlib in published work that relies on these calculations. |
-| SAM / CEC PV parameters | `breos/solar.py`, `breos/pv_modules.py` | CEC/SAM-style single-diode parameters and NREL SAM documentation inform module modelling assumptions. |
+| PV modelling | `breos/solar.py`, `breos/weather.py` | BREOS uses [pvlib python](https://pvlib-python.readthedocs.io/) for solar position, irradiance transposition, temperature, CEC single-diode evaluation (`calcparams_cec`, `max_power_point`), PVWatts losses, tracking, and inverter helpers. Cite pvlib in published work that relies on these calculations. |
+| CEC PV parameter fitting | `breos/cec_fit.py`, `breos/solar.py`, `breos/pv_modules.py` | The CEC 6-parameter coefficient calculator follows A. Dobos, "An Improved Coefficient Calculator for the California Energy Commission 6 Parameter Photovoltaic Module Model", J. Solar Energy Eng. 134 (2012), DOI:10.1115/1.4005759. |
 | Multi-objective optimization | `breos/optimization.py` | BREOS uses [pymoo](https://pymoo.org/) for NSGA-II multi-objective optimization. Cite pymoo where optimizer behavior is material to the study. |
 | Rainflow cycle counting | `breos/battery.py` | BREOS uses the `rainflow` Python package and ASTM E1049-style rainflow counting for battery cycle detection in the reference path. |
 | Battery cycle and calendar ageing | `breos/battery.py`, `breos/constants.py`, `breos/numba_kernels.py` | Naumann et al. (2020) parameterization and equations are used for cycle ageing and selected calendar/resistance ageing behavior. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Removed
+- The `nrel-pysam` runtime dependency. It was only ever reached transitively,
+  through pvlib's `fit_cec_sam`, to fit the CEC single-diode parameters on the
+  default PV path. `nrel-pysam` publishes no Python 3.14 wheel or sdist and was
+  the sole blocker to running BREOS on 3.14.
+
+### Added
+- `breos.cec_fit.fit_cec_params`: a pure-`scipy`/`pvlib` implementation of the
+  CEC 6-parameter coefficient calculator (Dobos 2012, DOI:10.1115/1.4005759),
+  a drop-in for `pvlib.ivtools.sdm.fit_cec_sam`. Across every bundled module it
+  reproduces the SAM fit to within 0.03% on maximum power over a
+  temperature x irradiance grid and 0.004% on annual energy, so model results
+  are unchanged. Validated against the `nrel-pysam` oracle by
+  `tools/validate_cec_fit.py`.
+- Python 3.14 support: the `3.14` classifier and CI matrix entry, now that the
+  `nrel-pysam` blocker is gone.
+
+### Changed
+- The default PV path fits CEC parameters via `breos.cec_fit.fit_cec_params`
+  instead of `pvlib.ivtools.sdm.fit_cec_sam`; `breos/solar.py` and the public
+  API are otherwise unchanged.
+- The two placeholder `Generic_400W` and `Generic_600W_Bifacial` catalog
+  modules now carry realistic mono-PERC datasheet specifications (their
+  previous made-up values fit cleanly under SAM only via an internal
+  short-circuit-current heuristic); their nameplate power and keys are
+  unchanged.
+
 ## [0.3.0] - 2026-06-24
 
 ### Fixed
@@ -94,7 +123,8 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   stack and moved heavier workflow packages behind extras: `plots`,
   `optimization`, `weather`, `fast`, `validation`, and `location-tools`.
   NREL-PySAM stays in the core set because the default PV model fits CEC
-  single-diode parameters at runtime via pvlib's `fit_cec_sam`.
+  single-diode parameters at runtime via pvlib's `fit_cec_sam`. (Removed after
+  0.3.0 — see the Unreleased section above.)
 - The `dev` extra now installs optional feature dependencies so contributor
   test runs continue to cover optional paths.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,34 @@ a `pvlib.Location`, which means BREOS does not own its own public API.
 - Estimated effort: ~3–4 weeks of focused work, split into many small
   PRs.
 
+### Declarative config schema with strict validation
+
+The public `App` config surface is currently defined and checked in four
+separate places: the `DEFAULTS` dict and imperative `validate_config` in
+`breos.app_config`, plus the `argparse` flag definitions and the
+`_add_override` calls in `breos.cli`. Adding one parameter means editing all
+four, which is drift-prone, and the hand-rolled validation is hard to keep in
+sync with the defaults. Replace it with a single declarative schema (a
+dataclass with field metadata, or `pydantic`) so defaults, types, bounds, and
+documentation live in one place.
+
+- **Near-term first step (do independently of the full refactor): reject
+  unknown config keys.** Today `merge_defaults` does `{**DEFAULTS, **config}`
+  and `validate_config` only checks *known* keys, so a typo such as
+  `batery_kwh` is silently dropped and the battery defaults to `0.0` — the run
+  succeeds and returns plausible-but-wrong numbers with no warning. This is a
+  real footgun for parametric/batch studies driven by many config files. Add an
+  allowed-key check that raises listing the unknown key(s), in the existing
+  "Unknown X. Available: ..." style. Small, self-contained, worth a test.
+- **Full step:** collapse `DEFAULTS`, the validation rules, and the CLI flag
+  definitions into the schema so a new parameter is added once, not four times.
+- **Side cleanup:** stop mutating the input config during resolution —
+  `resolve_pv_system` writes `cfg["n_modules"] = sum(...)` into the same dict
+  the `frozen=True` `ResolvedAppConfig` wraps, which makes the immutability
+  partly cosmetic and the data flow harder to follow.
+- Keep all error messages actionable; preserve current behaviour for valid
+  configs (regression-test the example configs in `configs/examples/`).
+
 ## Performance and portability
 
 ### Resource controls and Apple Silicon hygiene
@@ -123,6 +151,23 @@ provide module, inverter, environment, MPPT, and string-topology data.
   improve multi-array energy modeling.
 - Non-goal: code-compliance certification, conductor/fuse sizing, and physical
   wiring auto-routing.
+
+### Parameter sweeps and batch runs
+
+The CLI runs one config to one result (`breos run --config ... --output ...`).
+Research workflows often set up *many* configs — parametric sweeps over module
+count, battery size, tilt, tariffs, and so on — which today means scripting the
+Python `App` in a loop by hand. Add a first-class way to enumerate a parameter
+grid (or a set of config files) and collect the per-run results into one table.
+
+- For example a `breos sweep` command over a base config plus a parameter grid,
+  or a glob of config files resolved into one combined CSV/JSON of results.
+- Reuse the worker controls planned under "Resource controls and Apple Silicon
+  hygiene" for parallel execution of independent runs.
+- Echo the resolved config (and `breos` version) per row so a sweep output is
+  self-describing and reproducible.
+- Non-goal: this is explicit enumeration, not optimization — the `optimization`
+  module's NSGA-II sizing already covers searching for good designs.
 
 ### 0.3.0 workflow hardening
 

--- a/breos/cec_fit.py
+++ b/breos/cec_fit.py
@@ -1,0 +1,362 @@
+"""Pure-scipy CEC 6-parameter coefficient fit.
+
+This module computes the reference-condition parameters of the CEC single-diode
+("6-parameter") PV module model from the numbers found on a manufacturer
+datasheet. It is a drop-in replacement for
+:func:`pvlib.ivtools.sdm.fit_cec_sam` that depends only on ``scipy`` and
+``pvlib`` — it removes the transitive ``nrel-pysam`` (SAM SDK) dependency that
+``fit_cec_sam`` requires, which is the sole blocker for running BREOS on
+Python 3.14 (no ``cp314`` wheel and no sdist are published).
+
+The fitted parameters are consumed downstream by
+:func:`pvlib.pvsystem.calcparams_cec` and :func:`pvlib.pvsystem.max_power_point`
+exactly as before, so model results are unchanged.
+
+Algorithm
+---------
+The six reference parameters ``(a, I_L, I_o, R_s, R_sh, Adjust)`` are defined by
+six constraints evaluated at standard rating conditions (1000 W/m², 25 °C):
+the short-circuit, open-circuit and maximum-power points, a zero power-slope at
+the maximum-power point, and the datasheet temperature coefficients of open-
+circuit voltage (``beta_voc``) and maximum power (``gamma_pmp``). See
+
+    A. Dobos, "An Improved Coefficient Calculator for the California Energy
+    Commission 6 Parameter Photovoltaic Module Model", Journal of Solar Energy
+    Engineering 134 (2012), DOI:10.1115/1.4005759.
+
+``Adjust`` only rescales how the short-circuit current — and therefore the
+maximum power — tracks temperature away from 25 °C; it has no effect on the STC
+I–V curve. This lets the problem be solved as a one-dimensional search on
+``Adjust`` (matching the datasheet ``gamma_pmp``) wrapping a five-parameter De
+Soto solve in which ``alpha_sc`` and ``beta_voc`` carry the ``Adjust`` scaling.
+The modeled ``gamma_pmp`` is evaluated against the same ``calcparams_cec`` /
+``max_power_point`` path used at runtime, so the fit is self-consistent with the
+simulator.
+"""
+
+import warnings
+from typing import Tuple
+
+import numpy as np
+from pvlib.pvsystem import calcparams_cec, max_power_point
+from scipy import constants
+from scipy.optimize import brentq, root
+
+# Boltzmann constant in eV/K, taken from the same source pvlib uses, so the
+# I_o(T) scaling in the open-circuit-voltage constraint matches calcparams_cec.
+_BOLTZMANN_EV_K = constants.value("Boltzmann constant in eV/K")
+
+# Silicon band-gap reference value and its temperature dependence (Dobos Eqs. 6
+# and 7); these are pvlib's calcparams_cec defaults (EgRef, dEgdT).
+_EG_REF = 1.121
+_DEGDT = -0.0002677
+
+# Temperature offset used for the open-circuit-voltage temperature-coefficient
+# constraint (Dobos Eq. 22). SAM's 6parsolve and pvlib's own ``fit_desoto``
+# both evaluate this constraint 2 °C above the reference temperature.
+_DELTA_T_VOC = 2.0
+
+# Maximum-power temperature-coefficient grid (Dobos Eq. 10/25): power is
+# evaluated from -10 °C to 50 °C and adjacent normalised slopes are averaged.
+# For this uniform grid that average telescopes to the secant slope between the
+# endpoints, so only the three points needed for it are evaluated.
+_GAMMA_T_LOW = -10.0
+_GAMMA_T_HIGH = 50.0
+
+# Sanity ranges for the fitted coefficients, used to reject a converged-but-
+# unphysical solution before falling back to heuristics. The lower bounds and
+# positivity follow Dobos Table 5 and are what discriminate against spurious
+# roots (e.g. negative shunt resistance). The upper bounds are widened well
+# beyond the 2012-era Table 5 limits so that modern high-current / high-power
+# modules (210 mm cells with Isc ~18-20 A exceed the original 15 A I_L cap) are
+# not rejected.
+_PARAM_BOUNDS = {
+    "a_ref": (0.05, 50.0),
+    "I_L_ref": (0.1, 100.0),
+    "I_o_ref": (1e-20, 1e-5),
+    "R_s": (1e-4, 100.0),
+    "R_sh_ref": (1.0, 1e7),
+    "Adjust": (-100.0, 100.0),
+}
+
+_IRRAD_REF = 1000.0
+_TEMP_REF = 25.0
+
+
+# Per-technology empirical-guess coefficients (Dobos Tables 3 and 4): the
+# slope/intercept of ``a`` versus the cell count, and the C_s / C_sh factors
+# that scale series and shunt resistance. ``polySi`` maps to the multi-Si row.
+_EMPIRICAL_GUESS = {
+    "monosi": ((0.027, -0.0172), 0.32, 4.92),
+    "multisi": ((0.026, 0.0212), 0.34, 5.36),
+    "polysi": ((0.026, 0.0212), 0.34, 5.36),
+    "amorphous": ((0.029, 0.5264), 0.59, 0.92),
+    "cdte": ((0.012, 1.356), 0.46, 1.11),
+    "cigs": ((0.018, 0.327), 0.55, 1.22),
+    "cis": ((0.021, 0.0897), 0.61, 1.07),
+}
+
+# Tolerance (%/°C) on the modeled-vs-datasheet gamma for a fit to count as a
+# clean gamma match rather than a best-effort fallback.
+_GAMMA_TOL = 1e-3
+
+
+def _initial_guess(v_mp, i_mp, v_oc, i_sc, cells_in_series, temp_ref):
+    """De Soto five-parameter initial guess (Duffie & Beckman, as in pvlib)."""
+    t_ref_k = temp_ref + 273.15
+    a0 = 1.5 * _BOLTZMANN_EV_K * t_ref_k * cells_in_series
+    i_l0 = i_sc
+    i_o0 = i_sc * np.exp(-v_oc / a0)
+    r_s0 = (a0 * np.log1p((i_l0 - i_mp) / i_o0) - v_mp) / i_mp
+    r_sh0 = 100.0
+    return np.array([i_l0, i_o0, r_s0, r_sh0, a0])
+
+
+def _empirical_guess(celltype, v_mp, i_mp, v_oc, i_sc, cells_in_series):
+    """Technology-aware five-parameter guess (Dobos §4.3, Tables 3 and 4)."""
+    (slope, intercept), c_s, c_sh = _EMPIRICAL_GUESS.get(str(celltype).lower(), _EMPIRICAL_GUESS["monosi"])
+    a0 = slope * cells_in_series + intercept
+    i_l0 = i_sc
+    i_o0 = i_sc * np.exp(-v_oc / a0)
+    r_s0 = c_s * (v_oc - v_mp) / i_mp
+    r_sh0 = c_sh * v_oc / (i_sc - i_mp)
+    return np.array([i_l0, i_o0, r_s0, r_sh0, a0])
+
+
+def _reference_equations(params, v_mp, i_mp, v_oc, i_sc, alpha_eff, beta_eff, temp_ref):
+    """Residuals of the five reference-condition constraints (Dobos 2012).
+
+    ``params`` is ``[I_L, I_o, R_s, R_sh, a]`` at the reference conditions.
+    ``alpha_eff`` and ``beta_eff`` are the short-circuit-current and
+    open-circuit-voltage temperature coefficients already scaled by ``Adjust``
+    (Eqs. 8 and 9). The constraints are the short-circuit point (Eq. 11), the
+    open-circuit point (Eq. 12), the maximum-power point (Eq. 13), a zero
+    power-slope there (Eq. 19), and the open-circuit-voltage temperature
+    coefficient evaluated ``_DELTA_T_VOC`` above the reference (Eq. 22).
+    """
+    i_l, i_o, r_s, r_sh, a = params
+    t_ref_k = temp_ref + 273.15
+
+    y = np.empty(5)
+    # Short-circuit point: V = 0, I = Isc (Eq. 11).
+    y[0] = i_sc - i_l + i_o * np.expm1(i_sc * r_s / a) + i_sc * r_s / r_sh
+    # Open-circuit point: V = Voc, I = 0 (Eq. 12).
+    y[1] = -i_l + i_o * np.expm1(v_oc / a) + v_oc / r_sh
+    # Maximum-power point: V = Vmp, I = Imp (Eq. 13).
+    y[2] = i_mp - i_l + i_o * np.expm1((v_mp + i_mp * r_s) / a) + (v_mp + i_mp * r_s) / r_sh
+    # Zero power-slope at the maximum-power point (Eq. 19).
+    exp_mp = np.exp((v_mp + i_mp * r_s) / a)
+    y[3] = i_mp - v_mp * ((i_o / a) * exp_mp + 1.0 / r_sh) / (1.0 + (i_o * r_s / a) * exp_mp + r_s / r_sh)
+    # Open-circuit-voltage temperature coefficient at T' = Tref + dT (Eq. 22).
+    dt = _DELTA_T_VOC
+    t2_k = t_ref_k + dt
+    a2 = a * t2_k / t_ref_k
+    v_oc2 = v_oc + beta_eff * dt
+    i_l2 = i_l + alpha_eff * dt
+    eg2 = _EG_REF * (1.0 + _DEGDT * dt)
+    i_o2 = i_o * (t2_k / t_ref_k) ** 3 * np.exp((1.0 / _BOLTZMANN_EV_K) * (_EG_REF / t_ref_k - eg2 / t2_k))
+    y[4] = -i_l2 + i_o2 * np.expm1(v_oc2 / a2) + v_oc2 / r_sh
+    return y
+
+
+def _solve_five_params(adjust, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, x0, temp_ref):
+    """Solve the five reference parameters for a fixed ``Adjust``.
+
+    ``alpha_sc`` and ``beta_voc`` are the *unscaled* datasheet coefficients;
+    the ``Adjust`` scaling (Eqs. 8 and 9) is applied here.
+    """
+    alpha_eff = alpha_sc * (1.0 - adjust / 100.0)
+    beta_eff = beta_voc * (1.0 + adjust / 100.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        sol = root(
+            _reference_equations,
+            x0,
+            args=(v_mp, i_mp, v_oc, i_sc, alpha_eff, beta_eff, temp_ref),
+            method="lm",
+        )
+    return sol.x, sol.success
+
+
+def _modeled_pmp(temp, alpha_sc, a_ref, i_l_ref, i_o_ref, r_sh_ref, r_s, adjust):
+    """Maximum power at 1000 W/m² and ``temp`` via the runtime model path.
+
+    Uses the same ``calcparams_cec`` / ``max_power_point`` path the simulator
+    uses (Newton), falling back to the more robust Brent solver and finally to
+    NaN if a (typically unphysical, mid-iteration) parameter set will not
+    converge — so an exploratory evaluation never raises.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        params = calcparams_cec(_IRRAD_REF, temp, alpha_sc, a_ref, i_l_ref, i_o_ref, r_sh_ref, r_s, adjust)
+        for method in ("newton", "brentq"):
+            try:
+                return float(max_power_point(*params, method=method)["p_mp"])
+            except (RuntimeError, ValueError):
+                continue
+    return float("nan")
+
+
+def _modeled_gamma(five, adjust, alpha_sc):
+    """Modeled maximum-power temperature coefficient in %/°C (Dobos Eq. 10).
+
+    The paper averages adjacent normalised power slopes over -10 → 50 °C; for a
+    uniform grid that equals the secant slope between the endpoints, normalised
+    by the modeled power at the reference temperature.
+    """
+    i_l_ref, i_o_ref, r_s, r_sh_ref, a_ref = five
+    p_low = _modeled_pmp(_GAMMA_T_LOW, alpha_sc, a_ref, i_l_ref, i_o_ref, r_sh_ref, r_s, adjust)
+    p_high = _modeled_pmp(_GAMMA_T_HIGH, alpha_sc, a_ref, i_l_ref, i_o_ref, r_sh_ref, r_s, adjust)
+    p_ref = _modeled_pmp(_TEMP_REF, alpha_sc, a_ref, i_l_ref, i_o_ref, r_sh_ref, r_s, adjust)
+    return 100.0 * (p_high - p_low) / (p_ref * (_GAMMA_T_HIGH - _GAMMA_T_LOW))
+
+
+def _is_physical(five, adjust):
+    """True if the six parameters fall within the Dobos Table 5 sanity ranges."""
+    i_l_ref, i_o_ref, r_s, r_sh_ref, a_ref = five
+    values = {
+        "a_ref": a_ref,
+        "I_L_ref": i_l_ref,
+        "I_o_ref": i_o_ref,
+        "R_s": r_s,
+        "R_sh_ref": r_sh_ref,
+        "Adjust": adjust,
+    }
+    return all(np.isfinite(v) and lo <= v <= hi for (lo, hi), v in ((_PARAM_BOUNDS[k], values[k]) for k in values))
+
+
+_ADJUST_SCAN = np.arange(0.0, 60.0001, 4.0)
+
+
+def _solve_adjust(v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, gamma_pmp, x0, temp_ref):
+    """Find ``Adjust`` so the modeled gamma matches the datasheet ``gamma_pmp``.
+
+    ``gamma`` decreases monotonically with ``Adjust`` along a fixed solution
+    branch (a larger ``Adjust`` suppresses the photocurrent's rise with
+    temperature, so power falls faster). The branch is followed by warm-starting
+    each five-parameter solve from the previous solution (continuation), which
+    keeps the inner solver from hopping to a different root as ``Adjust`` moves
+    and makes gamma a smooth, monotone function to bracket and refine.
+
+    Returns ``(adjust, five_params)`` for the matched solution, or ``None`` if no
+    physical branch reaches the target gamma.
+    """
+
+    def march(direction):
+        """Walk Adjust outward from 0, returning physical (adjust, residual, five) samples."""
+        samples = []
+        guess = np.array(x0, dtype=float)
+        for step in _ADJUST_SCAN:
+            adjust = direction * step
+            five, ok = _solve_five_params(adjust, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, guess, temp_ref)
+            if not ok or not _is_physical(five, adjust):
+                break
+            gamma = _modeled_gamma(five, adjust, alpha_sc)
+            if not np.isfinite(gamma):
+                break
+            guess = five  # continuation: stay on this branch
+            samples.append((adjust, gamma - gamma_pmp, five))
+        return samples
+
+    # Sample both directions from 0; the +0 sample is shared, so drop the
+    # duplicate from the negative march.
+    samples = march(+1.0) + march(-1.0)[1:]
+    if not samples:
+        return None
+    samples.sort(key=lambda s: s[0])
+
+    for (a_lo, r_lo, five_lo), (a_hi, r_hi, _five_hi) in zip(samples, samples[1:]):
+        if r_lo == 0.0:
+            return a_lo, five_lo
+        if r_lo * r_hi < 0.0:
+            # Refine within the bracket, warm-starting from the low end each call.
+            def residual(adjust, _g=np.array(five_lo, dtype=float)):
+                five, _ok = _solve_five_params(adjust, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, _g, temp_ref)
+                _g[:] = five
+                return _modeled_gamma(five, adjust, alpha_sc) - gamma_pmp
+
+            adjust = brentq(residual, a_lo, a_hi, xtol=1e-10, rtol=1e-12)
+            five, _ = _solve_five_params(
+                adjust, v_mp, i_mp, v_oc, i_sc, alpha_sc, beta_voc, np.array(five_lo), temp_ref
+            )
+            return adjust, five
+
+    # No sign change on this branch: return the closest physical sample so the
+    # caller can still surface a usable (if gamma-imperfect) result.
+    best = min(samples, key=lambda s: abs(s[1]))
+    return best[0], best[2]
+
+
+def fit_cec_params(
+    celltype: str,
+    Vmp: float,
+    Imp: float,
+    Voc: float,
+    Isc: float,
+    alpha_sc: float,
+    beta_voc: float,
+    gamma_pmp: float,
+    cells_in_series: int,
+    temp_ref: float = 25.0,
+) -> Tuple[float, float, float, float, float, float]:
+    """Fit the CEC single-diode reference parameters from datasheet values.
+
+    Drop-in replacement for :func:`pvlib.ivtools.sdm.fit_cec_sam` that needs no
+    ``nrel-pysam``. Implements the coefficient calculator of Dobos 2012
+    (DOI:10.1115/1.4005759) with ``scipy`` and ``pvlib`` only.
+
+    Args:
+        celltype: Cell technology label (kept for signature parity with
+            ``fit_cec_sam``; the solver itself is technology-independent).
+        Vmp: Voltage at the maximum-power point [V].
+        Imp: Current at the maximum-power point [A].
+        Voc: Open-circuit voltage [V].
+        Isc: Short-circuit current [A].
+        alpha_sc: Short-circuit-current temperature coefficient [A/°C].
+        beta_voc: Open-circuit-voltage temperature coefficient [V/°C].
+        gamma_pmp: Maximum-power temperature coefficient [%/°C].
+        cells_in_series: Number of cells in series.
+        temp_ref: Reference temperature [°C] (default 25).
+
+    Returns:
+        ``(I_L_ref, I_o_ref, R_s, R_sh_ref, a_ref, Adjust)`` — the same tuple,
+        in the same order, that ``fit_cec_sam`` returns.
+
+    Raises:
+        RuntimeError: if no physical parameter set can be found.
+    """
+    guesses = (
+        _initial_guess(Vmp, Imp, Voc, Isc, cells_in_series, temp_ref),
+        _empirical_guess(celltype, Vmp, Imp, Voc, Isc, cells_in_series),
+    )
+
+    # Try the reported short-circuit current first and, if no branch matches the
+    # datasheet gamma, raise Isc by 1% per iteration (Dobos §5 heuristic, up to
+    # five iterations) to move a poorly conditioned module onto a well-shaped
+    # I-V curve. The first guess (De Soto) reproduces SAM on well-formed
+    # datasheets; the empirical guess (Dobos §4.3) is a robustness fallback. The
+    # best-but-imperfect candidate is retained so a usable result is returned
+    # even if no branch lands exactly on the target gamma.
+    fallback = None
+    for bump in range(6):
+        i_sc = Isc * (1.01**bump)
+        for x0 in guesses:
+            result = _solve_adjust(Vmp, Imp, Voc, i_sc, alpha_sc, beta_voc, gamma_pmp, x0, temp_ref)
+            if result is None:
+                continue
+            adjust, five = result
+            if not _is_physical(five, adjust):
+                continue
+            residual = abs(_modeled_gamma(five, adjust, alpha_sc) - gamma_pmp)
+            if residual <= _GAMMA_TOL:
+                i_l_ref, i_o_ref, r_s, r_sh_ref, a_ref = five
+                return (i_l_ref, i_o_ref, r_s, r_sh_ref, a_ref, adjust)
+            if fallback is None or residual < fallback[1]:
+                fallback = ((five, adjust), residual)
+
+    if fallback is not None:
+        (five, adjust), _ = fallback
+        i_l_ref, i_o_ref, r_s, r_sh_ref, a_ref = five
+        return (i_l_ref, i_o_ref, r_s, r_sh_ref, a_ref, adjust)
+
+    raise RuntimeError("CEC parameter fit did not converge to a physical solution.")

--- a/breos/pv_modules.py
+++ b/breos/pv_modules.py
@@ -75,37 +75,38 @@ MODULES: Dict[str, PVModuleParams] = {
         N_Cells=144,
     ),
     # -------------------------------------------------------------------------
-    # Generic 400W Module (Common residential panel)
-    # Note: Parameters are based on Canadian Solar CS1U-400MS
-    # to ensure successful calculation in pvlib's CEC IV model
+    # Generic 400W Module (common 72-cell / 144-half-cell residential panel)
+    # Representative mono-PERC specs (LONGi LR4-72HPH-400M family).
     # -------------------------------------------------------------------------
     "Generic_400W": PVModuleParams(
         Mpp=400,
-        Vmp=44.1,  # V - Voltage at MPP
-        Imp=9.08,  # A - Current at MPP
-        Voc=53.4,  # V - Open circuit voltage
-        Isc=9.60,  # A - Short circuit current
+        Vmp=41.0,  # V - Voltage at MPP
+        Imp=9.76,  # A - Current at MPP
+        Voc=49.3,  # V - Open circuit voltage
+        Isc=10.30,  # A - Short circuit current
         celltype="monoSi",
-        T_Pmax_pct=-0.36,  # %/°C - Power temperature coefficient
-        T_Voc_pct=-0.29,  # %/°C - Voltage temperature coefficient
+        T_Pmax_pct=-0.35,  # %/°C - Power temperature coefficient
+        T_Voc_pct=-0.265,  # %/°C - Voltage temperature coefficient
         T_Isc_pct=0.05,  # %/°C - Current temperature coefficient
-        N_Cells=144,  # Cells
-        Name="Generic 400W (Canadian Solar CS1U-400MS ref)",
+        N_Cells=144,  # 72-cell module (144 half-cells)
+        Name="Generic 400W (LONGi LR4-72HPH-400M ref)",
     ),
     # -------------------------------------------------------------------------
-    # Generic 600W Bifacial Module (Utility-scale)
+    # Generic 600W Bifacial Module (utility-scale, high-voltage 144-half-cell)
+    # Representative mono-PERC specs; the model treats it as a front-side module.
     # -------------------------------------------------------------------------
     "Generic_600W_Bifacial": PVModuleParams(
         Mpp=600,
-        Vmp=45.0,
-        Imp=13.33,
-        Voc=54.0,
-        Isc=14.5,
+        Vmp=44.6,
+        Imp=13.46,
+        Voc=53.7,
+        Isc=14.25,
         celltype="monoSi",
         T_Pmax_pct=-0.34,
         T_Voc_pct=-0.26,
-        T_Isc_pct=0.05,
-        N_Cells=156,
+        T_Isc_pct=0.046,
+        N_Cells=144,
+        Name="Generic 600W bifacial (utility-scale ref)",
     ),
 }
 

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pvlib
 from pvlib.location import Location
 
+from breos.cec_fit import fit_cec_params
 from breos.utils import get_hours_per_step
 
 # Module-level cache for CEC model parameters (depends only on module specs, not weather)
@@ -146,12 +147,12 @@ def _get_cec_params(pv_params: "PVModuleParams"):
     if key in _cec_param_cache:
         return _cec_param_cache[key]
 
-    cec = pvlib.ivtools.sdm.fit_cec_sam(
+    cec = fit_cec_params(
         celltype=pv_params.celltype,
-        v_mp=pv_params.Vmp,
-        i_mp=pv_params.Imp,
-        v_oc=pv_params.Voc,
-        i_sc=pv_params.Isc,
+        Vmp=pv_params.Vmp,
+        Imp=pv_params.Imp,
+        Voc=pv_params.Voc,
+        Isc=pv_params.Isc,
         alpha_sc=pv_params.alpha_sc,
         beta_voc=pv_params.beta_voc,
         gamma_pmp=pv_params.gamma_pmp,

--- a/docs/architecture/third-party-wrapping.md
+++ b/docs/architecture/third-party-wrapping.md
@@ -8,7 +8,7 @@
 
 BREOS imports several third-party libraries directly throughout the package
 (`pvlib`, `pandas`, `numpy`, `scipy`, `numba`, `rainflow`, `geopy`,
-`openmeteo-requests`, `timezonefinder`, `nrel-pysam`, `pymoo`,
+`openmeteo-requests`, `timezonefinder`, `pymoo`,
 `requests-cache`, `matplotlib`, `openpyxl`).
 
 Direct usage means those libraries co-own the BREOS public API. When they
@@ -92,7 +92,7 @@ signatures.
 | `PVSystem`         | `breos.adapters.pv_system`       | `pvlib.pvsystem.PVSystem`                        |
 | `irradiance.aoi`   | `breos.adapters.irradiance`      | `pvlib.irradiance.aoi`, `pvlib.iam.ashrae`       |
 | `cell_temperature` | `breos.adapters.thermal`         | `pvlib.temperature.faiman`                       |
-| `cec_model`        | `breos.adapters.pv_model`        | `pvlib.ivtools.sdm.fit_cec_sam`, `calcparams_cec`, `max_power_point`, `pvwatts_losses` |
+| `cec_model`        | `breos.adapters.pv_model`        | `breos.cec_fit.fit_cec_params`, `pvlib.pvsystem.calcparams_cec`, `max_power_point`, `pvwatts_losses` |
 | `inverter`         | `breos.adapters.inverter`        | `pvlib.inverter.pvwatts`                         |
 | `weather_io`       | `breos.adapters.weather_io`      | `pvlib.iotools.get_pvgis_tmy`, `get_nsrdb_psm4_tmy`, `read_epw` |
 
@@ -110,8 +110,6 @@ signatures.
 
 - `openmeteo-requests`, `requests-cache` → `breos.adapters.weather_client`.
 - `geopy`, `timezonefinder` → `breos.adapters.geo`.
-- `nrel-pysam` → `breos.adapters.sam_model` (reached transitively through
-  pvlib's `fit_cec_sam` on the default PV path).
 - `pymoo` → `breos.adapters.multi_objective` (used in `optimization.py`).
 - `openpyxl`, `pyarrow` → keep in validation/export-specific paths.
 

--- a/docs/getting-started/options.md
+++ b/docs/getting-started/options.md
@@ -32,8 +32,8 @@ Catalogue keys for the `pv_module` config key, from `breos.pv_modules.MODULES`.
 | Key | Power (W) | Name | Cell type |
 |---|---|---|---|
 | `Erlangen_445W` | 445 | Erlangen_445W | monoSi |
-| `Generic_400W` | 400 | Generic 400W (Canadian Solar CS1U-400MS ref) | monoSi |
-| `Generic_600W_Bifacial` | 600 | Generic_600W_Bifacial | monoSi |
+| `Generic_400W` | 400 | Generic 400W (LONGi LR4-72HPH-400M ref) | monoSi |
+| `Generic_600W_Bifacial` | 600 | Generic 600W bifacial (utility-scale ref) | monoSi |
 | `Suntech_STP550S_NOMT` | 415 | Suntech_STP550S-C72/Vmh | monoSi |
 | `Suntech_STP550S_STC` | 550 | Suntech_STP550S-C72/Vmh | monoSi |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "nrel-pysam>=7.1.0",
     "numpy>=2.0",
     "pandas>=2.3.3",
     "pvlib>=0.14.0,<0.16",

--- a/tests/test_cec_fit.py
+++ b/tests/test_cec_fit.py
@@ -1,0 +1,126 @@
+"""Tests for the pure-scipy CEC 6-parameter fit (``breos.cec_fit``)."""
+
+import warnings
+
+import numpy as np
+import pytest
+from pvlib.pvsystem import calcparams_cec, i_from_v, max_power_point
+
+from breos.cec_fit import _modeled_gamma, _solve_five_params, fit_cec_params
+from breos.pv_modules import MODULES, get_module
+
+# A well-formed datasheet (Suntech STP550S) used for the focused single-module
+# assertions; the catalog sweep below covers every bundled module.
+_KNOWN = dict(
+    celltype="monoSi",
+    Vmp=42.05,
+    Imp=13.08,
+    Voc=49.88,
+    Isc=14.01,
+    alpha_sc=0.05 * 14.01 / 100,
+    beta_voc=-0.304 * 49.88 / 100,
+    gamma_pmp=-0.36,
+    cells_in_series=144,
+)
+
+
+def _mpp_at(params, alpha_sc, irradiance, temp):
+    i_l, i_o, r_s, r_sh, a, adjust = params
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        cec = calcparams_cec(irradiance, temp, alpha_sc, a, i_l, i_o, r_sh, r_s, adjust)
+        return max_power_point(*cec, method="newton")
+
+
+class TestFitShape:
+    def test_returns_six_finite_floats(self):
+        params = fit_cec_params(**_KNOWN)
+        assert len(params) == 6
+        assert all(np.isfinite(v) for v in params)
+
+    def test_parameters_are_physical(self):
+        i_l, i_o, r_s, r_sh, a, adjust = fit_cec_params(**_KNOWN)
+        assert i_l > 0
+        assert i_o > 0
+        assert r_s > 0
+        assert r_sh > 0
+        assert a > 0
+        assert -100.0 <= adjust <= 100.0
+
+
+class TestParameterRecovery:
+    def test_recovers_stc_maximum_power_point(self):
+        params = fit_cec_params(**_KNOWN)
+        mpp = _mpp_at(params, _KNOWN["alpha_sc"], 1000.0, 25.0)
+        # The fit constrains the model to pass through the datasheet MPP at STC.
+        assert mpp["p_mp"] == pytest.approx(_KNOWN["Vmp"] * _KNOWN["Imp"], rel=2e-3)
+        assert mpp["v_mp"] == pytest.approx(_KNOWN["Vmp"], rel=5e-3)
+        assert mpp["i_mp"] == pytest.approx(_KNOWN["Imp"], rel=5e-3)
+
+    def test_open_circuit_current_is_essentially_zero(self):
+        i_l, i_o, r_s, r_sh, a, adjust = fit_cec_params(**_KNOWN)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            cec = calcparams_cec(1000.0, 25.0, _KNOWN["alpha_sc"], a, i_l, i_o, r_sh, r_s, adjust)
+            current_at_voc = float(i_from_v(_KNOWN["Voc"], *cec))
+        # Dobos validity check: current at Voc must be well under 1.5% of Imp.
+        assert abs(current_at_voc) < 0.015 * _KNOWN["Imp"]
+
+
+class TestGammaMatch:
+    def test_modeled_gamma_matches_datasheet(self):
+        i_l, i_o, r_s, r_sh, a, adjust = fit_cec_params(**_KNOWN)
+        gamma = _modeled_gamma((i_l, i_o, r_s, r_sh, a), adjust, _KNOWN["alpha_sc"])
+        assert gamma == pytest.approx(_KNOWN["gamma_pmp"], abs=2e-3)
+
+    def test_gamma_is_monotonic_decreasing_in_adjust(self):
+        # On a fixed solution branch, raising Adjust suppresses the photocurrent's
+        # rise with temperature, so the modeled power falls faster (more negative
+        # gamma). Solve the five params per Adjust and check the trend.
+        five0, _ = _solve_five_params(
+            0.0,
+            _KNOWN["Vmp"],
+            _KNOWN["Imp"],
+            _KNOWN["Voc"],
+            _KNOWN["Isc"],
+            _KNOWN["alpha_sc"],
+            _KNOWN["beta_voc"],
+            np.array([_KNOWN["Isc"], 1e-10, 0.3, 200.0, 2.0]),
+            25.0,
+        )
+        gammas = [_modeled_gamma(five0, adjust, _KNOWN["alpha_sc"]) for adjust in (-10.0, 0.0, 10.0, 20.0)]
+        assert all(np.diff(gammas) < 0)
+
+
+class TestEffectiveCoefficientSign:
+    def test_effective_alpha_sc_stays_positive(self):
+        # calcparams_cec scales alpha_sc by (1 - Adjust/100); for a positive
+        # datasheet alpha_sc and Adjust < 100 the effective coefficient must
+        # remain positive (Isc still rises with temperature).
+        *_, adjust = fit_cec_params(**_KNOWN)
+        effective_alpha = _KNOWN["alpha_sc"] * (1.0 - adjust / 100.0)
+        assert effective_alpha > 0
+
+
+class TestCatalogModules:
+    @pytest.mark.parametrize("name", list(MODULES))
+    def test_every_bundled_module_fits_and_recovers_mpp(self, name):
+        module = get_module(name)
+        params = fit_cec_params(
+            celltype=module.celltype,
+            Vmp=module.Vmp,
+            Imp=module.Imp,
+            Voc=module.Voc,
+            Isc=module.Isc,
+            alpha_sc=module.alpha_sc,
+            beta_voc=module.beta_voc,
+            gamma_pmp=module.gamma_pmp,
+            cells_in_series=module.N_Cells,
+        )
+        assert all(np.isfinite(v) for v in params)
+
+        mpp = _mpp_at(params, module.alpha_sc, 1000.0, 25.0)
+        assert mpp["p_mp"] == pytest.approx(module.Vmp * module.Imp, rel=2e-3)
+
+        gamma = _modeled_gamma(params[:5], params[5], module.alpha_sc)
+        assert gamma == pytest.approx(module.gamma_pmp, abs=5e-3)

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -3,6 +3,7 @@
 import pandas as pd
 import pytest
 
+import breos.solar as solar
 from breos.solar import (
     calculate_multi_array_production,
     calculate_pv_production_dc,
@@ -41,6 +42,33 @@ class TestPVProduction:
         )
         assert isinstance(dc, pd.Series)
         assert len(dc) == len(synthetic_weather)
+
+    def test_default_path_uses_local_cec_fit(self, synthetic_weather, porto_location, pv_params, monkeypatch):
+        calls = 0
+        original_fit = solar.fit_cec_params
+
+        def wrapped_fit(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original_fit(*args, **kwargs)
+
+        monkeypatch.setattr(solar, "fit_cec_params", wrapped_fit)
+        solar._cec_param_cache.clear()
+        try:
+            dc = calculate_pv_production_dc(
+                weather_data=synthetic_weather.iloc[:48],
+                location=porto_location,
+                tilt=35,
+                surface_azimuth=180,
+                n_modules=1,
+                pv_params=pv_params,
+                freq="h",
+            )
+        finally:
+            solar._cec_param_cache.clear()
+
+        assert calls == 1
+        assert dc.sum() > 0
 
     def test_all_non_negative(self, dc_production):
         assert (dc_production >= -0.01).all()  # small tolerance for floating point

--- a/tools/validate_cec_fit.py
+++ b/tools/validate_cec_fit.py
@@ -1,0 +1,196 @@
+"""Validation harness for the pure-scipy CEC fit (``breos.cec_fit``).
+
+Compares :func:`breos.cec_fit.fit_cec_params` against the ``nrel-pysam`` oracle
+:func:`pvlib.ivtools.sdm.fit_cec_sam` for every bundled catalog module, on three
+levels of increasing relevance:
+
+1. the six reference parameters;
+2. the downstream maximum power across a temperature x irradiance grid (the
+   number that actually feeds the simulator);
+3. a full-year DC energy run per module.
+
+Run this while ``nrel-pysam`` is still installed (it is the oracle):
+
+    .venv/bin/python tools/validate_cec_fit.py
+
+Gates: <=0.1% max Pmp deviation over the grid, and <=0.1% annual-energy
+deviation per module. This script is a development artifact; it is not part of
+the shipped package and is not exercised by the test suite.
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import pvlib  # noqa: E402
+from pvlib.location import Location  # noqa: E402
+from pvlib.pvsystem import calcparams_cec, max_power_point  # noqa: E402
+
+import breos.solar as solar  # noqa: E402
+from breos.cec_fit import fit_cec_params  # noqa: E402
+from breos.pv_modules import MODULES  # noqa: E402
+
+PARAM_LABELS = ("I_L_ref", "I_o_ref", "R_s", "R_sh_ref", "a_ref", "Adjust")
+
+# Downstream Pmp comparison grid: realistic operating envelope.
+GRID_IRRAD = (100.0, 200.0, 400.0, 600.0, 800.0, 1000.0)
+GRID_TEMP = (-10.0, 0.0, 10.0, 25.0, 40.0, 55.0, 70.0)
+
+PMP_GATE_PCT = 0.1
+ENERGY_GATE_PCT = 0.1
+
+
+def _oracle(module):
+    """Reference six-tuple from SAM via pvlib (requires nrel-pysam)."""
+    return pvlib.ivtools.sdm.fit_cec_sam(
+        celltype=module.celltype,
+        v_mp=module.Vmp,
+        i_mp=module.Imp,
+        v_oc=module.Voc,
+        i_sc=module.Isc,
+        alpha_sc=module.alpha_sc,
+        beta_voc=module.beta_voc,
+        gamma_pmp=module.gamma_pmp,
+        cells_in_series=module.N_Cells,
+    )
+
+
+def _candidate(module):
+    return fit_cec_params(
+        celltype=module.celltype,
+        Vmp=module.Vmp,
+        Imp=module.Imp,
+        Voc=module.Voc,
+        Isc=module.Isc,
+        alpha_sc=module.alpha_sc,
+        beta_voc=module.beta_voc,
+        gamma_pmp=module.gamma_pmp,
+        cells_in_series=module.N_Cells,
+    )
+
+
+def _pmp_grid(params, alpha_sc):
+    i_l, i_o, r_s, r_sh, a, adjust = params
+    out = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        for g in GRID_IRRAD:
+            for t in GRID_TEMP:
+                cec = calcparams_cec(g, t, alpha_sc, a, i_l, i_o, r_sh, r_s, adjust)
+                out.append(max_power_point(*cec, method="newton")["p_mp"])
+    return np.array(out)
+
+
+def _synthetic_weather(year=2023):
+    """One-year hourly weather with sinusoidal patterns (mirrors test fixture)."""
+    n = 8760
+    index = pd.date_range(start=f"{year}-01-01", periods=n, freq="h", tz="UTC")
+    hour_of_year = np.arange(n, dtype=float)
+    day_of_year = hour_of_year / 24.0
+    hour_of_day = hour_of_year % 24
+    solar_angle = np.clip(np.sin((hour_of_day - 6) / 12 * np.pi), 0, 1)
+    seasonal = 0.6 + 0.4 * np.sin((day_of_year - 80) / 365 * 2 * np.pi)
+    ghi = solar_angle * seasonal * 800
+    temp_air = 15 + 8 * np.sin((day_of_year - 80) / 365 * 2 * np.pi) + 4 * np.sin((hour_of_day - 14) / 24 * 2 * np.pi)
+    return pd.DataFrame(
+        {"ghi": ghi, "dni": ghi * 0.7, "dhi": ghi * 0.3, "temp_air": temp_air, "wind_speed": np.full(n, 3.0)},
+        index=index,
+    )
+
+
+def _annual_kwh(module, weather, location, fit_fn):
+    """Annual DC kWh for one module using ``fit_fn`` as the CEC fit."""
+    original = solar.fit_cec_params
+    solar.fit_cec_params = fit_fn
+    solar._cec_param_cache.clear()
+    try:
+        dc = solar.calculate_pv_production_dc(
+            weather_data=weather,
+            location=location,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=module,
+            freq="h",
+        )
+    finally:
+        solar.fit_cec_params = original
+        solar._cec_param_cache.clear()
+    return float(dc.sum()) / 1000.0
+
+
+def _sam_fit_fn(celltype, Vmp, Imp, Voc, Isc, alpha_sc, beta_voc, gamma_pmp, cells_in_series):
+    return pvlib.ivtools.sdm.fit_cec_sam(
+        celltype=celltype,
+        v_mp=Vmp,
+        i_mp=Imp,
+        v_oc=Voc,
+        i_sc=Isc,
+        alpha_sc=alpha_sc,
+        beta_voc=beta_voc,
+        gamma_pmp=gamma_pmp,
+        cells_in_series=cells_in_series,
+    )
+
+
+def main():
+    try:
+        _oracle(next(iter(MODULES.values())))
+    except ImportError:
+        print("nrel-pysam is not installed; the oracle is unavailable. Run this before removing the dependency.")
+        return 2
+
+    weather = _synthetic_weather()
+    location = Location(41.1579, -8.6291, tz="Europe/Lisbon")
+
+    worst_pmp = 0.0
+    worst_energy = 0.0
+    all_pass = True
+
+    for name, module in MODULES.items():
+        sam = _oracle(module)
+        new = _candidate(module)
+
+        print(f"\n=== {name}  (gamma_pmp={module.gamma_pmp}, N_Cells={module.N_Cells}) ===")
+        for label, s, n in zip(PARAM_LABELS, sam, new):
+            rel = abs(s - n) / abs(s) if s else float("nan")
+            print(f"  {label:9s}  sam={s: .6e}  new={n: .6e}  rel={rel:.2e}")
+
+        pmp_dev = float(
+            np.max(
+                np.abs(_pmp_grid(sam, module.alpha_sc) - _pmp_grid(new, module.alpha_sc))
+                / _pmp_grid(sam, module.alpha_sc)
+            )
+            * 100.0
+        )
+        worst_pmp = max(worst_pmp, pmp_dev)
+
+        kwh_sam = _annual_kwh(module, weather, location, _sam_fit_fn)
+        kwh_new = _annual_kwh(module, weather, location, fit_cec_params)
+        energy_dev = abs(kwh_sam - kwh_new) / kwh_sam * 100.0
+        worst_energy = max(worst_energy, energy_dev)
+
+        pmp_ok = pmp_dev <= PMP_GATE_PCT
+        energy_ok = energy_dev <= ENERGY_GATE_PCT
+        all_pass = all_pass and pmp_ok and energy_ok
+        print(f"  max Pmp deviation over T x G grid : {pmp_dev:.4f}%  [{'PASS' if pmp_ok else 'FAIL'}]")
+        print(
+            f"  annual DC energy  sam={kwh_sam:.3f} kWh  new={kwh_new:.3f} kWh  "
+            f"dev={energy_dev:.4f}%  [{'PASS' if energy_ok else 'FAIL'}]"
+        )
+
+    print("\n" + "=" * 70)
+    print(f"WORST Pmp deviation   : {worst_pmp:.4f}%   (gate <= {PMP_GATE_PCT}%)")
+    print(f"WORST energy deviation: {worst_energy:.4f}%   (gate <= {ENERGY_GATE_PCT}%)")
+    print("RESULT:", "ALL GATES PASS" if all_pass else "GATE FAILURE")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,6 @@ name = "breos"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "nrel-pysam" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "pvlib" },
@@ -164,7 +163,6 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.10.8" },
     { name = "matplotlib", marker = "extra == 'plots'", specifier = ">=3.10.8" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0" },
-    { name = "nrel-pysam", specifier = ">=7.1.0" },
     { name = "numba", marker = "extra == 'dev'", specifier = ">=0.63.1" },
     { name = "numba", marker = "extra == 'fast'", specifier = ">=0.63.1" },
     { name = "numpy", specifier = ">=2.0" },
@@ -1162,28 +1160,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3c/c1/54176da7749a1f35d62cf9212b839dacd841a41a4c6fb15805d4631260b0/niquests-3.18.3.tar.gz", hash = "sha256:d561dfeb5a932f9b5c7724302543883774d4a175fc22d9301753ab304c89ce08", size = 1020598, upload-time = "2026-03-30T07:17:21.67Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/38/0dedd89270e47eaf9bfaff526dd109510426c869b0421846902617fef04f/niquests-3.18.3-py3-none-any.whl", hash = "sha256:3db9831becafd3e48323c2ab4044801a9ddf7f08a634dab2276013e117cf0ae7", size = 207748, upload-time = "2026-03-30T07:17:20.033Z" },
-]
-
-[[package]]
-name = "nrel-pysam"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/91/7398f1bb9fd62d6c330816f9dca731cadf5a7cd49def6630aa85ccdfcfac/NREL_PySAM-7.1.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4bf5c48ccc25482b8b3802235e8adb8c1b5847e34e61a0493a2a91d2ec2ca683", size = 35465271, upload-time = "2025-08-11T16:26:26.347Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6a/afe9f30d2ee8add0412abdfab44d3fa74af6dfc055a10510b11d263985fb/NREL_PySAM-7.1.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:13240cb8488b59cda7da5453e71784e740ec3ce4a65b74331530f5d59c21c6d0", size = 36240527, upload-time = "2025-08-11T16:40:34.438Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/a8/1de97500c96c09e22af8f4e2cfa5c591a2888b6f6a504102fa978c711f06/NREL_PySAM-7.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:b8684ec80f6f063faa12dc11725aaa7bf4a7fd1fcc4b06f2767a43a31ef96972", size = 32837101, upload-time = "2025-08-11T16:40:46.473Z" },
-    { url = "https://files.pythonhosted.org/packages/95/c0/fd31ad86a5bf030b7cc0b85a7ee05eebb6badbd6b39ab1318fa16b82003f/NREL_PySAM-7.1.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5fade062ebc016c355182d8b1cec6ff8666e91e4bb31a57aeacab51ba19d6fa7", size = 35479725, upload-time = "2025-08-11T16:26:33.652Z" },
-    { url = "https://files.pythonhosted.org/packages/44/fe/a301f0f0e4d66f0ff5c2198f506925eb0de1301da5bac7debea3db5de263/NREL_PySAM-7.1.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:33ab57a6c33752426ef1ef33b88bc4765d62f7cbcd900cb9d80bef6c5cc6c59f", size = 36258468, upload-time = "2025-08-11T16:40:50.321Z" },
-    { url = "https://files.pythonhosted.org/packages/69/1d/f04d4e88ebc56d789795cb5c532feed1034d69860fa294b57f4d2435d37d/NREL_PySAM-7.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:011c303535a86f6f574a05801ba93321ebc714d1a711f2bd80a3e61e2adc2b6d", size = 32853532, upload-time = "2025-08-11T16:40:58.372Z" },
-    { url = "https://files.pythonhosted.org/packages/33/3f/b83a791cb0b930739c4572b91016f47443d3f21f787960aa786210fc5189/NREL_PySAM-7.1.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:2e03066c5f48a33ccb8f0d2257da60fe8864a2701f510a7c347fb274790078fa", size = 35476841, upload-time = "2025-08-11T16:26:41.147Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/4c/f91306e5046e161adb79a808255380afecff587b911f0f5a8e6866048caf/NREL_PySAM-7.1.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:ec394d7be641b305cdc8e29777d34c1f3993904e7cf56666bd40264b53d61e94", size = 36278249, upload-time = "2025-08-11T16:41:03.312Z" },
-    { url = "https://files.pythonhosted.org/packages/65/5b/50d7bab99f4608846d0376c131365ff1eaa41557a74f4657632caeef68bf/NREL_PySAM-7.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:ce4f7560db91e8b635a553ab2a809ca9f67b49d5110629eeafc1bce8b14dac80", size = 32854147, upload-time = "2025-08-11T16:41:14.654Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/3c/ebdbb4c860ebca0b52c73959ceb1015db5e13cd61635a0a8582f20dd4b74/nrel_pysam-7.1.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:c3dd553e1bfb54dfe7466bd820df017a1a3e66cbe38496254281ee1add5ce941", size = 45082950, upload-time = "2025-08-11T16:26:30.014Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/cd/dfcfac8688d1cedcb0d9d04d3f5d6ef7da7cf5f37440d5976e43999146ee/nrel_pysam-7.1.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:157f66e28d0bf494d970ab3bf1fa58c208694bb67a45bd25d00eaf31eb125966", size = 47053909, upload-time = "2025-08-11T16:40:42.265Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/47/7ee0e7684e6cb10474ca1a62866fb53e51bcafd7ecbcf2f4f2a277fa0559/nrel_pysam-7.1.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:9887172608b10327f4a0a0ec412fb523d2d9a733e31085cb8ffda776b39d1135", size = 45198587, upload-time = "2025-08-11T16:26:37.347Z" },
-    { url = "https://files.pythonhosted.org/packages/05/e9/4877239dec2b52323d995eac565607c4dc4e7bcfda8b97dfbd001d04d77e/nrel_pysam-7.1.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:0ae907e2903fdd90dea45e73b04017986799ba11456c5cc45d80fb6c291f5c66", size = 47254264, upload-time = "2025-08-11T16:40:54.418Z" },
-    { url = "https://files.pythonhosted.org/packages/58/75/cb75294901ece360b537e5ca4a91fc5d829d2efe32760bc1da418b4e3375/nrel_pysam-7.1.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:74d3c090711795b755d5f390d54e64f9e42b2bee5f33a5ecbe59e15ded3c41dd", size = 45196490, upload-time = "2025-08-11T16:26:44.909Z" },
-    { url = "https://files.pythonhosted.org/packages/81/58/c860ed724993aca7748770a351dc5eaa9612c81435d40cfcf115362b3fb7/nrel_pysam-7.1.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:0290f10db930367d688dc486aceb160a05cc285a0fb4df7096a78398356a00a4", size = 47251341, upload-time = "2025-08-11T16:41:06.753Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`nrel-pysam` was BREOS's only Python 3.14 blocker — it ships no `cp314` wheel
and no sdist. It was never imported directly; it was reached transitively
through pvlib's `fit_cec_sam`, used once (`solar._get_cec_params`) to fit the
CEC single-diode parameters on the default PV path.

This PR replaces that single call with **`breos/cec_fit.py`**, a pure
`scipy`/`pvlib` implementation of the CEC 6-parameter coefficient calculator
(A. Dobos, *J. Solar Energy Eng.* 134, 2012, DOI:10.1115/1.4005759), and drops
the dependency.

`fit_cec_params` is a drop-in for `fit_cec_sam` (same 6-tuple, same order).
`solar._get_cec_params` calls it instead; the `_cec_param_cache` and the public
API are unchanged.

## No change to model results

Validated against the `nrel-pysam` oracle for **every bundled module** by
`tools/validate_cec_fit.py` (kept while pysam is still installable; not shipped):

| Gate | Worst across modules | Threshold |
|------|---------------------|-----------|
| Max Pmp deviation over a T×G grid | **0.025%** | ≤ 0.1% |
| Annual DC energy deviation | **0.004%** | ≤ 0.1% |

## How the algorithm reproduces SAM

- Five reference params from the De Soto constraints (short-/open-circuit, MPP,
  zero power-slope, and the `beta_voc` temperature constraint at `ΔT=2`, which
  is what SAM's `6parsolve` and pvlib's `fit_desoto` actually use).
- `Adjust` solved on a 1-D bracket so the modeled `gamma_pmp` — the secant slope
  of Pmp from −10→50 °C, evaluated through the exact runtime
  `calcparams_cec`/`max_power_point` path — matches the datasheet, with
  warm-start continuation to keep the inner solver on one branch.
- Multi-start (De Soto + Dobos §4.3 empirical guesses, Isc-bump §5 heuristic)
  and widened sanity ranges make it robust on modern high-current modules
  (210 mm cells, Isc > 15 A) without ever raising.

## Catalog change

The two placeholder `Generic_400W` / `Generic_600W_Bifacial` modules carried
made-up values that fit under SAM only via its internal Isc heuristic; they now
carry realistic mono-PERC datasheet specs (nameplate power and keys unchanged).

## Other changes

- `pyproject.toml`: drop `nrel-pysam>=7.1.0`; add the `3.14` classifier.
- `.github/workflows/tests.yml`: add `"3.14"` to the matrix.
- New `tests/test_cec_fit.py` (param recovery, gamma match, gamma-vs-Adjust
  monotonicity, effective-alpha sign, full catalog sweep).
- `CHANGELOG.md`, `ATTRIBUTIONS.md`, `docs/architecture/third-party-wrapping.md`
  updated; `uv.lock` regenerated.

## Verification

- `pytest`: 206 passed (12 new).
- `ruff check` / `ruff format --check`: clean.
- `tools/verify_release_artifacts.py`: builds + installs without pysam.
- Full PV path runs with the `PySAM` import blocked (simulates 3.14).

Target release: 0.3.2.