### PR TITLE
Release 0.3.1: pin requires-python <3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.1] - 2026-06-25
+
+### Changed
+- Pinned `requires-python` to `>=3.11,<3.14`. The transitive `nrel-pysam`
+  dependency (reached through pvlib's CEC fit) publishes no Python 3.14 wheel
+  or sdist, so installs on 3.14 could not resolve. This is a stopgap; 0.3.2
+  removes the `nrel-pysam` dependency and lifts the cap.
+
 ## [0.3.0] - 2026-06-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "breos"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python library for PV and battery energy-system simulation and optimization"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -98,7 +98,7 @@ wheels = [
 
 [[package]]
 name = "breos"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "nrel-pysam" },


### PR DESCRIPTION
Cuts the 0.3.1 hotfix release.

- Bump version 0.3.0 → 0.3.1
- CHANGELOG: document the `requires-python = >=3.11,<3.14` stopgap. The transitive `nrel-pysam` dependency (reached via pvlib's CEC fit) ships no Python 3.14 wheel, so 3.14 installs could not resolve. 0.3.2 removes `nrel-pysam` and lifts the cap.
- `uv.lock` synced to 0.3.1.

The functional pin landed in #41; this PR is the version + changelog bump so a `v0.3.1` tag can be cut from `main` (publish.yml publishes to PyPI on tag push).