### PR TITLE
Prepare 0.3.3 workflow and bug-fix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   model being LFP-only: `"LFP"` normalizes to `"lfp"`, while unsupported
   chemistries raise instead of silently reusing LFP cycle-aging parameters.
 
+### Fixed
+- `PVModuleParams` no longer discards a user-supplied `gamma_pmp`: the
+  constructor argument existed but `__post_init__` unconditionally overwrote
+  it with `T_Pmax_pct`. It now only defaults to `T_Pmax_pct` when not given,
+  matching the `alpha_sc_abs` / `beta_voc_abs` override pattern. Catalog
+  modules and configs that never set `gamma_pmp` are unaffected.
+
 ## [0.3.2] - 2026-06-26
 
 > **Upgrading:** config validation is now strict — a config with an unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+- `breos sweep`, a serial parameter-grid CLI command that expands a `[sweep]`
+  section in a normal App config and writes one combined CSV with varied
+  parameters, resolved system sizing, BREOS version, and scalar result metrics.
+- `configs/examples/sweep.toml` as a runnable sweep example over module count
+  and battery size.
+- Release-smoke tests for the README quickstart, the Monte Carlo example path,
+  and the pymoo-backed multi-objective optimization helper.
+- `breos.solar.resolve_pvwatts_losses`, used by dry-run/config inspection to
+  report resolved PVWatts loss components and their combined percentage.
+
+### Changed
+- `breos run --dry-run` and `breos validate-config --json` now include the
+  fully resolved static PVWatts loss stack instead of only echoing
+  `pv_loss_overrides`.
+- `BatteryConfig.battery_type` is now explicit about the native degradation
+  model being LFP-only: `"LFP"` normalizes to `"lfp"`, while unsupported
+  chemistries raise instead of silently reusing LFP cycle-aging parameters.
+
 ## [0.3.2] - 2026-06-26
 
 > **Upgrading:** config validation is now strict — a config with an unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 - `BatteryConfig.battery_type` is now explicit about the native degradation
   model being LFP-only: `"LFP"` normalizes to `"lfp"`, while unsupported
   chemistries raise instead of silently reusing LFP cycle-aging parameters.
+- `BatteryConfig.eol_percentage` now defaults to `0.70`, aligning with the
+  App config default `battery_eol_percentage = 0.70` and the optimizer's
+  battery-spec fallback (previously `0.80` and `0.8` respectively — three
+  surfaces, two values). App and CLI results are unchanged (they always pass
+  the config value explicitly), but direct `BatteryConfig` users who relied
+  on the implicit `0.80` will now see batteries replaced later, at 70% SOH;
+  pass `eol_percentage=0.8` to keep the old threshold. The same applies to
+  optimization battery specs without an explicit `eol_percentage`.
 
 ### Fixed
 - `dc_to_ac` (and therefore `calculate_pv_production_ac`) clipped ~4% below

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   chemistries raise instead of silently reusing LFP cycle-aging parameters.
 
 ### Fixed
+- `dc_to_ac` (and therefore `calculate_pv_production_ac`) clipped ~4% below
+  the intended inverter AC nameplate: it passed the nameplate
+  (`pv_peak_power_w / inverter_loading_ratio`) as pvlib's `pdc0`, which is a
+  DC-input limit whose AC nameplate is `eta_inv_nom * pdc0`. The DC limit is
+  now derived as `nameplate / eta_inv_nom`, so clipping happens at the same
+  AC rating used by `InverterConfig.size_from_pv`, the App energy balance,
+  `economics.calculate_costs`, and the CLI's reported `ac_rating_kw`. This
+  raises `dc_to_ac` / `calculate_pv_production_ac` outputs slightly at every
+  operating point (most visibly during clipping hours); App simulation
+  results are unchanged because the App path converts DC through
+  `simulate_energy_balance`, not `dc_to_ac`.
 - `PVModuleParams` no longer discards a user-supplied `gamma_pmp`: the
   constructor argument existed but `__post_init__` unconditionally overwrote
   it with `T_Pmax_pct`. It now only defaults to `T_Pmax_pct` when not given,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   and the pymoo-backed multi-objective optimization helper.
 - `breos.solar.resolve_pvwatts_losses`, used by dry-run/config inspection to
   report resolved PVWatts loss components and their combined percentage.
+- `sell_price_inflation` App config key and `--sell-price-inflation` CLI flag
+  (default `0.0`). `CostParams` and `cost_analysis_projection` already
+  supported an annual export-price inflation, but no config key existed and
+  neither the App runner nor the Monte Carlo runner passed it, so the public
+  paths always projected with `0.0`. The value is validated in
+  `validate_config`, threaded through both projection call sites, and shown
+  in `breos run --dry-run` / `validate-config --json`. The `0.0` default
+  reproduces existing results bit-for-bit.
 
 ### Changed
 - `breos run --dry-run` and `breos validate-config --json` now include the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Removed
+- The `Suntech_STP550S_NOMT` catalog module. Its datasheet points were NMOT
+  ratings (800 W/m², Mpp = 415 W), but the CEC single-diode fit interprets
+  `Vmp`/`Imp`/`Voc`/`Isc` as STC values, so the entry produced silently wrong
+  model parameters. Configs referencing it now fail with the standard
+  "Module '...' not found. Available: ..." error; use `Suntech_STP550S_STC`
+  (the same physical module at STC) instead.
+
 ### Added
 - `breos sweep`, a serial parameter-grid CLI command that expands a `[sweep]`
   section in a normal App config and writes one combined CSV with varied

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: "BREOS: Building Renewable Energy Optimization Software"
-message: "If you use BREOS in your research, please cite it as below."
+message: "If you use BREOS in your research, please cite the SSRN preprint below."
 type: software
 authors:
   - given-names: Leonardo
@@ -36,4 +36,6 @@ preferred-citation:
     - given-names: "A. S."
       family-names: Guimarães
   year: 2026
-  notes: "Manuscript under submission."
+  doi: "10.2139/ssrn.7032064"
+  url: "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=7032064"
+  notes: "SSRN preprint."

--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ breos list emissions
 breos list load-profiles
 ```
 
+Run a parameter grid from a normal config plus a `[sweep]` section:
+
+```toml
+location = "porto"
+n_modules = 10
+annual_consumption_kwh = 4000
+battery_kwh = 0.0
+cost_preset = "residential_pt"
+
+[sweep]
+n_modules = [8, 10, 12]
+battery_kwh = [0.0, 5.0]
+```
+
+```bash
+breos sweep --config configs/examples/sweep.toml --output sweep_results.csv
+```
+
+The command runs every parameter combination and writes one CSV row per run,
+including the varied parameters, resolved system sizing, BREOS version, and
+top-level scalar result metrics.
+
 Run a Monte Carlo study over weather-year and demand uncertainty:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -338,15 +338,16 @@ RLP sources, weather/solar-resource APIs, and input assumptions to record.
 
 ## Citation
 
-If you use BREOS in your research, please cite the paper (currently under
-submission):
+If you use BREOS in your research, please cite the preprint:
 
 ```bibtex
