### PR TITLE
Back-merge: 0.3.3 release into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.3.3] - 2026-07-02
 
 ### Removed
 - The `Suntech_STP550S_NOMT` catalog module. Its datasheet points were NMOT
@@ -46,6 +46,13 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   on the implicit `0.80` will now see batteries replaced later, at 70% SOH;
   pass `eol_percentage=0.8` to keep the old threshold. The same applies to
   optimization battery specs without an explicit `eol_percentage`.
+
+### Documentation
+- Updated the README and `CITATION.cff` to cite the SSRN preprint DOI
+  (`10.2139/ssrn.7032064`).
+- Added the BLAST degradation-engine design note and refreshed roadmap
+  priorities around model accuracy, validation, energy-loss accounting, and
+  future default-model profiles.
 
 ### Fixed
 - `dc_to_ac` (and therefore `calculate_pv_production_ac`) clipped ~4% below
@@ -225,8 +232,8 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   stack and moved heavier workflow packages behind extras: `plots`,
   `optimization`, `weather`, `fast`, `validation`, and `location-tools`.
   NREL-PySAM stays in the core set because the default PV model fits CEC
-  single-diode parameters at runtime via pvlib's `fit_cec_sam`. (Removed after
-  0.3.0 — see the Unreleased section above.)
+  single-diode parameters at runtime via pvlib's `fit_cec_sam`. (Removed in
+  0.3.2.)
 - The `dev` extra now installs optional feature dependencies so contributor
   test runs continue to cover optional paths.
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,8 +20,8 @@ keywords:
   - solar
   - degradation
 license: BSD-3-Clause
-version: 0.3.2
-date-released: "2026-06-26"
+version: 0.3.3
+date-released: "2026-07-02"
 preferred-citation:
   type: article
   title: "A Modular, Open-Source Python Framework for Household PV-Battery Sizing: Validation, Multi-Objective Optimisation, and Uncertainty Analysis"

--- a/README.md
+++ b/README.md
@@ -303,12 +303,13 @@ pv_dc = calculate_pv_production_dc(weather, location, tilt=35, surface_azimuth=1
 # ...
 ```
 
-## Version 0.3.2 Scope
+## Version 0.3.3 Scope
 
-BREOS 0.3.2 focuses on PV and stationary-battery simulation, economic
-analysis, emissions, Monte Carlo uncertainty studies, and PV/battery sizing.
-The public API is centered on `breos.App`, with lower-level modules available
-for users who need to assemble their own study pipeline.
+BREOS 0.3.3 focuses on PV and stationary-battery simulation, economic
+analysis, emissions, Monte Carlo uncertainty studies, PV/battery sizing, and
+serial parameter sweeps. The public API is centered on `breos.App`, with
+lower-level modules available for users who need to assemble their own study
+pipeline.
 
 ## Weather Data Note
 

--- a/docs/architecture/blast-degradation-engine.md
+++ b/docs/architecture/blast-degradation-engine.md
@@ -10,8 +10,7 @@ BREOS's battery degradation is calibrated for **LFP only**. Calendar aging uses
 the Naumann/Lam power-law (`k0, Ea, b, n`) in `update_battery_soh_calendar`, and
 cycle aging uses an LFP Naumann/Wöhler form in `update_battery_soh_cyclewise`.
 Before 0.3.3, a config could name a non-LFP pack (`BatteryConfig.battery_type`)
-but still age it on LFP curves. In 0.3.3 (in `[Unreleased]` at the time of
-writing — `pyproject.toml` still reads 0.3.2) the native path was made explicit:
+but still age it on LFP curves. In 0.3.3 the native path was made explicit:
 `BatteryConfig(battery_type="LFP")` normalizes to `"lfp"`, and unsupported
 chemistries now raise instead of silently reusing LFP cycle-aging parameters.
 The runner (`breos/runners/app.py`) still does not expose battery chemistry as

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ uvx breos run --location porto --n-modules 10 --annual-consumption-kwh 4000
 To install a specific release tag directly from GitHub instead:
 
 ```bash
-pip install "breos @ git+https://github.com/Str4vinci/breos.git@v0.3.2"
+pip install "breos @ git+https://github.com/Str4vinci/breos.git@v0.3.3"
 ```
 
 ## From source

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ Design decisions and refactoring plans for BREOS's internal structure.
 
 ## Status
 
-BREOS is pre-1.0 (current release `0.3.2`, beta). The public API may change
+BREOS is pre-1.0 (current release `0.3.3`, beta). The public API may change
 between minor releases. The [roadmap](https://github.com/Str4vinci/breos/blob/main/ROADMAP.md)
 tracks larger refactoring work — notably, the planned [adapter layer for
 third-party libraries](architecture/third-party-wrapping.md) will change

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "breos"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python library for PV and battery energy-system simulation and optimization"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -101,7 +101,7 @@ wheels = [
 
 [[package]]
 name = "breos"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Standard post-release back-merge of `main` into `develop` after tagging v0.3.3.

Brings the 0.3.3 release commit (version bump to 0.3.3, CHANGELOG/CITATION/README/docs) onto develop so it no longer trails at 0.3.2. Clean fast-forward — develop has no commits main lacks.

Matches the back-merge done for 0.3.0/0.3.1/0.3.2.