-@unpublished{rodrigues2026breos,
+@misc{rodrigues2026breos,
   author = {Rodrigues, L. and Delgado, J. M. P. Q. and Mendes, A. and Guimar{\~a}es, A. S.},
   title  = {A Modular, Open-Source Python Framework for Household PV-Battery Sizing: Validation, Multi-Objective Optimisation, and Uncertainty Analysis},
   year   = {2026},
-  note   = {Manuscript under submission}
+  doi    = {10.2139/ssrn.7032064},
+  url    = {https://papers.ssrn.com/sol3/papers.cfm?abstract_id=7032064},
+  note   = {SSRN preprint}
 }
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,8 +95,9 @@ Option discovery work:
 
 Config inspection work:
 
-- Extend the dry-run summary with the fully resolved PVWatts loss components
-  (today it only echoes `pv_loss_overrides`).
+- **Shipped in 0.3.3:** the dry-run / `validate-config --json` summary now
+  includes the fully resolved static PVWatts loss components and combined loss
+  percentage after applying `pv_loss_overrides`.
 
 Agent and contributor setup:
 
@@ -227,14 +228,72 @@ count, battery size, tilt, tariffs, and so on — which today means scripting th
 Python `App` in a loop by hand. Add a first-class way to enumerate a parameter
 grid (or a set of config files) and collect the per-run results into one table.
 
-- For example a `breos sweep` command over a base config plus a parameter grid,
-  or a glob of config files resolved into one combined CSV/JSON of results.
-- Reuse the worker controls planned under "Resource controls and Apple Silicon
-  hygiene" for parallel execution of independent runs.
-- Echo the resolved config (and `breos` version) per row so a sweep output is
-  self-describing and reproducible.
+- **MVP shipped in 0.3.3:** `breos sweep --config ... --output ...` expands a
+  `[sweep]` parameter grid in a normal App config, runs the Cartesian product
+  serially, and writes one combined CSV with varied parameters, resolved system
+  sizing, the BREOS version, and top-level scalar result metrics.
+- Remaining work: accept a glob/list of config files resolved into one combined
+  CSV/JSON of results.
+- Remaining work: reuse the worker controls planned under "Resource controls
+  and Apple Silicon hygiene" for parallel execution of independent runs.
+- Remaining work: optionally echo a fuller resolved-config payload per row when
+  users need more than the current resolved sizing columns.
 - Non-goal: this is explicit enumeration, not optimization — the `optimization`
   module's NSGA-II sizing already covers searching for good designs.
+
+### Globalization: economics and grid emissions beyond Europe
+
+BREOS ships cost and grid-emission presets that are entirely European. The cost
+catalog (`breos/data/configs/costs.json`) covers only `residential_de`,
+`residential_es`, and `residential_pt` — all Eurozone, priced implicitly in EUR
+with no currency field — and the emissions catalog
+(`breos/data/configs/emissions.json`) covers only the ~36 ENTSO-E countries.
+Adding other countries' economics would let non-European users get realistic
+LCOE, payback, and CO₂ results without hand-entering every cost.
+
+- Introduce an explicit `currency` concept. Today every cost is bare EUR; adding
+  other-country presets first needs a currency field per cost preset, surfaced in
+  results and plots, so a BRL or USD preset cannot be silently mixed with EUR
+  defaults.
+- Add non-EU cost presets to `costs.json` (electricity tariff, feed-in / sold
+  price, module / inverter / storage capex, install and maintenance), each citing
+  its source and year and following the existing `residential_<cc>` key
+  convention.
+- Add non-European grid-emission factors to `emissions.json` beyond the ENTSO-E
+  set (for example BR, US, AU, IN, CN, JP), keyed by the same ISO country codes,
+  with source and vintage documented.
+- Keep the "Unknown cost preset '...'. Available: ..." and "Unknown emissions
+  country '...'" errors actionable as the catalogs grow.
+- Non-goal: live tariff / FX feeds or time-of-use tariff structures — this is
+  static, documented, per-country presets, not a market-data integration.
+
+### Additional Li-ion battery chemistries
+
+The battery degradation model is calibrated for LFP only. Calendar aging uses the
+Naumann 2020 LFP parameter sets (`naumann_lam_field_calibrated` default and
+variants in `breos/constants.py`), and cycle aging uses LFP Wöhler curves
+(`WOEHLER_LFP_CONSERVATIVE` / `_TYPICAL` / `_OPTIMISTIC`, consumed in
+`breos/polysun_degradation.py`). This is the same "label without the physics" gap
+as bifacial modules. In 0.3.3 the native `BatteryConfig.battery_type` selector
+was made honest: `LFP` normalizes to `lfp`, and unsupported values now raise
+instead of silently reusing LFP cycle-aging parameters. Add real per-chemistry
+aging so NMC / NCA packs degrade on their own parameters.
+
+- Add a `battery_chemistry` config key (defaulting to `lfp`) that selects the
+  calendar and Wöhler parameter sets, validated in the existing "Unknown X.
+  Available: ..." style.
+- Add NMC and NCA parameter sets (calendar-aging coefficients and Wöhler `a` / `b`
+  cycle coefficients), each with a documented source; consider LTO and
+  sodium-ion as later additions.
+- Allow per-chemistry calendar-life and round-trip-efficiency defaults where they
+  differ from LFP (for example NMC's higher energy density but shorter cycle
+  life).
+- Default `lfp` must reproduce current results bit-for-bit — regression-test the
+  example configs in `configs/examples/`, exactly as the PV-capability items above
+  require.
+- Non-goal: electrochemical / physics-based (single-particle, P2D) models — this
+  stays an empirical Wöhler-plus-calendar approach, just parameterised per
+  chemistry.
 
 ### 0.3.0 workflow hardening
 
@@ -248,8 +307,9 @@ workflows before adding new feature families:
   demos without committing large weather files.
 - Improve multi-objective sizing examples, result serialization, and Pareto
   plotting documentation.
-- Add release smoke tests for the exact README quickstart, MC example, and MOO
-  example.
+- **Shipped in 0.3.3:** release smoke tests cover the README quickstart, the
+  Monte Carlo example path with generated local weather, and the pymoo-backed
+  multi-objective optimization helper.
 
 ## Distribution and release automation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,23 +3,108 @@
 This document tracks planned work that is not yet scheduled. Items here
 are intentions, not commitments — see GitHub issues for active work.
 
+## Model accuracy and validation
+
+The goal is a gold-standard *engine* — PVsyst/HelioScope-class results
+without the 3D scene modeling. That standard is earned two ways: closing
+known systematic modeling gaps, and publishing reproducible evidence that
+the numbers are right. This work takes priority over architectural
+refactoring (see the deferred adapter layer at the bottom of this document).
+
+### Standing validation and benchmark suite
+
+The single highest-leverage credibility item. PVsyst's authority comes from
+decades of published validation; BREOS needs a reproducible harness that
+compares its annual and monthly yields against SAM/PVWatts and against
+measured public datasets (e.g. NREL PVDAQ), per location and per model
+choice, with deltas documented and tracked over time.
+
+- Start from the existing seeds: `tools/validate_cec_fit.py` and
+  `tools/batch_compare_locations.py`.
+- Publish expected-delta tables per transposition / cell-temperature / IAM
+  choice, and wire a CI job that fails when a delta drifts beyond a stated
+  tolerance.
+- Every new physics capability (bifacial, cell-temperature models, IAM
+  models) lands with its row in the benchmark table — this generalizes the
+  per-item "validate against baseline" notes elsewhere in this roadmap.
+
+### Mid-interval solar position for hourly weather
+
+`solar._prepare_solarpos_and_weather` computes solar position at the
+interval *labels* of hourly averaged irradiance. PVWatts/SAM (and PVsyst,
+equivalently) evaluate sun position at the interval midpoint; using labels
+causes a systematic transposition/AOI error that is worst near
+sunrise/sunset and for east/west-facing arrays, and it biases every
+anisotropic transposition model. This is the cheapest meaningful accuracy
+win available.
+
+- Add a half-interval shift for interval-averaged weather, opt-in at first
+  so existing configs reproduce bit-for-bit, then fold it into the
+  recommended profile (below).
+- While in there, pass `apparent_zenith` consistently: AOI already uses it,
+  but `get_total_irradiance` currently receives the true `zenith`.
+- Document the expected annual-yield delta via the benchmark suite.
+
+### One inverter model everywhere (App, dc_to_ac, optimizer)
+
+Three inverter representations exist today and they disagree: the `App`
+energy balance uses a flat efficiency plus an AC cap treated as the
+nameplate; `solar.dc_to_ac` uses pvlib's pvwatts part-load curve but passes
+the intended AC nameplate as pvlib's `pdc0` (a *DC input* limit), so it
+clips ~4% low; and the NSGA-II optimizer applies no AC clipping at all and
+prices systems without the daily connection fee or battery replacements.
+Designs are picked by one model and reported by another, which biases the
+Pareto front toward high DC/AC ratios whose clipping is never seen.
+
+- Unify on a single conversion model (the pvwatts part-load curve is the
+  better physics) with one definition of the AC nameplate.
+- Make "the optimizer scores designs with the same engine that reports
+  them" a regression-tested invariant; this includes aligning
+  `align_load_to_pv` with the App's wall-clock/UTC load alignment.
+- This extends Phase 1 of "String-aware inverter validation and modeling"
+  below and subsumes its App-only scope.
+
+### Battery charge/discharge power limits
+
+The dispatch loop has no C-rate limits: charging is unbounded (a 5 kWh pack
+absorbs any surplus in a single step) and discharge is bounded only by the
+shared inverter AC rating. Credible sizing studies need power limits.
+
+- Add max charge/discharge power keys (or a C-rate key, default ~0.5C),
+  validated in the existing "Unknown X. Available: ..." style.
+- Unlimited stays available explicitly, and the default must be introduced
+  with a documented yield/self-consumption delta — it will change results
+  for small batteries paired with large arrays.
+
+### Energy loss waterfall
+
+PVsyst's loss diagram is its most-loved diagnostic, and it is pure engine
+work: report the chain transposition gain → IAM → temperature → static
+PVWatts stack (already componentized) → inverter clipping → conversion →
+battery round-trip → curtailment. Today curtailed energy in the surplus
+branch vanishes without a trace, and `inverter.InverterConversionResult`
+already carries clipping bookkeeping but has no production caller. Surface
+the waterfall in `App.result()` and the CLI JSON output.
+
+### Horizon-profile input
+
+Far-horizon shading without any 3D: PVGIS TMY is already fetched with
+`usehorizon=True`, so PVGIS-sourced weather accounts for it implicitly —
+but user-supplied weather files and custom horizons get nothing. Accept a
+horizon profile (azimuth/elevation pairs) and apply it via pvlib's horizon
+tools, documenting the PVGIS overlap so shading is not double-counted.
+
+### Recommended model profile and future defaults
+
+Isotropic transposition, label-timestamp sun position, beam-only IAM, and
+free-standing Faiman coefficients are all kept as defaults for bit-for-bit
+compatibility — but they are not what a gold-standard engine should
+recommend. Define a documented "recommended" profile (haydavies/perez
+transposition, mid-interval sun position, diffuse IAM, mount-appropriate
+thermal coefficients), steer new users to it in the quickstart, and plan
+the default flip for a major version with a clear upgrade note.
+
 ## Architecture
-
-### Wrap third-party modules behind adapters
-
-Concentrate every direct import of `pvlib`, `scipy`, `rainflow`, and other
-third-party scientific libraries in a small `breos.adapters` layer so that
-upstream API changes only affect a single file rather than the whole
-package. The current `Location` parameter exposed by
-`solar.calculate_pv_production_dc` (and several other public functions) is
-a `pvlib.Location`, which means BREOS does not own its own public API.
-
-- Tracking issue: [#11](https://github.com/Str4vinci/breos/issues/11)
-- Design: [docs/architecture/third-party-wrapping.md](docs/architecture/third-party-wrapping.md)
-- Scope: pvlib first (Phase 1), then scipy / rainflow (Phase 2), then IO
-  clients (Phase 3). Pandas, numpy, and matplotlib are kept direct.
-- Estimated effort: ~3–4 weeks of focused work, split into many small
-  PRs.
 
 ### Declarative config schema with strict validation
 
@@ -146,9 +231,15 @@ end-to-end through `build_dc_system_base` and the multi-array path):
 - **Bifacial rear-gain** — see the dedicated item below.
 - **Cell-temperature model choice** — `faiman` is currently hardcoded in
   `_compute_effective_irradiance_and_cell_temp`; expose `sapm`, `pvsyst`, and
-  `noct_sam` with their parameter sets.
+  `noct_sam` with their parameter sets. Lead with mount-type parameter
+  presets (open rack vs roof mount): the current free-standing coefficients
+  run cool for rooftop residential systems — BREOS's primary audience — and
+  systematically overestimate their yield.
 - **IAM model choice** — `ashrae` is currently hardcoded; expose `martin_ruiz`,
-  `physical`, and the SAPM IAM.
+  `physical`, and the SAPM IAM. Also apply IAM to the diffuse components:
+  effective irradiance currently applies IAM to beam only (diffuse passes at
+  1.0), a ~0.5–1% systematic overestimate; pvlib's `iam.marion_diffuse`
+  covers the sky/ground diffuse terms.
 - **DC-side loss refinements** — optional time-series ohmic/soiling/snow models in
   place of (parts of) the flat PVWatts loss stack, where inputs allow.
 - Non-goal: replacing the CEC single-diode core or the PVWatts loss model as the
@@ -209,7 +300,8 @@ provide module, inverter, environment, MPPT, and string-topology data.
 
 - Design note: [docs/architecture/string-inverter-sizing.md](docs/architecture/string-inverter-sizing.md)
 - Phase 1: apply aggregate inverter AC clipping consistently in the main
-  `App` energy flow.
+  `App` energy flow. Shipped for the `App` path; extended and superseded by
+  "One inverter model everywhere" under Model accuracy and validation.
 - Phase 2: add a pure validation API for string voltage windows, startup
   voltage, MPPT current limits, parallel-string compatibility, and DC/AC ratio
   warnings.
@@ -264,8 +356,24 @@ LCOE, payback, and CO₂ results without hand-entering every cost.
   with source and vintage documented.
 - Keep the "Unknown cost preset '...'. Available: ..." and "Unknown emissions
   country '...'" errors actionable as the catalogs grow.
-- Non-goal: live tariff / FX feeds or time-of-use tariff structures — this is
-  static, documented, per-country presets, not a market-data integration.
+- Non-goal: live tariff / FX feeds — this is static, documented, per-country
+  presets, not a market-data integration. Time-of-use tariff *structures* are
+  no longer a non-goal; see the dedicated item below.
+
+### Time-of-use tariff structures
+
+Flat import/export prices cannot value a battery correctly in markets where
+time-of-use tariffs are standard (ES 2.0TD periods, PT bi/tri-horária, DE
+dynamic tariffs) — and battery economics is BREOS's differentiator.
+Restructure the economics layer so a tariff is a pluggable price time series
+rather than a single scalar, and ship static, documented TOU presets per
+country following the existing `residential_<cc>` convention.
+
+- Requires per-timestep import/export pricing in the results path; the
+  flat-price path must reproduce current results bit-for-bit.
+- Later: TOU-aware dispatch (charge/discharge on price signals) as an opt-in
+  strategy — greedy self-consumption stays the default.
+- Non-goal: live tariff APIs, dynamic hourly market prices, FX feeds.
 
 ### Additional Li-ion battery chemistries
 
@@ -323,6 +431,29 @@ documented in [docs/release.md](docs/release.md). Remaining work:
 
 - Protect `v*` tags in GitHub repository settings so only maintainers can
   create release tags.
+
+## Deferred
+
+### Wrap third-party modules behind adapters
+
+**Deprioritized 2026-07:** the model-accuracy and validation work above
+delivers more user-visible value per week of effort; pvlib API churn is
+modest and the `pvlib>=0.14,<0.16` pin already contains it. Revisit once
+the accuracy items land.
+
+Concentrate every direct import of `pvlib`, `scipy`, `rainflow`, and other
+third-party scientific libraries in a small `breos.adapters` layer so that
+upstream API changes only affect a single file rather than the whole
+package. The current `Location` parameter exposed by
+`solar.calculate_pv_production_dc` (and several other public functions) is
+a `pvlib.Location`, which means BREOS does not own its own public API.
+
+- Tracking issue: [#11](https://github.com/Str4vinci/breos/issues/11)
+- Design: [docs/architecture/third-party-wrapping.md](docs/architecture/third-party-wrapping.md)
+- Scope: pvlib first (Phase 1), then scipy / rainflow (Phase 2), then IO
+  clients (Phase 3). Pandas, numpy, and matplotlib are kept direct.
+- Estimated effort: ~3–4 weeks of focused work, split into many small
+  PRs.
 
 ## Reference load profiles pending license verification
 

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -43,6 +43,7 @@ DEFAULTS: dict[str, Any] = {
     "projection_years": 20,
     "cost_preset": None,
     "inflation_rate": 0.02,
+    "sell_price_inflation": 0.0,
     "discount_rate": 0.03,
     "emissions_country": None,
     "pv_degradation_rate": 0.005,
@@ -206,6 +207,8 @@ def validate_config(cfg: dict[str, Any]) -> None:
         for name, value in overrides.items():
             if not isinstance(value, (int, float)) or not 0 <= value <= 100:
                 raise ValueError(f"'pv_loss_overrides[{name!r}]' must be a percentage between 0 and 100")
+    if not -1 < cfg["sell_price_inflation"] < 1:
+        raise ValueError("'sell_price_inflation' must be between -1 and 1 (exclusive)")
     if not 0 <= cfg["battery_min_soc"] < cfg["battery_max_soc"] <= 1:
         raise ValueError("'battery_min_soc' and 'battery_max_soc' must satisfy 0 <= min < max <= 1")
     if not 0 < cfg["battery_eol_percentage"] < 1:
@@ -350,6 +353,7 @@ def resolve_costs(cfg: dict[str, Any]) -> CostParams:
 
     params["dc_ac_ratio"] = cfg["inverter_loading_ratio"]
     params.setdefault("inflation_rate", cfg["inflation_rate"])
+    params.setdefault("sell_price_inflation", cfg["sell_price_inflation"])
     params.setdefault("discount_rate", cfg["discount_rate"])
     params["pv_degradation_rate"] = cfg["pv_degradation_rate"]
 

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -65,6 +65,8 @@ from breos.constants import (
 from breos.economics import BATTERY_REPLACEMENT_COST_PER_KWH
 from breos.utils import get_hours_per_step, remap_datetime_index_years
 
+SUPPORTED_BATTERY_TYPES: tuple[str, ...] = ("lfp",)
+
 
 @dataclass
 class BatteryConfig:
@@ -103,10 +105,12 @@ class BatteryConfig:
     # Inverter AC rating (W) shared by PV and battery discharge; AC output is
     # clipped to this each step. None disables clipping (legacy behavior).
     inverter_ac_capacity_w: Optional[float] = None
-    # Battery chemistry
-    battery_type: str = "lfp"  # Battery chemistry type
+    # Battery chemistry. The native degradation model is currently LFP-only;
+    # unsupported values fail loudly instead of reusing LFP parameters.
+    battery_type: str = "lfp"
 
     def __post_init__(self):
+        self.battery_type = _normalise_battery_type(self.battery_type)
         # Auto-compute replacement cost
         if self.replacement_cost is None:
             if self.nominal_energy_wh > 1:
@@ -1025,12 +1029,25 @@ def resistance_to_efficiency(
     return eff_charge, eff_discharge
 
 
+def _normalise_battery_type(battery_type: str) -> str:
+    """Normalize and validate the native battery chemistry selector."""
+    normalised = str(battery_type).strip().lower()
+    if normalised not in SUPPORTED_BATTERY_TYPES:
+        available = ", ".join(SUPPORTED_BATTERY_TYPES)
+        raise ValueError(
+            f"Unsupported battery_type {battery_type!r}. "
+            f"The native BREOS degradation model currently supports only: {available}."
+        )
+    return normalised
+
+
 def _get_cycle_params(battery_type: str = "lfp") -> Tuple[float, float, float, float, float]:
     """Get cycle aging (Naumann-style) parameters for a battery chemistry.
 
     Returns:
         Tuple of (a_q, b_q, c_doc_q, d_doc_q, z_q)
     """
+    _normalise_battery_type(battery_type)
     return (A_Q, B_Q, C_DOC_Q, D_DOC_Q, Z_Q)
 
 

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -79,11 +79,15 @@ class BatteryConfig:
 
     For AC-coupled systems:
     - All energy goes through inverter first
+
+    ``eol_percentage`` defaults to 0.70 (replace the battery when its state
+    of health falls to 70% of nominal capacity), matching the App config
+    default ``battery_eol_percentage``.
     """
 
     nominal_energy_wh: float  # Required — nominal capacity in Wh
     initial_soh: float = 100.0  # Initial state of health (%)
-    eol_percentage: float = 0.80  # End of life threshold (fraction)
+    eol_percentage: float = 0.70  # End of life threshold (fraction)
     max_soc: float = DEFAULT_MAX_SOC
     min_soc: float = DEFAULT_MIN_SOC
     charge_efficiency: float = DEFAULT_CHARGE_EFFICIENCY

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import csv
+import itertools
 import json
 import sys
 import tomllib
@@ -15,7 +17,7 @@ from breos.app_config import resolve_app_config
 from breos.load_profiles import PROFILE_ALIASES, PROFILE_NAMES
 from breos.pv_modules import MODULES
 from breos.resources import load_config_json
-from breos.solar import PEREZ_MODELS, SURFACE_TYPES, TRANSPOSITION_MODELS
+from breos.solar import PEREZ_MODELS, SURFACE_TYPES, TRANSPOSITION_MODELS, resolve_pvwatts_losses
 
 
 def _package_version() -> str:
@@ -131,6 +133,7 @@ def _resolved_config_summary(config: dict[str, Any]) -> dict[str, Any]:
             "surface_type": cfg["surface_type"],
             "model_perez": cfg["model_perez"],
             "pv_loss_overrides": cfg["pv_loss_overrides"],
+            "losses": resolve_pvwatts_losses(cfg["pv_loss_overrides"]),
         },
         "inverter": {
             "efficiency": cfg["inverter_efficiency"],
@@ -291,6 +294,99 @@ def _validate_config(args: argparse.Namespace) -> int:
     return 0
 
 
+def _normalise_sweep_grid(raw_grid: Any) -> dict[str, list[Any]]:
+    """Validate and normalise a ``[sweep]`` section into parameter lists."""
+    if not isinstance(raw_grid, dict):
+        raise TypeError("Sweep config must contain a [sweep] table with parameter arrays.")
+
+    grid: dict[str, list[Any]] = {}
+    for key, values in raw_grid.items():
+        normalised_key = key.replace("-", "_")
+        if not isinstance(values, list) or not values:
+            raise ValueError(f"sweep.{key} must be a non-empty array of values")
+        grid[normalised_key] = values
+
+    if not grid:
+        raise ValueError("Sweep config must define at least one parameter under [sweep].")
+    return grid
+
+
+def _csv_cell(value: Any) -> Any:
+    """Return a stable scalar representation for CSV output."""
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, sort_keys=True)
+    return value
+
+
+def _scalar_result_items(result: dict[str, Any]) -> dict[str, Any]:
+    """Keep only top-level scalar result metrics for a sweep row."""
+    scalars: dict[str, Any] = {}
+    for key, value in result.items():
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            scalars[key] = value
+    return scalars
+
+
+def _write_sweep_csv(rows: list[dict[str, Any]], output: Path) -> None:
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: _csv_cell(value) for key, value in row.items()})
+
+
+def _sweep(args: argparse.Namespace) -> int:
+    config = _load_config(args.config)
+    raw_grid = config.pop("sweep", None)
+    if raw_grid is None:
+        raise ValueError("Sweep config must include a [sweep] section.")
+
+    grid = _normalise_sweep_grid(raw_grid)
+    param_keys = list(grid)
+    rows: list[dict[str, Any]] = []
+
+    for run_idx, values in enumerate(itertools.product(*(grid[key] for key in param_keys)), start=1):
+        varied = dict(zip(param_keys, values))
+        run_config = {**config, **varied}
+        resolved = _resolved_config_summary(run_config)
+
+        app = App(run_config)
+        app.simulate()
+        result = app.result()
+
+        row: dict[str, Any] = {
+            "run": run_idx,
+            "breos_version": _package_version(),
+        }
+        row.update({f"param_{key}": value for key, value in varied.items()})
+        row.update(
+            {
+                "resolved_location": resolved["location"]["key"] or "custom",
+                "resolved_n_modules": resolved["pv"]["n_modules"],
+                "resolved_battery_kwh": resolved["battery"]["capacity_kwh"],
+                "resolved_pv_kwp": resolved["pv"]["system_kwp"],
+                "resolved_inverter_ac_kw": resolved["inverter"]["ac_rating_kw"],
+            }
+        )
+        row.update(_scalar_result_items(result))
+        rows.append(row)
+
+    _write_sweep_csv(rows, args.output)
+
+    if args.json:
+        print(json.dumps({"runs": len(rows), "results_csv": str(args.output), "rows": rows}, indent=2))
+    else:
+        print(f"Sweep: {len(rows)} runs written to {args.output}")
+    return 0
+
+
 def _montecarlo(args: argparse.Namespace) -> int:
     from breos.montecarlo import MonteCarloSettings, run_montecarlo
 
@@ -420,6 +516,12 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("config", type=Path, help="TOML or JSON config file.")
     validate.add_argument("--json", action="store_true", help="Write machine-readable JSON.")
     validate.set_defaults(func=_validate_config)
+
+    sweep = subparsers.add_parser("sweep", help="Run a parameter-grid sweep from a config [sweep] section.")
+    sweep.add_argument("--config", type=Path, required=True, help="TOML or JSON config file with a [sweep] section.")
+    sweep.add_argument("--output", type=Path, default=Path("sweep_results.csv"), help="Combined results CSV path.")
+    sweep.add_argument("--json", action="store_true", help="Print machine-readable summary to stdout.")
+    sweep.set_defaults(func=_sweep)
 
     mc = subparsers.add_parser(
         "montecarlo",

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -72,6 +72,7 @@ def _build_config(args: argparse.Namespace) -> dict[str, Any]:
     _add_override(overrides, "resolution", args.resolution)
     _add_override(overrides, "projection_years", args.projection_years)
     _add_override(overrides, "inflation_rate", args.inflation_rate)
+    _add_override(overrides, "sell_price_inflation", args.sell_price_inflation)
     _add_override(overrides, "discount_rate", args.discount_rate)
     _add_override(overrides, "pv_degradation_rate", args.pv_degradation_rate)
     _add_override(overrides, "calendar_model", args.calendar_model)
@@ -159,6 +160,7 @@ def _resolved_config_summary(config: dict[str, Any]) -> dict[str, Any]:
             "cost_preset": cfg["cost_preset"],
             "projection_years": cfg["projection_years"],
             "inflation_rate": cfg["inflation_rate"],
+            "sell_price_inflation": cfg["sell_price_inflation"],
             "discount_rate": cfg["discount_rate"],
         },
         "emissions": {
@@ -490,6 +492,9 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--resolution", choices=("h", "15min"), help="Simulation time resolution.")
     run.add_argument("--projection-years", type=int, help="Economic projection horizon.")
     run.add_argument("--inflation-rate", type=float, help="Annual electricity price inflation.")
+    run.add_argument(
+        "--sell-price-inflation", type=float, help="Annual inflation of the grid export (sell) price. Default 0."
+    )
     run.add_argument("--discount-rate", type=float, help="Discount rate for NPV calculations.")
     run.add_argument("--pv-degradation-rate", type=float, help="Annual PV degradation rate.")
     run.add_argument("--calendar-model", help="Battery calendar aging model.")

--- a/breos/montecarlo.py
+++ b/breos/montecarlo.py
@@ -273,6 +273,7 @@ def _simulate_trajectory(
         costs=costs,
         num_years=years_per_run,
         inflation_rate=cfg["inflation_rate"],
+        sell_price_inflation=cfg["sell_price_inflation"],
         discount_rate=cfg["discount_rate"],
         freq=freq,
         yearly_summary_df=yearly_df,

--- a/breos/optimization.py
+++ b/breos/optimization.py
@@ -439,7 +439,7 @@ def _build_battery_config_from_spec(
         discharge_efficiency=batt_spec.get("discharge_efficiency", 0.9795),
         standby_loss_wh=batt_spec.get("standby_loss_wh", 5.0),
         initial_soh=initial_soh,
-        eol_percentage=batt_spec.get("eol_percentage", 0.8),
+        eol_percentage=batt_spec.get("eol_percentage", 0.7),
         inverter_efficiency=inverter_efficiency,
         dc_coupled=batt_spec.get("dc_coupled", True),
         calendar_model=batt_spec.get("calendar_model", "naumann_lam_field_calibrated"),

--- a/breos/pv_modules.py
+++ b/breos/pv_modules.py
@@ -42,23 +42,6 @@ MODULES: Dict[str, PVModuleParams] = {
         N_Cells=6 * 24,  # 144 cells
         Name="Suntech_STP550S-C72/Vmh",
     ),
-    # NMOT-condition variant of the STP550S: same physical 550 W module, but
-    # rated at Nominal Module Operating Temperature (800 W/m2, 20 degC
-    # ambient), hence Mpp=415 under the 550-family key.
-    "Suntech_STP550S_NOMT": PVModuleParams(
-        Mpp=415,  # W - Maximum Power Point at NMOT (550 W at STC)
-        Vmp=38.9,  # V - Voltage at MPP
-        Imp=10.67,  # A - Current at MPP
-        Voc=46.9,  # V - Open circuit voltage
-        Isc=11.22,  # A - Short circuit current
-        celltype="monoSi",
-        Module_Efficiency=0.213,  # fraction - Module Efficiency (21.3 %)
-        T_Pmax_pct=-0.36,  # %/°C - Power temperature coefficient
-        T_Voc_pct=-0.304,  # %/°C - Voltage temperature coefficient
-        T_Isc_pct=0.05,  # %/°C - Current temperature coefficient
-        N_Cells=6 * 24,  # 144 cells
-        Name="Suntech_STP550S-C72/Vmh",
-    ),
     # -------------------------------------------------------------------------
     # 445W Mono-Si Module (Used in max_case.py - Erlangen, Germany)
     # -------------------------------------------------------------------------
@@ -154,7 +137,7 @@ def list_modules() -> List[str]:
 
     Example:
         >>> list_modules()
-        ['Suntech_STP550S_STC', 'Suntech_STP550S_NOMT', 'Erlangen_445W', 'Generic_400W', 'Generic_600W_Bifacial']
+        ['Suntech_STP550S_STC', 'Erlangen_445W', 'Generic_400W', 'Generic_600W_Bifacial']
     """
     return list(MODULES.keys())
 

--- a/breos/runners/app.py
+++ b/breos/runners/app.py
@@ -159,6 +159,7 @@ def run_app_simulation(
         costs=costs,
         num_years=projection_years,
         inflation_rate=cfg["inflation_rate"],
+        sell_price_inflation=cfg["sell_price_inflation"],
         discount_rate=cfg["discount_rate"],
         freq=freq,
         yearly_summary_df=yearly_df,

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -181,7 +181,8 @@ class PVModuleParams:
 
         # 3. HANDLE POWER (gamma_pmp)
         # Power is almost always used as %/C in pvlib models, passed as unitless decimal or %
-        self.gamma_pmp = self.T_Pmax_pct
+        if self.gamma_pmp is None:
+            self.gamma_pmp = self.T_Pmax_pct
 
 
 def _prepare_solarpos_and_weather(weather_data: pd.DataFrame, location: Location, freq: str):

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -588,7 +588,12 @@ def dc_to_ac(
     """
     inv_size = pv_peak_power_w / inverter_loading_ratio
 
-    ac_power = pvlib.inverter.pvwatts(pdc=dc_power, pdc0=inv_size, eta_inv_nom=inverter_efficiency, eta_inv_ref=0.9637)
+    # pvlib's pdc0 is the DC-input limit; the AC nameplate is
+    # pac0 = eta_inv_nom * pdc0. BREOS sizes inverters by AC nameplate
+    # (pv_peak / loading ratio), so back out the matching DC limit.
+    pdc0 = inv_size / inverter_efficiency
+
+    ac_power = pvlib.inverter.pvwatts(pdc=dc_power, pdc0=pdc0, eta_inv_nom=inverter_efficiency, eta_inv_ref=0.9637)
 
     return pd.Series(ac_power, index=dc_power.index, name="ac_power_W")
 

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -37,6 +37,37 @@ DEFAULT_PVWATTS_LOSSES: Dict[str, float] = {
     "availability": 3.0,
 }
 
+
+def resolve_pvwatts_losses(
+    loss_overrides: Optional[Dict[str, float]] = None,
+    *,
+    age_degradation_percent: float = 0.0,
+) -> dict[str, Any]:
+    """Return resolved PVWatts loss components and their combined percentage.
+
+    ``loss_overrides`` replaces named BREOS default components. Age-based
+    degradation is reported separately because App applies annual degradation
+    outside the static PVWatts component stack.
+    """
+    components = dict(DEFAULT_PVWATTS_LOSSES)
+    if loss_overrides:
+        unknown = set(loss_overrides) - set(DEFAULT_PVWATTS_LOSSES)
+        if unknown:
+            valid = ", ".join(sorted(DEFAULT_PVWATTS_LOSSES))
+            raise ValueError(f"Unknown loss component(s) {sorted(unknown)}. Valid components: {valid}")
+        components.update(loss_overrides)
+
+    combined_percent = pvlib.pvsystem.pvwatts_losses(
+        age=age_degradation_percent,
+        **components,
+    )
+    return {
+        "components_pct": components,
+        "age_degradation_pct": float(age_degradation_percent),
+        "combined_pct": float(combined_percent),
+    }
+
+
 # Sky-diffusion (transposition) models for projecting GHI/DHI/DNI onto the
 # plane of array, as supported by pvlib.irradiance.get_total_irradiance.
 # ``isotropic`` is the simple, robust baseline (and the default); the
@@ -284,14 +315,6 @@ def _dc_from_poa(
     to DEFAULT_PVWATTS_LOSSES; ``loss_overrides`` replaces individual
     components (percent).
     """
-    loss_components = dict(DEFAULT_PVWATTS_LOSSES)
-    if loss_overrides:
-        unknown = set(loss_overrides) - set(DEFAULT_PVWATTS_LOSSES)
-        if unknown:
-            valid = ", ".join(sorted(DEFAULT_PVWATTS_LOSSES))
-            raise ValueError(f"Unknown loss component(s) {sorted(unknown)}. Valid components: {valid}")
-        loss_components.update(loss_overrides)
-
     I_L_ref, I_o_ref, R_s, R_sh_ref, a_ref, Adjust = _get_cec_params(pv_params)
 
     with warnings.catch_warnings():
@@ -307,10 +330,10 @@ def _dc_from_poa(
     else:
         age_degradation_factor = 0.0
 
-    total_losses_percent = pvlib.pvsystem.pvwatts_losses(
-        age=age_degradation_factor,
-        **loss_components,
-    )
+    total_losses_percent = resolve_pvwatts_losses(
+        loss_overrides,
+        age_degradation_percent=age_degradation_factor,
+    )["combined_pct"]
 
     p_mp = mpp["p_mp"] if isinstance(mpp, dict) else mpp.p_mp
     dc_power = np.asarray(p_mp) * n_modules * (1 - total_losses_percent / 100)

--- a/configs/README.md
+++ b/configs/README.md
@@ -8,14 +8,15 @@ keep your own runnable example configs.
 ```
 configs/
 ├── base/        # editable copies of the packaged JSON presets (reference only)
-└── examples/    # runnable run configs for `breos run --config`
+└── examples/    # runnable CLI configs for `breos run`, `sweep`, and `montecarlo`
 ```
 
 - **`base/`** mirrors the packaged presets (`locations`, `costs`, `emissions`,
   `financials`, `electricity`). Read them to see what BREOS ships and to copy
   values into your run config. The CLI always loads its own packaged copies, so
   editing files here is for reference — it does not change a run.
-- **`examples/`** holds run configs — the inputs for a single `breos run`.
+- **`examples/`** holds CLI configs — mostly single-run inputs for `breos run`,
+  plus dedicated `sweep` and Monte Carlo examples.
 
 ## Running a simulation
 
@@ -31,6 +32,9 @@ breos run --config configs/examples/pv-only.toml --battery-kwh 5
 
 # Monte Carlo over weather years + demand (needs a multi-year weather file)
 breos montecarlo --config configs/examples/montecarlo.toml --runs 100 --plots
+
+# Parameter grid over a base scenario
+breos sweep --config configs/examples/sweep.toml --output sweep_results.csv
 ```
 
 ### Monte Carlo
@@ -61,6 +65,7 @@ breos list locations | modules | cost-presets | emissions | load-profiles
 | [`pv-only.toml`](examples/pv-only.toml) | Baseline with no battery, to compare storage scenarios against |
 | [`germany-berlin.toml`](examples/germany-berlin.toml) | Swapping location + cost preset + emissions factor together |
 | [`east-west-roof.toml`](examples/east-west-roof.toml) | Multiple `[[pv_arrays]]` (split east/west roof) |
+| [`sweep.toml`](examples/sweep.toml) | Parameter grid over module count and battery size (`breos sweep`) |
 | [`montecarlo.toml`](examples/montecarlo.toml) | Monte Carlo over weather years + demand (`breos montecarlo`) |
 | [`external-rlp.toml`](examples/external-rlp.toml) | Using non-bundled, licensed load profiles |
 
@@ -76,8 +81,8 @@ any example and edit it for your own scenario.
   as a template and put the licensed CSV files in a local directory such as
   `external_rlp/` (do not commit third-party RLPs).
 - `breos run` configs are **flat** key/value files (TOML or JSON). The only
-  recognised table is `[[pv_arrays]]`. The `[montecarlo]` table is read by
-  `breos montecarlo`, and `breos run` ignores it.
+  recognised table for `breos run` is `[[pv_arrays]]`. The `[sweep]` and
+  `[montecarlo]` tables are read by their dedicated CLI commands.
 - Configs written for the research `pvbat` engine — with nested model sections,
   inheritance, or simulation-type blocks — are **not** compatible: BREOS
   silently ignores keys it does not recognise, so those sections would be dropped

--- a/configs/examples/sweep.toml
+++ b/configs/examples/sweep.toml
@@ -1,0 +1,20 @@
+# Parameter sweep: run every combination under [sweep] and collect one CSV.
+#
+#   breos sweep --config configs/examples/sweep.toml --output sweep_results.csv
+#
+# The top-level keys are the base App config. Each key under [sweep] replaces
+# the matching top-level App config key for that run.
+
+location = "porto"
+n_modules = 10
+annual_consumption_kwh = 4000
+battery_kwh = 0.0
+load_profile = "demandlib_h0"
+cost_preset = "residential_pt"
+emissions_country = "PT"
+projection_years = 20
+resolution = "h"
+
+[sweep]
+n_modules = [8, 10, 12]
+battery_kwh = [0.0, 5.0]

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -1,9 +1,11 @@
 # Optimization
 
 Optimization helpers for system configuration. Brent's method handles smooth
-one-dimensional problems (tilt); simple sweeps handle battery sizing and ZEB
+one-dimensional problems (tilt); helper sweeps handle battery sizing and ZEB
 sizing; [pymoo](https://pymoo.org/) powers public multi-objective PV/battery
-sizing (PV count, battery, cost, grid independence, and ZEB ratio).
+sizing (PV count, battery, cost, grid independence, and ZEB ratio). For
+end-to-end App runs over an explicit config grid, use the `breos sweep` CLI
+command documented in [Recipes](../getting-started/recipes.md#parameter-sweep).
 
 Install `breos[optimization]` to use pymoo-backed multi-objective sizing.
 The one-dimensional helpers use the core scientific stack.

--- a/docs/architecture/blast-degradation-engine.md
+++ b/docs/architecture/blast-degradation-engine.md
@@ -1,0 +1,398 @@
+# BLAST Degradation Engine
+
+**Status:** Proposed — not yet implemented
+**Relates to:** ROADMAP "Additional Li-ion battery chemistries"
+**Owner:** BREOS maintainers
+
+## Problem
+
+BREOS's battery degradation is calibrated for **LFP only**. Calendar aging uses
+the Naumann/Lam power-law (`k0, Ea, b, n`) in `update_battery_soh_calendar`, and
+cycle aging uses an LFP Naumann/Wöhler form in `update_battery_soh_cyclewise`.
+Before 0.3.3, a config could name a non-LFP pack (`BatteryConfig.battery_type`)
+but still age it on LFP curves. In 0.3.3 (in `[Unreleased]` at the time of
+writing — `pyproject.toml` still reads 0.3.2) the native path was made explicit:
+`BatteryConfig(battery_type="LFP")` normalizes to `"lfp"`, and unsupported
+chemistries now raise instead of silently reusing LFP cycle-aging parameters.
+The runner (`breos/runners/app.py`) still does not expose battery chemistry as
+an App config key; BLAST remains the planned route for real non-LFP physics.
+
+NREL's [BLAST-Lite](https://github.com/NREL/BLAST-Lite) (BSD-3) provides **14
+lab-calibrated, DOI-cited degradation models** (in the version vendored) spanning
+the exact chemistries the roadmap names (NMC111/622/811, NCA, NCA-Si, LMO, LTO,
+2nd-life). They are empirical (calendar + cycle), not electrochemical/P2D —
+matching our stated non-goal.
+
+## Decision: vendor as a parallel engine, do not re-map parameters
+
+BLAST's parameterization is **structurally different** from BREOS's, so
+translating BLAST numbers into BREOS's `(k0,Ea,b,n)` + Wöhler form is
+lossy-to-impossible:
+
+| BREOS knob | BLAST equivalent | Maps? |
+|---|---|---|
+| `k0` calendar rate | `qcal_A` (absorbs T_ref + %↔fraction) | ✅ algebra |
+| `Ea` Arrhenius | `qcal_B = −Ea/R` | ✅ algebra |
+| `b` time exponent | `qcal_p` | ✅ same role |
+| `n` (`soc^n` stress) | `exp(qcal_C·soc/T)` — exponential, T-coupled (or via `Ua`) | ❌ different function |
+| Wöhler/Naumann cycle `(a,b,c,d,z)` | `(qcyc_A…E, qcyc_p)` — **T-dependent**, linear DOD | ❌ different model |
+
+BREOS cycle aging is temperature-*independent*; BLAST's is not. Worse, several
+target chemistries (NMC111 Kokam, NMC622 DENSO, LFP Sony-Murata, NCA-Si Sony)
+split capacity loss into **separate LLI / LAM / resistance modes**, with LAM a
+**sigmoid "knee"** and DENSO an **exponential break-in** — shapes BREOS's
+single-bucket power-law cannot represent at all. A BLAST parameter is only
+meaningful paired with its exact equation + trajectory kernel.
+
+Therefore: **vendor BLAST's model classes and run them as an opt-in alternative
+engine behind a config selector.** Default LFP path stays bit-for-bit.
+
+## Architecture
+
+```
+breos/degradation/
+  __init__.py
+  blast/                     # vendored, BSD-3 header + NOTICE preserved
+    degradation_model.py     # BatteryDegradationModel base + trajectory kernels
+    rainflow.py              # (or reuse breos's `rainflow` dep — see note)
+    functions.py             # rescale_soc ONLY — see vendoring notes below
+    models/                  # all 14 chemistry classes (enabled in phases)
+  engine.py                  # BlastEngine adapter — uniform step() interface
+```
+
+- **Vendor, do not add `blast-lite` as a PyPI dependency.** The PyPI package
+  pulls `matplotlib`/`pandas` and carries all 14 models. Vendoring lets us trim
+  to a **numpy-only** subset: `degradation_model.py` imports `matplotlib` (only a
+  commented test block) and `pandas` (only the DataFrame input path BREOS won't
+  use) — both removable. Keeps the core install lean, consistent with our
+  optional-extras philosophy. **One exception:** `lfp_gr_SonyMurata3Ah` (P3b)
+  imports `scipy.stats` for cell-to-cell variability sampling — `scipy` is
+  already a BREOS core dependency, so no new dep; the Phase 0/1 flagship + POC
+  (LFP 250Ah, NCA Panasonic) are genuinely numpy-only.
+- **NumPy 2 rename (required, Phase 0).** Upstream pins `numpy<2.0.0` and calls
+  `np.trapz` at ~40 sites (`degradation_model.py:537` plus ~12 of the 14
+  models); BREOS requires `numpy>=2.0`, where `np.trapz` was **removed**.
+  Rename `np.trapz` → `np.trapezoid` throughout the vendored files — the two
+  are numerically identical, so Phase 0 stays behavior-neutral. No other
+  NumPy-2-removed APIs (`np.NaN`, `np.float_`, `np.in1d`, …) appear in the
+  vendoring scope (checked 2026-07-01).
+- **Extract `rescale_soc` only — do not vendor `blast/utils/functions.py`
+  wholesale.** The full file imports `h5pyd`, `geopy`, and `scipy.spatial` for
+  NSRDB-fetching/demo helpers and would fail at import inside BREOS; the base
+  class needs only the ~9-line `rescale_soc`.
+- **Pull from clean upstream `github.com/NREL/BLAST-Lite`** (org renamed —
+  redirects to `NatLabRockies/BLAST-Lite`; record the exact commit vendored in
+  `ATTRIBUTIONS.md`), NOT the local `work/BLAST-Lite` checkout — that copy has
+  a botched `NREL→NLR` find/replace (`nlr.gov`, broken FASTSim links,
+  `Paul.Gasper@nlr.gov`) plus a fork-local `numpy<2.0.0` pin.
+
+### Adapter contract (`breos/degradation/engine.py`)
+
+A thin `BlastEngine` wraps one BLAST model instance and exposes what the energy
+loop needs, mirroring the current native flow:
+
+```python
+class BlastEngine:
+    def __init__(self, blast_model_key: str): ...     # instantiates the class
+    def step(self, t_secs_day, soc_abs_day, T_cell_day_C) -> float:
+        # calls model.update_battery_state(...); returns SoH fraction = outputs['q'][-1]
+    def soh(self) -> float: ...                        # current q
+    def state_snapshot(self) -> dict: ...              # for cross-year threading
+    @classmethod
+    def from_snapshot(cls, key, snapshot) -> "BlastEngine": ...
+    def reset(self): ...                               # on replacement (fresh instance)
+```
+
+BLAST's `update_battery_state(t_secs, soc, T_celsius)` is already designed for
+**incremental chunks** — it appends to internal state arrays and tracks
+cumulative `t_days`/`efc` itself. We pass **per-day relative seconds**
+(`[0, 3600, …, 86400]`); only the per-chunk delta matters, and the model
+accumulates total time. SoH = `outputs['q'][-1]` (fraction of nominal, 1.0→0),
+same semantics as `battery_soh_decimal`.
+
+## Integration (per-day incremental — "Strategy A")
+
+`simulate_energy_balance` already runs degradation on a **daily cadence**: it
+buffers a day of absolute SoC and, once `soc_buf_idx >= steps_per_day`, calls
+`update_battery_soh_cyclewise` + `update_battery_soh_calendar`
+(`breos/battery.py:429-464`). The BLAST path slots in at exactly that point:
+
+```python
+if degradation_engine == "blast":
+    battery_soh_decimal = blast_engine.step(t_secs_day, soc_series.values, mean_T_cell_or_series)
+else:
+    # existing native cyclewise + calendar calls, unchanged
+```
+
+This preserves the **degradation→dispatch feedback** (usable capacity shrinks via
+`update_battery_soc` as SoH drops) — a post-processing "run BLAST once over the
+whole series" approach would break that feedback and is rejected.
+
+### Daily time grid (correctness)
+
+BLAST derives elapsed time from the chunk itself —
+`delta_t_days = t_days[-1] - t_days[0]` (`degradation_model.py:523`). But the loop
+buffers only `steps_per_day` **post-step** SoC samples (`battery.py:413`), which
+for hourly data span 0..23 h — `delta_t_days` would be 23/24, undercounting
+calendar aging (~4 %/day) and dropping the final cycle segment.
+
+The adapter must build a **full-day grid of `steps_per_day + 1` endpoints**:
+
+- **SoC:** prepend the day's start anchor (the prior day's last `soc_absolute`,
+  or the initial SoC on day 0) to the buffered values → 25 points for hourly
+  spanning `t_secs = [0, 3600, …, 86400]`, so `delta_t_days == 1.0` exactly.
+- **Boundary sharing:** day N's last sample *is* day N+1's anchor. Because BLAST
+  computes `delta_efc` per chunk as `sum(|diff(soc)|)/2`, sharing the boundary
+  endpoint counts each SoC segment exactly once across the two chunks — no gap,
+  no double-count.
+- **Temperature:** pass the matching `T_cell` series on the same grid (BLAST
+  trapz-integrates it); the existing `T_cell_day_sum` daily mean is not enough for
+  the series path.
+
+So the BLAST path must retain one extra carry variable: the start-of-day SoC and
+`T_cell` anchors.
+
+### Cross-year state threading (critical)
+
+The runner calls `simulate_energy_balance` **once per simulated year**, threading
+degradation state via `initial_fec`, `initial_calendar_seconds`, etc.
+(`breos/runners/app.py:103-114`). BLAST state is richer than those scalars, so:
+
+- Add `initial_degradation_state: dict | None` param to `simulate_energy_balance`
+  and return a `final_degradation_state` in its tuple (or thread the live
+  `BlastEngine` instance through the year loop).
+- On year N+1, rebuild via `BlastEngine.from_snapshot(...)` so cumulative
+  `t_days`/`efc`/states continue seamlessly.
+
+### Replacement reset
+
+On replacement (`breos/battery.py:507`), the native path zeroes the scalar
+accumulators. BLAST path instead calls `blast_engine.reset()` (fresh instance).
+
+### Resistance fade
+
+Phase 1: **disable `enable_resistance_fade` for the BLAST path** (raise if both
+set) — BLAST multi-mode models expose `outputs['r']`, but mapping resistance→RTE
+derate is its own task. Defer to Phase 4.
+
+## Config plumbing
+
+New keys (added in all the places the ROADMAP "declarative schema" item flags as
+drift-prone — keep additions minimal until that lands):
+
+1. `breos/app_config.py` `DEFAULTS`: `"degradation_engine": "native"`,
+   `"blast_model": None`.
+2. `breos/app_config.py` `validate_config`: `degradation_engine ∈ {native, blast}`;
+   if `blast`, `blast_model` must be a currently-enabled key (actionable
+   "Unknown … Available:" error listing the enabled models). Also **reject
+   `degradation_engine="blast"` together with Monte Carlo** until Phase 4 — raise
+   a clear error, never silently fall back to native (see the Monte Carlo note in
+   Performance / Phasing).
+3. `breos/runners/app.py`: pass both into `BatteryConfig`. **Retire or fully
+   deprecate the legacy `battery_type` field** (see Open decisions) — the new
+   `degradation_engine` / `blast_model` keys replace it; don't overload a field
+   that currently means native-LFP-only.
+4. `breos/cli.py`: `--degradation-engine` / `--blast-model` flags via
+   `_add_override`.
+
+`degradation_engine="native"` (default) ⇒ existing behavior, **bit-for-bit**.
+
+When `blast_model` is set, its chemistry profile (see below) is resolved into the
+`BatteryConfig` defaults *before* user overrides are applied, following the
+precedence rule in "Chemistry profile registry."
+
+## Model catalog (vendor all 14, enable in phases)
+
+Vendor **all 14** model files — they are tiny and share one base class, so the
+marginal cost of the full catalog over a subset is negligible. *Enabling* a key
+(exposing it as a supported `blast_model` value) is gated on a passing smoke test
++ a surfaced `experimental_range`, so the engine is honest about which cells a
+stationary, low-C-rate study is extrapolating.
+
+Enable order is by degradation-form complexity: the 2-bucket power-law models
+need no new kernels; the sigmoid / break-in / multi-mode models exercise the
+`_update_sigmoid_state` / `_update_exponential_relax_state` / `_update_power_B_state`
+kernels and multi-output handling, so they validate last.
+
+| Key | Class | Form | Enable |
+|---|---|---|---|
+| `lfp_gr_250ah_prismatic` | `Lfp_Gr_250AhPrismatic` | 2-bucket power | **P1 — LFP flagship (stationary)** |
+| `nca_gr_panasonic_3ah` | `Nca_Gr_Panasonic3Ah_Battery` | 2-bucket power | **P1 — POC** |
+| `lmo_gr_nissanleaf_66ah_2nd` | `Lmo_Gr_NissanLeaf66Ah_2ndLife_Battery` | 2-bucket power | P3a (2nd-life) |
+| `nmc811_grsi_lgm50_5ah` | `Nmc811_GrSi_LGM50_5Ah_Battery` | 2-bucket power | P3a |
+| `nmc811_grsi_lgmj1_4ah` | `Nmc811_GrSi_LGMJ1_4Ah_Battery` | 2-bucket power | P3a |
+| `nmc_gr_50ah_b1` | `NMC_Gr_50Ah_B1` | 2-bucket power | P3a |
+| `nmc_gr_50ah_b2` | `NMC_Gr_50Ah_B2` | 2-bucket power | P3a |
+| `nmc_gr_75ah_a` | `NMC_Gr_75Ah_A` | 2-bucket power | P3a |
+| `nmc111_gr_sanyo_2ah` | `Nmc111_Gr_Sanyo2Ah_Battery` | 3× power (q + R) | P3a |
+| `nmc_lto_10ah` | `Nmc_Lto_10Ah_Battery` | 3× power (incl. qGain rise) | P3a |
+| `lfp_gr_sonymurata_3ah` | `Lfp_Gr_SonyMurata3Ah_Battery` | sigmoid + power_B, multi-mode | P3b |
+| `nca_grsi_sonymurata_2p5ah` | `NCA_GrSi_SonyMurata2p5Ah_Battery` | 2× sigmoid | P3b |
+| `nmc111_gr_kokam_75ah` | `Nmc111_Gr_Kokam75Ah_Battery` | power×4 + sigmoid (LLI+LAM+R) | P3b |
+| `nmc622_gr_denso_50ah` | `Nmc622_Gr_DENSO50Ah_Battery` | power + exp break-in | P3b |
+
+Note: several keys (Panasonic, Sony-Murata cylindrical, the NMC fast-charge
+pouches) are EV / high-power cells tested well above stationary C-rates — they
+run, but lean on the out-of-range warning below.
+
+## Chemistry profile registry (per-chemistry settings)
+
+There are **three tiers** of per-chemistry data; only the third is a user
+*setting*. Conflating them is the trap to avoid.
+
+1. **Degradation parameters** (`qcal_*` / `qcyc_*`) — baked into the vendored
+   BLAST class, calibrated to papers. **Never user-tunable.**
+2. **Validity ranges** (`experimental_range`, e.g. the 250Ah LFP declares
+   `cycling_temperature: [10, 45]`, `dod: [0.8, 1]`, `max_rate_charge: 0.65`) —
+   also baked in; drives **warnings, not tuning**.
+3. **Operating-envelope defaults** — RTE, SoC window (`min_soc`/`max_soc`),
+   `eol_percentage`, C-rate limits, energy density. These **differ by chemistry**
+   (LFP tolerates 0–100% DoD + long calendar life; NMC/NCA prefer narrower
+   windows; LTO huge cycle life / low energy density; 2nd-life Leaf starts below
+   100% SoH) and **are the legitimate "settings per chemistry."**
+
+### Design: a declarative registry feeding existing `BatteryConfig` fields
+
+A small `breos/degradation/chemistry_profiles.py` (or JSON in `breos/data/configs/`,
+mirroring the existing `costs.json` / `emissions.json` preset pattern) keyed by
+`blast_model`, supplying **only tier-3 defaults**. Selecting a model auto-loads
+its profile; every field stays independently overridable.
+
+Precedence (explicit, least-surprising):
+
+```
+explicit user config  >  chemistry profile default  >  global BatteryConfig default
+```
+
+**Merge-order implementation note.** `resolve_app_config` currently does
+`merge_defaults(config)` *then* validates (`app_config.py:382-385`), so by
+validation time the raw user keys are indistinguishable from defaults. To honor
+the precedence above, capture the **raw user key set** before merging and resolve
+as `{**DEFAULTS, **chemistry_profile, **raw_user_config}` — the profile fills only
+keys the user did not set. (This is also a prerequisite the ROADMAP "declarative
+schema" item will need.)
+
+### Rules
+
+- **Don't fabricate tier-3 numbers.** Ship a per-chemistry default only where a
+  source supports it; otherwise inherit the global default. (Same "documented
+  source" bar the ROADMAP sets — a made-up per-chemistry RTE is worse than the
+  honest global default.)
+- **Cost stays out of the chemistry profile.** $/kWh already lives in the
+  cost-preset system; duplicating it here creates two sources of truth. The
+  profile owns the *electrochemical* envelope only.
+- **Warn, don't block, on conflicts.** If a user picks NMC and forces
+  `max_soc=1.0`, emit an `experimental_range` warning — don't reject it.
+
+Net: BLAST class owns the *physics*, the chemistry profile owns *policy
+defaults*, the user keeps the final say.
+
+## Known integration risks to verify
+
+- **Throughput double-counting.** BLAST rescales `delta_efc`/`Crate` by current
+  SoH *internally* (`_extract_stressors` multiplies by `outputs['q'][-1]` to
+  convert to nominal-normalized units). BREOS's `soc_absolute` is normalized by
+  **current** capacity — `Battery_Energy_Wh / (nominal_energy_wh ×
+  battery_soh_decimal)` (`battery.py:407`) — which is exactly the input BLAST's
+  internal rescale assumes, so the composition is correct by construction: no
+  double-derate. The adapter-parity validation case must still assert this
+  invariant (per-day `delta_efc` × nominal ≈ energy actually cycled that day).
+- **Time-base continuity** across daily chunks and across yearly
+  `simulate_energy_balance` calls — assert cumulative `t_days` is monotonic and
+  matches wall-clock.
+- **Temperature input granularity.** Native calendar uses daily-mean cell temp;
+  BLAST `_extract_stressors` can take the intraday series (it trapz-integrates).
+  Decide per-day series vs mean; prefer passing the day's `T_cell` series.
+
+## Testing & validation
+
+- **Vendoring smoke (Phase 0):** every vendored module imports under BREOS's
+  `numpy>=2.0` and each model runs one `update_battery_state` chunk — catches
+  the upstream `np.trapz` usage (removed in NumPy 2) and any missed heavy
+  imports.
+- **Regression (gate):** default `native` path reproduces current results
+  bit-for-bit on `configs/examples/` — same rule as every PV-capability item.
+- **Adapter parity:** a constant 25 °C / fixed-SoC profile through `BlastEngine`
+  matches BLAST standalone (`model.simulate_battery_life`) to ≤1e-6 — proves the
+  adapter doesn't distort the model.
+- **Cross-year continuity:** 1×20yr run == 20×1yr runs threaded through the
+  snapshot API (SoH trajectory identical).
+- **Per-chemistry smoke:** each enabled key runs a 20-yr sim; SoH monotonic
+  non-increasing (except LTO qGain early-life), ends in a plausible band; no NaNs.
+- **Replacement:** EoL triggers `reset()` and SoH returns to ~1.0.
+
+## Performance note
+
+The BLAST path does per-day rainflow + trapz; it does **not** use the
+`numba_kernels` fast path. Fine for single studies (~7300 daily calls / 20 yr).
+For Monte Carlo / NSGA-II inner loops it will be slower — defer a fast mode
+(BLAST's own `is_constant_input` repeat-accumulate, or numba) to Phase 4.
+
+Monte Carlo also has its **own** year loop with separate state threading
+(`montecarlo.py:182`), which the Phase 1 runner changes do not touch. So
+`degradation_engine="blast"` + Monte Carlo is **rejected at validation** until
+Phase 4 wires that loop — never silently run as native.
+
+## Licensing / attribution
+
+- Preserve the BSD-3 copyright header (`Alliance for Energy Innovation, LLC`) and
+  the DOE-contract `NOTICE` text in every vendored file.
+- Add a BLAST-Lite entry to `ATTRIBUTIONS.md` (source, commit/version vendored,
+  DOIs of the model papers).
+
+## Phasing
+
+- **Phase 0** — Vendor **all 14** model files + base class + rainflow +
+  `rescale_soc` (numpy-only trim; **`np.trapz` → `np.trapezoid`** NumPy-2
+  rename); license/NOTICE/ATTRIBUTIONS with the upstream commit pinned. No
+  behavior change (`np.trapezoid` is numerically identical).
+- **Phase 1** — `BlastEngine` adapter (incl. the daily-grid endpoint
+  construction) + minimal App-level `degradation_engine`/`blast_model` config;
+  **cross-year state threading + replacement reset** — *required here, not
+  deferred*: the runner loops `simulate_energy_balance` once per year
+  (`runners/app.py:68`), so without threading every simulated year silently
+  resets BLAST. Enable the two simple 2-bucket-power models end-to-end —
+  **LFP 250Ah prismatic (flagship)** + **NCA Panasonic (POC)**; default path
+  untouched. Adapter-parity, cross-year-continuity, and regression tests.
+- **Phase 2** — The **chemistry profile registry** (precedence + raw-key
+  merge-order) + full config/CLI plumbing (`--degradation-engine` /
+  `--blast-model`; **retire** the legacy `battery_type` selector — see the
+  resolved decision below).
+- **Phase 3a** — Enable the remaining **power-law** chemistries (LMO 2nd-life,
+  NMC811 M50/MJ1, NMC 50Ah B1/B2, NMC 75Ah A, NMC111 Sanyo, NMC-LTO);
+  per-chemistry smoke tests + `experimental_range` out-of-bounds warnings.
+- **Phase 3b** — Enable the **sigmoid / break-in / multi-mode** chemistries
+  (LFP Sony-Murata, NCA-Si Sony-Murata, NMC111 Kokam, NMC622 DENSO) — exercises
+  the sigmoid/exp/power-B kernels and multi-output handling.
+- **Phase 4 (later)** — **Monte Carlo BLAST support** (thread state through
+  `montecarlo.py`'s own year loop — until then `blast` + MC raises);
+  resistance-fade mapping for multi-mode models; fast/repeat mode for Monte
+  Carlo; ROADMAP + docs update.
+
+## Open decisions
+
+Settle before implementation begins:
+
+- **[OPEN] Cross-year state carrier.** Either thread a serialized
+  `state_snapshot()` dict through `simulate_energy_balance`'s return tuple
+  (consistent with the existing `initial_fec` / `final` scalar pattern; keeps
+  engine objects out of the function signature) **or** pass the live `BlastEngine`
+  instance through the runner's year loop (less code). Recommendation:
+  **snapshot** — BLAST state is four dicts of numpy arrays
+  (`states`/`outputs`/`stressors`/`rates`), trivially copyable and picklable,
+  which Phase 4 Monte Carlo (process pools) will want anyway; a live engine
+  mutates a caller-owned object across yearly calls, a pattern
+  `simulate_energy_balance` currently avoids. Not yet decided.
+
+Resolved:
+
+- **[DECIDED] Do not repurpose `battery_type` for BLAST chemistry.** In 0.3.3 it
+  became a guarded native-LFP selector instead of a silent no-op for non-LFP
+  values. The new `degradation_engine` / `blast_model` keys should select BLAST
+  chemistry rather than overloading `battery_type`.
+
+## Non-goals
+
+- Replacing the native Naumann/Lam LFP path as the default.
+- Electrochemical / P2D models.
+- Re-mapping BLAST parameters into BREOS's equation form.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -60,7 +60,8 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 Unknown top-level keys are rejected at load time. A misspelled key such as
 `batery_kwh` raises an error listing the offending key rather than being
 silently ignored (which would quietly fall back to the default). The optional
-`[montecarlo]` section used by `breos montecarlo` is recognised and allowed.
+`[sweep]` and `[montecarlo]` sections used by their dedicated CLI commands are
+recognised and allowed.
 
 ## Battery capacity and the SOC window
 
@@ -91,6 +92,11 @@ maps to the v1 field calibration. The explicit
 `"naumann_lam_field_calibrated_v2"` for the v2 field-calibrated fit with Lam
 `Ea`/`n` fixed and `k0`/`b` fitted to field data.
 
+The native BREOS degradation path is currently calibrated for LFP cells only.
+Lower-level `BatteryConfig(battery_type="LFP")` normalizes to `"lfp"`; other
+chemistries raise instead of silently reusing LFP cycle-aging parameters. See
+the roadmap for the planned opt-in multi-chemistry degradation engine.
+
 ## Discovering available options
 
 Use the CLI to list packaged option keys:
@@ -113,8 +119,10 @@ breos run --config quickstart.toml --dry-run
 ```
 
 These commands resolve packaged presets, modules, inverter sizing, battery
-settings, load-profile choices, and emissions settings without fetching weather
-or simulating.
+settings, load-profile choices, emissions settings, and the static PVWatts loss
+stack without fetching weather or simulating. In JSON output, `pv.losses`
+contains the resolved component percentages plus the combined PVWatts loss
+percentage after applying any `pv_loss_overrides`.
 
 ## Custom location
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -43,6 +43,7 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `projection_years` | `20` | Economic projection horizon |
 | `cost_preset` | `None` | Cost preset key from packaged defaults |
 | `inflation_rate` | `0.02` | Annual electricity price inflation |
+| `sell_price_inflation` | `0.0` | Annual inflation of the grid export (sell) price |
 | `discount_rate` | `0.03` | Discount rate for NPV |
 | `emissions_country` | `None` | Country code for CO2 calculations (`"PT"`, `"DE"`, `"ES"`, ...) |
 | `pv_degradation_rate` | `0.005` | Annual PV degradation rate (0.5% / year) |

--- a/docs/getting-started/options.md
+++ b/docs/getting-started/options.md
@@ -34,7 +34,6 @@ Catalogue keys for the `pv_module` config key, from `breos.pv_modules.MODULES`.
 | `Erlangen_445W` | 445 | Erlangen_445W | monoSi |
 | `Generic_400W` | 400 | Generic 400W (LONGi LR4-72HPH-400M ref) | monoSi |
 | `Generic_600W_Bifacial` | 600 | Generic 600W bifacial (utility-scale ref) | monoSi |
-| `Suntech_STP550S_NOMT` | 415 | Suntech_STP550S-C72/Vmh | monoSi |
 | `Suntech_STP550S_STC` | 550 | Suntech_STP550S-C72/Vmh | monoSi |
 
 ## Cost presets

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -36,7 +36,10 @@ breos run --config quickstart.toml --output result.json
 fetching weather or running a simulation. `--dry-run` writes the same resolved
 configuration summary as JSON. A successful dry run shows the location,
 timezone, module count, PV size, inverter AC rating, load profile, battery
-capacity, cost preset, and emissions preset.
+capacity, cost preset, emissions preset, and resolved static PVWatts loss
+components. The loss block applies any `pv_loss_overrides` and reports the
+combined percentage, so you can verify shading/soiling/wiring assumptions before
+fetching weather.
 
 The final command runs the full simulation and writes a JSON object with
 scalar headline keys plus `yearly`, `monthly`, and `financial` detail blocks.

--- a/docs/getting-started/recipes.md
+++ b/docs/getting-started/recipes.md
@@ -113,6 +113,39 @@ raises annual yield further. Leave both unset to keep pvlib's 0.25 default.
 From the CLI, the equivalent flag is `--transposition-model perez`
 (alias `--sky-model`).
 
+## Parameter sweep
+
+Use `breos sweep` when you want to run the same scenario over an explicit grid
+of App config values. The top-level keys define the base scenario; every key
+under `[sweep]` replaces the matching top-level key for each run. The command
+runs the Cartesian product and writes one CSV row per combination:
+
+```toml
+location = "porto"
+n_modules = 10
+annual_consumption_kwh = 4000
+battery_kwh = 0.0
+load_profile = "demandlib_h0"
+cost_preset = "residential_pt"
+emissions_country = "PT"
+projection_years = 20
+resolution = "h"
+
+[sweep]
+n_modules = [8, 10, 12]
+battery_kwh = [0.0, 5.0]
+```
+
+```bash
+breos sweep --config config.toml --output sweep_results.csv
+```
+
+The output includes the varied parameters (`param_*` columns), resolved system
+sizing, the BREOS version, and top-level scalar result metrics such as grid
+independence, NPV, payback, LCOE, and battery replacement totals. This is
+explicit enumeration, not an optimizer; use the optimization API for searching
+over objectives and constraints.
+
 ## 15-minute resolution
 
 Hourly weather is interpolated to 15-minute steps (Makima), and the bundled

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,7 @@ resources
 release
 architecture/third-party-wrapping
 architecture/string-inverter-sizing
+architecture/blast-degradation-engine
 legal/load-profile-data
 adr/index
 changelog

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -174,6 +174,17 @@ class TestAppValidation:
                 }
             )
 
+    def test_invalid_sell_price_inflation(self):
+        with pytest.raises(ValueError, match="sell_price_inflation"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "sell_price_inflation": 1.0,
+                }
+            )
+
     def test_invalid_pv_loss_overrides_value(self):
         with pytest.raises(ValueError, match="pv_loss_overrides"):
             App(
@@ -319,6 +330,25 @@ class TestAppValidation:
         # A 10% SOC window stores a tenth of the energy of the default
         # 10-90% window, so grid independence must drop
         assert narrow_gi < default_gi
+
+    def test_sell_price_inflation_reaches_projection(self, _patch_weather):
+        def _run(**extra):
+            app = App(
+                {
+                    "location": "porto",
+                    "n_modules": 6,
+                    "annual_consumption_kwh": 3000,
+                    "projection_years": 2,
+                    **extra,
+                }
+            )
+            app.simulate()
+            return app.result()["npv_savings_eur"]
+
+        # Inflating the export price raises later-year export revenue, so
+        # cumulative NPV savings must grow. The key used to exist only on
+        # CostParams and never reached cost_analysis_projection from a config.
+        assert _run(sell_price_inflation=0.5) > _run()
 
     def test_transposition_model_reaches_simulation(self, _patch_weather):
         def _run(model):

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -9,6 +9,7 @@ from breos.battery import (
     _get_degradation_params,
     apply_indoor_temperature_model,
     simulate_energy_balance,
+    update_battery_soh_cyclewise,
 )
 from breos.constants import LAM_EA_J_MOL, LAM_SOC_EXPONENT_N
 
@@ -37,8 +38,18 @@ class TestBatteryConfig:
         assert cfg.replacement_cost == 1000.0
 
     def test_battery_type_accessible(self):
-        cfg = BatteryConfig(nominal_energy_wh=5000, battery_type="lfp")
+        cfg = BatteryConfig(nominal_energy_wh=5000, battery_type="LFP")
         assert cfg.battery_type == "lfp"
+
+    def test_non_lfp_battery_type_rejected(self):
+        with pytest.raises(ValueError, match="supports only: lfp"):
+            BatteryConfig(nominal_energy_wh=5000, battery_type="nmc")
+
+    def test_cycle_aging_rejects_non_lfp_battery_type(self):
+        soc = pd.Series([0.1, 0.8, 0.2], index=pd.date_range("2025-01-01", periods=3, freq="h"))
+
+        with pytest.raises(ValueError, match="supports only: lfp"):
+            update_battery_soh_cyclewise(1.0, soc, 5000.0, battery_type="nca")
 
     def test_field_calibrated_default_is_v1(self):
         assert _get_degradation_params("naumann_lam_field_calibrated") == _get_degradation_params(

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -19,10 +19,24 @@ class TestBatteryConfig:
         cfg = BatteryConfig(nominal_energy_wh=5000)
         assert cfg.max_soc == 0.90
         assert cfg.min_soc == 0.10
+        assert cfg.eol_percentage == 0.70
         assert cfg.dc_coupled is True
         assert cfg.inverter_efficiency == 0.96
         assert cfg.battery_type == "lfp"
         assert cfg.calendar_model == "naumann_lam_field_calibrated"
+
+    def test_eol_default_agrees_across_config_surfaces(self):
+        # BatteryConfig, the App config DEFAULTS, and the optimizer's
+        # battery-spec fallback used to disagree (0.80 / 0.70 / 0.8); the
+        # replacement threshold must default to the same value everywhere.
+        from breos.app_config import DEFAULTS
+        from breos.optimization import _build_battery_config_from_spec
+
+        direct = BatteryConfig(nominal_energy_wh=5000)
+        from_spec = _build_battery_config_from_spec({}, nominal_energy_wh=5000)
+
+        assert direct.eol_percentage == DEFAULTS["battery_eol_percentage"]
+        assert from_spec.eol_percentage == DEFAULTS["battery_eol_percentage"]
 
     def test_replacement_cost_auto(self):
         cfg = BatteryConfig(nominal_energy_wh=10000)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,27 @@ def test_run_from_flags_outputs_json(monkeypatch, capsys):
     assert output["grid_independence_pct"] == 42.0
 
 
+def test_run_flag_sell_price_inflation_reaches_config(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "App", FakeApp)
+
+    exit_code = cli.main(
+        [
+            "run",
+            "--location",
+            "porto",
+            "--n-modules",
+            "10",
+            "--annual-consumption-kwh",
+            "4000",
+            "--sell-price-inflation",
+            "0.03",
+        ]
+    )
+
+    assert exit_code == 0
+    assert FakeApp.seen_config["sell_price_inflation"] == 0.03
+
+
 def test_run_from_toml_config_with_cli_override(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "App", FakeApp)
     config_path = tmp_path / "experiment.toml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the BREOS command line interface."""
 
+import csv
 import json
 
 from breos import cli
@@ -172,3 +173,55 @@ battery_kwh = 5.0
     assert output["valid"] is True
     assert output["location"]["key"] == "porto"
     assert output["pv"]["n_modules"] == 10
+    assert output["pv"]["losses"]["components_pct"]["shading"] == 3.0
+    assert 14.0 < output["pv"]["losses"]["combined_pct"] < 15.0
+
+
+def test_sweep_expands_grid_and_writes_combined_csv(monkeypatch, tmp_path, capsys):
+    seen_configs = []
+
+    class SweepFakeApp:
+        def __init__(self, config):
+            self.config = config
+            seen_configs.append(config)
+
+        def simulate(self):
+            return None
+
+        def result(self):
+            return {
+                "grid_independence_pct": 40.0 + self.config["n_modules"],
+                "npv_savings_eur": 1000.0 + self.config["battery_kwh"],
+                "yearly": [{"year": 1}],
+            }
+
+    monkeypatch.setattr(cli, "App", SweepFakeApp)
+    config_path = tmp_path / "sweep.toml"
+    config_path.write_text(
+        """
+location = "porto"
+n_modules = 8
+annual_consumption_kwh = 3500
+battery_kwh = 0
+cost_preset = "residential_pt"
+
+[sweep]
+n_modules = [8, 10]
+battery_kwh = [0.0, 5.0]
+""".strip(),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "sweep.csv"
+
+    exit_code = cli.main(["sweep", "--config", str(config_path), "--output", str(output_path), "--json"])
+
+    assert exit_code == 0
+    assert len(seen_configs) == 4
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["runs"] == 4
+    rows = list(csv.DictReader(output_path.open(encoding="utf-8")))
+    assert len(rows) == 4
+    assert rows[0]["param_n_modules"] == "8"
+    assert rows[-1]["param_battery_kwh"] == "5.0"
+    assert "yearly" not in rows[0]
+    assert rows[0]["grid_independence_pct"] == "48.0"

--- a/tests/test_economics.py
+++ b/tests/test_economics.py
@@ -29,6 +29,7 @@ class TestCostDefaultsSingleSource:
             "cost_preset": "minimal",
             "inverter_loading_ratio": 1.25,
             "inflation_rate": 0.02,
+            "sell_price_inflation": 0.01,
             "discount_rate": 0.0,
             "pv_degradation_rate": 0.005,
         }
@@ -39,6 +40,7 @@ class TestCostDefaultsSingleSource:
         assert params == CostParams(
             dc_ac_ratio=1.25,
             inflation_rate=0.02,
+            sell_price_inflation=0.01,
             discount_rate=0.0,
             pv_degradation_rate=0.005,
         )

--- a/tests/test_montecarlo.py
+++ b/tests/test_montecarlo.py
@@ -87,6 +87,24 @@ def test_run_montecarlo_defaults_years_to_projection_years(tmp_path):
     assert result.summary["npv_savings_eur"]["std"] == 0.0
 
 
+def test_run_montecarlo_threads_sell_price_inflation(tmp_path, monkeypatch):
+    import breos.montecarlo as mc_module
+
+    weather = _write_multiyear_weather(tmp_path / "multi.csv")
+    seen = {}
+    original = mc_module.cost_analysis_projection
+
+    def _capture(*args, **kwargs):
+        seen["sell_price_inflation"] = kwargs.get("sell_price_inflation")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(mc_module, "cost_analysis_projection", _capture)
+    settings = MonteCarloSettings(weather_file=str(weather), n_runs=1, years_per_run=2, seed=0)
+    run_montecarlo({**_base_config(), "sell_price_inflation": 0.04}, settings)
+
+    assert seen["sell_price_inflation"] == 0.04
+
+
 def test_run_montecarlo_rejects_empty_weather(tmp_path):
     empty = tmp_path / "empty.csv"
     pd.DataFrame({"date": [], "shortwave_radiation": []}).to_csv(empty, index=False)

--- a/tests/test_pv_modules.py
+++ b/tests/test_pv_modules.py
@@ -1,0 +1,25 @@
+"""Tests for the PV module catalog."""
+
+import pytest
+
+from breos.pv_modules import MODULES, get_module, list_modules
+
+
+class TestCatalog:
+    def test_get_module_is_case_insensitive_copy(self):
+        module = get_module("suntech_stp550s_stc")
+        module.Mpp = 1
+        assert MODULES["Suntech_STP550S_STC"].Mpp == 550
+
+    def test_unknown_module_error_lists_available(self):
+        with pytest.raises(KeyError, match="not found. Available:"):
+            get_module("No_Such_Module")
+
+    def test_nomt_entry_removed(self):
+        # The Suntech_STP550S_NOMT entry fed NMOT datasheet points (800 W/m2,
+        # Mpp=415) into the STC-based CEC fit, which interprets Vmp/Imp/Voc/Isc
+        # as STC values — physically wrong, so the entry was removed. Lookups
+        # must fail with the actionable catalog error, not fit silently.
+        assert "Suntech_STP550S_NOMT" not in list_modules()
+        with pytest.raises(KeyError, match="not found. Available:"):
+            get_module("Suntech_STP550S_NOMT")

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,0 +1,122 @@
+"""Release-smoke coverage for documented public workflows."""
+
+import tomllib
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import breos
+from breos.montecarlo import MonteCarloSettings, run_montecarlo
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _weather_frame(index: pd.DatetimeIndex) -> pd.DataFrame:
+    hour = index.hour.to_numpy()
+    daylight = np.clip(np.sin((hour - 6) / 12 * np.pi), 0, None)
+    ghi = 700.0 * daylight
+    return pd.DataFrame(
+        {
+            "temperature_2m": 15.0 + 8.0 * daylight,
+            "wind_speed_10m": 2.0,
+            "shortwave_radiation": ghi,
+            "direct_normal_irradiance": 0.8 * ghi,
+            "diffuse_radiation": 0.2 * ghi,
+        },
+        index=index,
+    )
+
+
+def _write_multiyear_weather(path: Path, years=(2021,)) -> Path:
+    frames = []
+    for year in years:
+        idx = pd.date_range(f"{year}-01-01", f"{year}-12-31 23:00", freq="h")
+        weather = _weather_frame(idx)
+        weather.insert(0, "date", idx)
+        frames.append(weather)
+    pd.concat(frames, ignore_index=True).to_csv(path, index=False)
+    return path
+
+
+def test_readme_quickstart_smoke(_patch_weather):
+    app = breos.App(
+        {
+            "location": "porto",
+            "n_modules": 10,
+            "annual_consumption_kwh": 4000,
+            "battery_kwh": 5.0,
+            "cost_preset": "residential_pt",
+            "emissions_country": "PT",
+        }
+    )
+
+    app.simulate()
+    result = app.result()
+
+    assert result["grid_independence_pct"] > 0
+    assert result["payback_year"] is None or result["payback_year"] >= 1
+    assert "npv_savings_eur" in result
+    assert result["co2_avoided_total_kg"] > 0
+
+
+def test_montecarlo_example_config_smoke(tmp_path):
+    with (REPO_ROOT / "configs" / "examples" / "montecarlo.toml").open("rb") as f:
+        config = tomllib.load(f)
+
+    weather_file = _write_multiyear_weather(tmp_path / "historical.csv")
+    config["projection_years"] = 1
+    config["montecarlo"]["weather_file"] = str(weather_file)
+    config["montecarlo"]["n_runs"] = 1
+    config["montecarlo"]["years_per_run"] = 1
+
+    settings = MonteCarloSettings(
+        weather_file=str(weather_file),
+        n_runs=1,
+        years_per_run=1,
+        seed=42,
+    )
+
+    result = run_montecarlo(config, settings)
+
+    assert len(result.runs) == 1
+    assert result.available_years == [2021]
+    assert "npv_savings_eur" in result.summary
+
+
+def test_multi_objective_optimization_smoke():
+    pytest.importorskip("pymoo")
+
+    from breos.optimization import optimize_system_multi_objective
+
+    idx = pd.date_range("2025-01-01 00:00", periods=24, freq="h", tz="UTC")
+    tmy_data = _weather_frame(idx)
+    houseload = pd.DataFrame({"Load": [500.0] * len(idx)}, index=idx)
+    config = {
+        "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
+        "simulation": {"resolution": "h"},
+        "constraints": {
+            "budget_eur": 100000.0,
+            "max_area_m2": 100.0,
+            "max_modules": 4,
+            "max_battery_kwh": 2.0,
+            "max_tilt_deg": 30.0,
+        },
+        "mode": {"fixed_azimuth": 180},
+        "battery": {"temperature": 20.0, "min_soc": 0.1, "max_soc": 0.9},
+    }
+
+    result = optimize_system_multi_objective(
+        tmy_data,
+        houseload,
+        config,
+        pop_size=4,
+        n_gen=1,
+        seed=1,
+        verbose=False,
+    )
+
+    pareto = result.details["pareto"]
+    assert not pareto.empty
+    assert {"Modules", "Battery_kWh", "Grid_Independence_%", "NPV_Eur", "ZEB_Ratio"}.issubset(pareto.columns)

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -12,6 +12,7 @@ from breos.solar import (
     calculate_multi_array_production,
     calculate_pv_production_dc,
     calculate_pv_production_dc_tracking,
+    dc_to_ac,
     default_azimuth,
     estimate_optimal_tilt,
 )
@@ -43,6 +44,31 @@ class TestPVModuleParams:
         # A user-supplied gamma_pmp must not be silently replaced by T_Pmax_pct.
         params = _module_params(gamma_pmp=-0.30)
         assert params.gamma_pmp == -0.30
+
+
+class TestDcToAc:
+    def _dc(self, watts, periods=4):
+        idx = pd.date_range("2023-06-01", periods=periods, freq="h", tz="UTC")
+        return pd.Series([float(watts)] * periods, index=idx)
+
+    def test_clips_at_ac_nameplate(self):
+        # AC nameplate = pv_peak / loading ratio = 8000 W. pvlib's pdc0 is a
+        # DC-input limit (pac0 = eta * pdc0), so passing the nameplate as pdc0
+        # used to clip ~4% low, at eta * nameplate = 7680 W.
+        ac = dc_to_ac(self._dc(20000.0), pv_peak_power_w=10000.0, inverter_loading_ratio=1.25, inverter_efficiency=0.96)
+        assert ac.max() == pytest.approx(8000.0)
+
+    def test_full_dc_limit_reaches_nameplate_exactly(self):
+        # At pdc == pdc0 (= nameplate / eta) the pvwatts curve outputs pac0.
+        ac = dc_to_ac(
+            self._dc(8000.0 / 0.96), pv_peak_power_w=10000.0, inverter_loading_ratio=1.25, inverter_efficiency=0.96
+        )
+        assert ac.iloc[0] == pytest.approx(8000.0)
+
+    def test_part_load_stays_below_input_and_nameplate(self):
+        ac = dc_to_ac(self._dc(4000.0), pv_peak_power_w=10000.0, inverter_loading_ratio=1.25, inverter_efficiency=0.96)
+        assert (ac < 4000.0).all()
+        assert (ac <= 8000.0).all()
 
 
 class TestTiltAndAzimuth:

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -8,12 +8,41 @@ from breos.solar import (
     PEREZ_MODELS,
     SURFACE_TYPES,
     TRANSPOSITION_MODELS,
+    PVModuleParams,
     calculate_multi_array_production,
     calculate_pv_production_dc,
     calculate_pv_production_dc_tracking,
     default_azimuth,
     estimate_optimal_tilt,
 )
+
+
+def _module_params(**overrides):
+    """Generic_400W-style datasheet values for PVModuleParams tests."""
+    params = dict(
+        Mpp=400,
+        Vmp=41.0,
+        Imp=9.76,
+        Voc=49.3,
+        Isc=10.30,
+        T_Pmax_pct=-0.35,
+        T_Voc_pct=-0.265,
+        T_Isc_pct=0.05,
+        N_Cells=144,
+    )
+    params.update(overrides)
+    return PVModuleParams(**params)
+
+
+class TestPVModuleParams:
+    def test_gamma_pmp_defaults_to_power_coefficient(self):
+        params = _module_params()
+        assert params.gamma_pmp == params.T_Pmax_pct
+
+    def test_gamma_pmp_override_is_respected(self):
+        # A user-supplied gamma_pmp must not be silently replaced by T_Pmax_pct.
+        params = _module_params(gamma_pmp=-0.30)
+        assert params.gamma_pmp == -0.30
 
 
 class TestTiltAndAzimuth:


### PR DESCRIPTION
## Summary
- add the serial `breos sweep` CLI workflow, example config, docs, and release-smoke coverage
- expose resolved PVWatts losses in config inspection and make native battery chemistry behavior explicit
- fix PV module gamma overrides, standalone AC clipping, sell-price inflation plumbing, the invalid NOMT module entry, and EOL default alignment
- update roadmap priorities around model accuracy and validation

## Verification
- `uv run pytest -q` (254 passed)
- `uv run ruff check breos tests`
- `uv run ruff format --check breos tests`
- `uv run sphinx-build -W -b html docs docs/_build/html`