### PR TITLE
Use PVWatts part-load conversion in App dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to BREOS are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Changed
+- The App energy balance and public `dc_to_ac()` helper now share the same
+  PVWatts part-load inverter curve. Dispatch therefore accounts for loading-
+  dependent conversion losses when serving load, exporting PV, and
+  discharging the battery, while preserving the shared AC nameplate,
+  charge-before-export behavior, and explicit 0.3.4 energy ledger. Lower-
+  level `BatteryConfig` callers that omit an inverter nameplate retain the
+  legacy unbounded flat-efficiency fallback because part load is undefined
+  without a rated power.
+
 ## [0.3.4] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -221,10 +221,11 @@ PV loss overrides, battery SOC limits, tariffs, inflation, and discounting.
   (default `isotropic`), with `albedo`/`surface_type` for ground reflectance
   and `model_perez` for the Perez coefficient set (see configuration docs). See
   [docs/resources.md](docs/resources.md) for pvlib and PV model references.
-- **Inverter**: the energy balance applies a flat `inverter_efficiency` and
-  clips AC output (PV and battery discharge combined) at the inverter rating
-  implied by `inverter_loading_ratio` — the same rating used for inverter
-  CAPEX. DC surplus above the rating can still charge a DC-coupled battery.
+- **Inverter**: the energy balance and `dc_to_ac()` use the same PVWatts
+  part-load curve, parameterized by nominal `inverter_efficiency`, and clip
+  PV and battery discharge at their shared AC rating implied by
+  `inverter_loading_ratio` — the same rating used for inverter CAPEX. DC
+  surplus above the rating can still charge a DC-coupled battery.
 - **Battery SOC window**: `battery_kwh` is the nominal pack capacity. The
   energy balance only cycles the battery between `battery_min_soc` and
   `battery_max_soc`, so the effective storage swing is

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -117,6 +117,7 @@ from breos.inverter import (
     InverterConfig,
     InverterConversionResult,
     calculate_dc_ac_power,
+    dc_power_for_ac_output,
     get_inverter_preset,
 )
 
@@ -318,6 +319,7 @@ __all__ = [
     # Inverter
     "get_inverter_preset",
     "calculate_dc_ac_power",
+    "dc_power_for_ac_output",
     # Battery
     "simulate_energy_balance",
     "apply_indoor_temperature_model",

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -63,6 +63,7 @@ from breos.constants import (
     Z_R,
 )
 from breos.economics import BATTERY_REPLACEMENT_COST_PER_KWH
+from breos.inverter import calculate_dc_ac_power, dc_power_for_ac_output
 from breos.utils import get_hours_per_step, remap_datetime_index_years
 
 SUPPORTED_BATTERY_TYPES: tuple[str, ...] = ("lfp",)
@@ -225,7 +226,8 @@ def _dispatch_dc_step(
         "battery_inverter_loss": 0.0,
         "grid_import": 0.0,
     }
-    pv_ac_max = min(pv_dc * inv_eff, inv_cap_ac_wh)
+    pv_conversion = calculate_dc_ac_power(pv_dc, inv_cap_ac_wh, inv_eff)
+    pv_ac_max = pv_conversion.ac_power_w
 
     def charge(surplus_dc: float) -> float:
         nonlocal battery_energy
@@ -241,21 +243,23 @@ def _dispatch_dc_step(
 
     if has_battery and pv_ac_max >= load:
         ledger["pv_ac_to_load"] = load
-        dc_to_load = load / inv_eff if inv_eff > 0.0 else 0.0
+        dc_to_load = dc_power_for_ac_output(load, inv_cap_ac_wh, inv_eff)
         surplus_dc = max(0.0, pv_dc - dc_to_load)
         drawn = charge(surplus_dc)
         remaining_dc = surplus_dc - drawn
-        export_headroom = max(0.0, inv_cap_ac_wh - load)
-        export_ac = min(remaining_dc * inv_eff, export_headroom)
-        dc_export = export_ac / inv_eff if inv_eff > 0.0 else 0.0
+        direct_conversion = calculate_dc_ac_power(dc_to_load + remaining_dc, inv_cap_ac_wh, inv_eff)
+        export_ac = max(0.0, direct_conversion.ac_power_w - load)
+        dc_export = max(0.0, dc_to_load + remaining_dc - direct_conversion.clipping_loss_dc_w - dc_to_load)
         ledger["pv_ac_export"] = export_ac
         ledger["pv_dc_to_inverter"] = dc_to_load + dc_export
-        ledger["pv_dc_curtailed"] = max(0.0, remaining_dc - dc_export)
+        ledger["pv_dc_curtailed"] = direct_conversion.clipping_loss_dc_w
+        ledger["pv_direct_inverter_loss"] = direct_conversion.conversion_loss_w
     elif has_battery:
         ledger["pv_ac_to_load"] = pv_ac_max
-        dc_to_inverter = pv_ac_max / inv_eff if inv_eff > 0.0 else 0.0
+        dc_to_inverter = pv_dc - pv_conversion.clipping_loss_dc_w
         ledger["pv_dc_to_inverter"] = dc_to_inverter
-        excess_dc = max(0.0, pv_dc - dc_to_inverter)
+        ledger["pv_direct_inverter_loss"] = pv_conversion.conversion_loss_w
+        excess_dc = pv_conversion.clipping_loss_dc_w
         deficit = load - pv_ac_max
         if excess_dc > 1e-12:
             # The inverter is saturated by PV. DC above its immediate AC
@@ -265,31 +269,64 @@ def _dispatch_dc_step(
             ledger["grid_import"] = deficit
         else:
             available = max(0.0, battery_energy - emin)
-            headroom = max(0.0, inv_cap_ac_wh - pv_ac_max)
-            target_ac = min(deficit, cap_discharge_ac_wh, headroom)
-            total_eff = eff_discharge * inv_eff
-            if available > 0.0 and total_eff > 0.0 and target_ac > 0.0:
-                draw = min(available, target_ac / total_eff)
+            target_total_ac = min(load, inv_cap_ac_wh)
+            if available > 0.0 and eff_discharge > 0.0 and target_total_ac > pv_ac_max:
+                total_dc_target = dc_power_for_ac_output(target_total_ac, inv_cap_ac_wh, inv_eff)
+                battery_dc = min(available * eff_discharge, max(0.0, total_dc_target - pv_dc))
+
+                def combined_conversion(battery_dc_input: float) -> tuple[float, float, float]:
+                    total_dc = pv_dc + battery_dc_input
+                    conversion = calculate_dc_ac_power(total_dc, inv_cap_ac_wh, inv_eff)
+                    if total_dc <= 0.0:
+                        return 0.0, 0.0, 0.0
+                    battery_ac = conversion.ac_power_w * battery_dc_input / total_dc
+                    pv_ac = conversion.ac_power_w - battery_ac
+                    return pv_ac, battery_ac, conversion.conversion_loss_w
+
+                # The public discharge limit is AC delivered. If it binds,
+                # solve for the battery DC contribution at the one shared
+                # inverter operating point rather than applying a second
+                # independent part-load curve.
+                if math.isfinite(cap_discharge_ac_wh):
+                    _, unconstrained_battery_ac, _ = combined_conversion(battery_dc)
+                    if unconstrained_battery_ac > cap_discharge_ac_wh:
+                        lower = 0.0
+                        upper = battery_dc
+                        for _ in range(40):
+                            midpoint = (lower + upper) / 2.0
+                            _, midpoint_battery_ac, _ = combined_conversion(midpoint)
+                            if midpoint_battery_ac < cap_discharge_ac_wh:
+                                lower = midpoint
+                            else:
+                                upper = midpoint
+                        battery_dc = upper
+
+                pv_delivered_ac, delivered_ac, total_inverter_loss = combined_conversion(battery_dc)
+                draw = battery_dc / eff_discharge
                 battery_energy -= draw
-                after_cells = draw * eff_discharge
-                delivered_ac = after_cells * inv_eff
+                total_inverter_dc = pv_dc + battery_dc
+                battery_inverter_loss = (
+                    total_inverter_loss * battery_dc / total_inverter_dc if total_inverter_dc > 0.0 else 0.0
+                )
                 ledger["battery_discharge_dc"] = draw
                 ledger["battery_ac_to_load"] = delivered_ac
-                ledger["battery_discharge_loss"] = draw - after_cells
-                ledger["battery_inverter_loss"] = after_cells - delivered_ac
-                ledger["grid_import"] = max(0.0, deficit - delivered_ac)
+                ledger["battery_discharge_loss"] = draw - battery_dc
+                ledger["battery_inverter_loss"] = battery_inverter_loss
+                ledger["pv_ac_to_load"] = pv_delivered_ac
+                ledger["pv_direct_inverter_loss"] = total_inverter_loss - battery_inverter_loss
+                ledger["grid_import"] = max(0.0, load - pv_delivered_ac - delivered_ac)
             else:
                 ledger["grid_import"] = deficit
     else:
         usable_ac = pv_ac_max
         ledger["pv_ac_to_load"] = min(usable_ac, load)
         ledger["pv_ac_export"] = usable_ac - ledger["pv_ac_to_load"]
-        dc_to_inverter = usable_ac / inv_eff if inv_eff > 0.0 else 0.0
+        dc_to_inverter = pv_dc - pv_conversion.clipping_loss_dc_w
         ledger["pv_dc_to_inverter"] = dc_to_inverter
-        ledger["pv_dc_curtailed"] = max(0.0, pv_dc - dc_to_inverter)
+        ledger["pv_dc_curtailed"] = pv_conversion.clipping_loss_dc_w
+        ledger["pv_direct_inverter_loss"] = pv_conversion.conversion_loss_w
         ledger["grid_import"] = max(0.0, load - ledger["pv_ac_to_load"])
 
-    ledger["pv_direct_inverter_loss"] = ledger["pv_dc_to_inverter"] * (1.0 - inv_eff)
     return battery_energy, ledger
 
 
@@ -625,7 +662,14 @@ def simulate_energy_balance(
         pv_curtailment = ledger["pv_dc_curtailed"]
         battery_charge_loss = ledger["battery_charge_loss"]
         battery_discharge_loss = ledger["battery_discharge_loss"]
-        pv_production = (pv_dc_power - pv_curtailment) * battery_config.inverter_efficiency
+        # Compatibility field: retain the exact 0.3.4 result when a lower-
+        # level caller omits the inverter rating. With a finite inverter, use
+        # the explicit part-load conversion loss. Public economics use the AC
+        # ledger fields instead.
+        if math.isinf(cap_wh):
+            pv_production = (pv_dc_power - pv_curtailment) * battery_config.inverter_efficiency
+        else:
+            pv_production = pv_dc_power - pv_curtailment - ledger["pv_direct_inverter_loss"]
         battery_energy_delta = Battery_Energy_Wh - battery_energy_beginning
 
         # Compute cell temperature via lumped thermal model

--- a/breos/battery.py
+++ b/breos/battery.py
@@ -587,7 +587,10 @@ def simulate_energy_balance(
     for i in range(n_steps):
         step_time = rng[i]
         # Get values for this timestep via fast array indexing
-        pv_dc_power = _pv_dc_vals[i] * hours_per_step  # DC power (Wh) before inverter
+        # Treat negative model/data artefacts as zero generation, matching the
+        # public inverter helper and preventing negative PV from being
+        # allocated through the shared PV/battery conversion path.
+        pv_dc_power = max(0.0, _pv_dc_vals[i] * hours_per_step)  # DC power (Wh) before inverter
         load = _load_vals[i] * hours_per_step  # AC Load in Wh
         T_ambient = _temp_vals[i]
         T_cell = T_ambient  # default; overridden by thermal model below

--- a/breos/inverter.py
+++ b/breos/inverter.py
@@ -198,6 +198,7 @@ def calculate_dc_ac_power(
     ac_power = max(
         0.0,
         min(
+            dc_used,
             inverter_ac_power,
             (inverter_efficiency / PVWATTS_REFERENCE_EFFICIENCY)
             * pdc0
@@ -244,4 +245,8 @@ def dc_power_for_ac_output(ac_power_w: float, inverter_ac_power: float, inverter
     c = normalized_ac - PVWATTS_CURVE_CONSTANT
     discriminant = max(0.0, b * b - 4.0 * a * c)
     zeta = (-b - math.sqrt(discriminant)) / (2.0 * a)
-    return min(upper, max(0.0, zeta * upper))
+    # At unusually high nominal efficiencies the empirical PVWatts curve can
+    # exceed 100% conversion efficiency around its peak. The forward helper
+    # caps AC output at DC input to preserve energy conservation, so its
+    # inverse must also request at least the target amount of DC.
+    return min(upper, max(ac_target, zeta * upper))

--- a/breos/inverter.py
+++ b/breos/inverter.py
@@ -7,8 +7,14 @@ This module handles:
 - Efficiency calculations
 """
 
+import math
 from dataclasses import dataclass
 from typing import Optional
+
+PVWATTS_REFERENCE_EFFICIENCY = 0.9637
+PVWATTS_CURVE_QUADRATIC = -0.0162
+PVWATTS_CURVE_LINEAR = 0.9858
+PVWATTS_CURVE_CONSTANT = -0.0059
 
 
 @dataclass
@@ -134,7 +140,7 @@ def calculate_dc_ac_power(
     pv_dc_power: float, inverter_ac_power: float, inverter_efficiency: float = 0.96
 ) -> InverterConversionResult:
     """
-    Calculate AC output and loss buckets for a DC-to-AC inverter.
+    Calculate AC output and loss buckets with the PVWatts part-load curve.
 
     Clipping is reported on the DC side: power above the DC input required
     to saturate the AC rating is ``clipping_loss_dc_w``. The AC-equivalent
@@ -144,7 +150,7 @@ def calculate_dc_ac_power(
     Args:
         pv_dc_power: DC power from PV array (W)
         inverter_ac_power: Inverter AC rating (W)
-        inverter_efficiency: Inverter efficiency at MPP
+        inverter_efficiency: Nominal inverter efficiency
 
     Returns:
         InverterConversionResult with AC output and loss buckets.
@@ -161,12 +167,46 @@ def calculate_dc_ac_power(
             clipping_loss_ac_equivalent_w=0.0,
         )
 
-    theoretical_ac = pv_dc_power * inverter_efficiency
-    ac_power = min(theoretical_ac, inverter_ac_power)
-    dc_used = min(pv_dc_power, inverter_ac_power / inverter_efficiency)
+    if pv_dc_power <= 0.0:
+        return InverterConversionResult(
+            ac_power_w=0.0,
+            conversion_loss_w=0.0,
+            clipping_loss_dc_w=0.0,
+            clipping_loss_ac_equivalent_w=0.0,
+        )
+
+    # A lower-level BatteryConfig may intentionally omit the inverter
+    # nameplate. With no rated power there is no part-load ratio to evaluate,
+    # so retain the historical unbounded flat-efficiency behavior. App always
+    # supplies its sized finite AC rating.
+    if not math.isfinite(inverter_ac_power):
+        ac_power = pv_dc_power * inverter_efficiency
+        return InverterConversionResult(
+            ac_power_w=ac_power,
+            conversion_loss_w=pv_dc_power - ac_power,
+            clipping_loss_dc_w=0.0,
+            clipping_loss_ac_equivalent_w=0.0,
+        )
+
+    # PVWatts defines pdc0 as the DC input at which the inverter reaches its
+    # AC nameplate (pac0 = eta_inv_nom * pdc0). BREOS exposes the AC rating,
+    # so derive the matching pdc0 here. This is the single conversion path
+    # used by both the public solar helper and the App dispatch engine.
+    pdc0 = inverter_ac_power / inverter_efficiency
+    dc_used = min(pv_dc_power, pdc0)
+    zeta = dc_used / pdc0
+    ac_power = max(
+        0.0,
+        min(
+            inverter_ac_power,
+            (inverter_efficiency / PVWATTS_REFERENCE_EFFICIENCY)
+            * pdc0
+            * (PVWATTS_CURVE_QUADRATIC * zeta**2 + PVWATTS_CURVE_LINEAR * zeta + PVWATTS_CURVE_CONSTANT),
+        ),
+    )
     clipping_loss_dc = max(0.0, pv_dc_power - dc_used)
     conversion_loss = max(0.0, dc_used - ac_power)
-    clipping_loss_ac_equiv = max(0.0, theoretical_ac - ac_power)
+    clipping_loss_ac_equiv = clipping_loss_dc * inverter_efficiency
 
     return InverterConversionResult(
         ac_power_w=ac_power,
@@ -174,3 +214,34 @@ def calculate_dc_ac_power(
         clipping_loss_dc_w=clipping_loss_dc,
         clipping_loss_ac_equivalent_w=clipping_loss_ac_equiv,
     )
+
+
+def dc_power_for_ac_output(ac_power_w: float, inverter_ac_power: float, inverter_efficiency: float = 0.96) -> float:
+    """Return the minimum DC input required for a requested PVWatts AC output.
+
+    The inverse is solved on the monotonic operating range up to the inverter
+    nameplate. Requests above the nameplate are clamped to it. Keeping this
+    inverse beside :func:`calculate_dc_ac_power` prevents dispatch from
+    silently reverting to a flat-efficiency approximation.
+    """
+    ac_target = max(0.0, min(float(ac_power_w), max(0.0, float(inverter_ac_power))))
+    inverter_ac_power = max(0.0, float(inverter_ac_power))
+    inverter_efficiency = min(1.0, max(0.0, float(inverter_efficiency)))
+    if ac_target <= 0.0 or inverter_ac_power <= 0.0 or inverter_efficiency <= 0.0:
+        return 0.0
+    if not math.isfinite(inverter_ac_power):
+        return ac_target / inverter_efficiency
+
+    upper = inverter_ac_power / inverter_efficiency
+    if ac_target >= inverter_ac_power:
+        return upper
+
+    # Rearrange the PVWatts polynomial in zeta = pdc / pdc0 and take
+    # the root on its monotonic operating interval (0 < zeta < 1).
+    normalized_ac = ac_target * PVWATTS_REFERENCE_EFFICIENCY / inverter_ac_power
+    a = -PVWATTS_CURVE_QUADRATIC
+    b = -PVWATTS_CURVE_LINEAR
+    c = normalized_ac - PVWATTS_CURVE_CONSTANT
+    discriminant = max(0.0, b * b - 4.0 * a * c)
+    zeta = (-b - math.sqrt(discriminant)) / (2.0 * a)
+    return min(upper, max(0.0, zeta * upper))

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -17,6 +17,7 @@ from pvlib.albedo import SURFACE_ALBEDOS
 from pvlib.location import Location
 
 from breos.cec_fit import fit_cec_params
+from breos.inverter import calculate_dc_ac_power
 from breos.utils import get_hours_per_step
 
 # Module-level cache for CEC model parameters (depends only on module specs, not weather)
@@ -1119,12 +1120,7 @@ def dc_to_ac(
     """
     inv_size = pv_peak_power_w / inverter_loading_ratio
 
-    # pvlib's pdc0 is the DC-input limit; the AC nameplate is
-    # pac0 = eta_inv_nom * pdc0. BREOS sizes inverters by AC nameplate
-    # (pv_peak / loading ratio), so back out the matching DC limit.
-    pdc0 = inv_size / inverter_efficiency
-
-    ac_power = pvlib.inverter.pvwatts(pdc=dc_power, pdc0=pdc0, eta_inv_nom=inverter_efficiency, eta_inv_ref=0.9637)
+    ac_power = dc_power.map(lambda value: calculate_dc_ac_power(value, inv_size, inverter_efficiency).ac_power_w)
 
     return pd.Series(ac_power, index=dc_power.index, name="ac_power_W")
 

--- a/docs/api/energy-balance.md
+++ b/docs/api/energy-balance.md
@@ -29,6 +29,13 @@ converts them once to Wh (`W × interval hours`), applies all limits and
 conservation equations in energy units, then converts flows back to W.
 Stored-energy state columns remain Wh.
 
+Direct PV and battery discharge use the same PVWatts part-load inverter
+curve as `breos.solar.dc_to_ac`. The configured AC nameplate remains shared:
+PV output consumes headroom before battery discharge, and combined delivery
+cannot exceed the rating. A lower-level `BatteryConfig` with no inverter
+nameplate keeps the legacy unbounded flat-efficiency fallback because an
+inverter loading fraction cannot be defined without rated power.
+
 ## DC routing and limits
 
 Direct PV serves AC load first. Surplus PV DC charges the battery before
@@ -74,10 +81,11 @@ to a free full state at calendar boundaries.
 
 ## Compatibility fields and KPIs
 
-`PV_Production` is retained as an AC-equivalent compatibility field:
-`(PV_DC − PV_DC_Curtailed) × inverter_efficiency`. It is identical to the
-legacy field when no inverter cap binds, but it is not physical AC delivery
-through storage and new KPIs do not derive from it.
+`PV_Production` is retained as an AC-equivalent compatibility field. With a
+finite inverter it is non-curtailed PV minus the explicit direct-PV inverter
+loss; lower-level callers that omit a nameplate retain the exact legacy
+`(PV_DC − PV_DC_Curtailed) × inverter_efficiency` calculation. It is not
+physical AC delivery through storage, and new KPIs do not derive from it.
 
 Self-consumed PV is `PV_AC_To_Load + Battery_AC_To_Load_PV`. Usable system AC
 generation is self-consumed PV plus `PV_AC_Export`. Grid independence is

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -59,7 +59,7 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `battery_max_charge_power_w` | `None` | Maximum DC power entering the battery charge path; `None` is unlimited |
 | `battery_max_discharge_power_w` | `None` | Maximum battery AC power delivered to load; `None` is unlimited |
 | `dc_coupled` | `True` | DC-coupled / hybrid inverter. `False` is unsupported in 0.3.x and raises |
-| `inverter_efficiency` | `0.96` | Inverter efficiency |
+| `inverter_efficiency` | `0.96` | Nominal inverter efficiency used by the PVWatts part-load curve |
 | `inverter_loading_ratio` | `1.25` | DC/AC oversizing ratio; also sets the inverter AC rating that clips production |
 | `pv_loss_overrides` | `None` | Per-component overrides (percent) for the fixed PVWatts system losses, e.g. `{"shading": 0.0}` |
 | `start_date` | `"2023-01-01"` | First simulation date |

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -404,9 +404,9 @@ class TestAppValidation:
         base = _run(None)
         no_shading = _run({"shading": 0.0})
 
-        # Both operands are rounded to 2 decimals by build_result, so the
-        # tightest honest tolerance is the rounding granularity (±0.005 each).
-        assert no_shading == pytest.approx(base / 0.97, abs=0.011)
+        # Removing a DC loss increases production. The AC increase is not a
+        # fixed 1 / 0.97 ratio because inverter efficiency varies with load.
+        assert no_shading > base
 
     def test_smaller_inverter_clips_app_production(self, _patch_weather):
         def _run(loading_ratio):

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -12,6 +12,8 @@ from breos.battery import (
     update_battery_soh_cyclewise,
 )
 from breos.constants import LAM_EA_J_MOL, LAM_SOC_EXPONENT_N
+from breos.inverter import calculate_dc_ac_power
+from breos.solar import dc_to_ac
 
 
 class TestBatteryConfig:
@@ -238,7 +240,30 @@ class TestSimulateEnergyBalance:
         # Export uses the headroom left after serving the load
         assert results_df["Sell_To_Grid"].max() == pytest.approx(500.0)
         # total_pv sums the clipped AC production
-        assert total_pv == pytest.approx(1000.0 + 1000.0 + 960.0)
+        expected = sum(calculate_dc_ac_power(value, 1000.0, config.inverter_efficiency).ac_power_w for value in pv_dc)
+        assert total_pv == pytest.approx(expected)
+
+    def test_pv_only_dispatch_matches_public_dc_to_ac_curve(self):
+        idx = pd.date_range("2025-01-01", periods=5, freq="h", tz="UTC")
+        pv_dc = pd.Series([0.0, 50.0, 400.0, 900.0, 1400.0], index=idx)
+        houseload = pd.DataFrame({"Load": 0.0}, index=idx)
+        config = BatteryConfig(nominal_energy_wh=0, inverter_ac_capacity_w=1000.0)
+
+        results_df, *_ = simulate_energy_balance(
+            pv_dc=pv_dc,
+            houseload=houseload,
+            battery_config=config,
+            freq="h",
+        )
+        expected = dc_to_ac(
+            pv_dc,
+            pv_peak_power_w=1250.0,
+            inverter_loading_ratio=1.25,
+            inverter_efficiency=config.inverter_efficiency,
+        )
+
+        np.testing.assert_allclose(results_df["PV_Production"], expected)
+        np.testing.assert_allclose(results_df["PV_AC_Export"], expected)
 
     def test_battery_shares_inverter_cap_and_charges_from_clipped_dc(self):
         idx = pd.date_range("2025-01-01 00:00", periods=2, freq="h", tz="UTC")
@@ -380,7 +405,7 @@ class TestEnergyLedger:
         hours = 0.25 if freq == "15min" else 1.0
         assert total_pv == pytest.approx(results["PV_Production"].sum() * hours)
         assert total_pv == pytest.approx(
-            ((results["PV_DC"] - results["PV_DC_Curtailed"]) * config.inverter_efficiency).sum() * hours
+            (results["PV_DC"] - results["PV_DC_Curtailed"] - results["PV_Direct_Inverter_Loss"]).sum() * hours
         )
 
     def test_charge_precedes_export_and_curtailment_is_unusable_dc(self):
@@ -409,6 +434,22 @@ class TestEnergyLedger:
         assert inverter_output.max() <= 2000.0 + 1e-8
         assert results["PV_DC_To_Battery"].max() <= 1000.0 + 1e-8
         assert results["Battery_AC_To_Load"].max() <= 700.0 + 1e-8
+
+        simultaneous = results["Battery_AC_To_Load"] > 0.0
+        combined_dc = (
+            results.loc[simultaneous, "PV_DC_To_Inverter"]
+            + results.loc[simultaneous, "Battery_Discharge_DC"] * config.discharge_efficiency
+        )
+        expected_ac = combined_dc.map(
+            lambda value: (
+                calculate_dc_ac_power(
+                    value,
+                    config.inverter_ac_capacity_w,
+                    config.inverter_efficiency,
+                ).ac_power_w
+            )
+        )
+        np.testing.assert_allclose(inverter_output.loc[simultaneous], expected_ac)
 
     def test_hourly_and_quarter_hour_energy_agree(self):
         pv_hourly = [0.0, 7000.0, 2000.0, 0.0, 9000.0, 0.0]

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -265,6 +265,31 @@ class TestSimulateEnergyBalance:
         np.testing.assert_allclose(results_df["PV_Production"], expected)
         np.testing.assert_allclose(results_df["PV_AC_Export"], expected)
 
+    @pytest.mark.parametrize("nominal_energy_wh", [0.0, 1000.0])
+    def test_negative_pv_input_is_clamped_before_dispatch(self, nominal_energy_wh):
+        idx = pd.date_range("2025-01-01", periods=1, freq="h", tz="UTC")
+        config = BatteryConfig(
+            nominal_energy_wh=nominal_energy_wh,
+            inverter_ac_capacity_w=1000.0,
+            standby_loss_wh=0.0,
+            enable_replacement=False,
+        )
+
+        results, *_ = simulate_energy_balance(
+            pv_dc=pd.Series([-100.0], index=idx),
+            houseload=pd.DataFrame({"Load": [500.0]}, index=idx),
+            battery_config=config,
+            temperature_series=pd.Series(25.0, index=idx),
+        )
+
+        assert results["PV_DC"].iloc[0] == 0.0
+        assert results["PV_DC_To_Battery"].iloc[0] == 0.0
+        assert results["PV_DC_To_Inverter"].iloc[0] == 0.0
+        assert results["PV_AC_To_Load"].iloc[0] == 0.0
+        assert results["Houseload"].iloc[0] == pytest.approx(
+            results["Battery_AC_To_Load"].iloc[0] + results["Import_From_Grid"].iloc[0]
+        )
+
     def test_battery_shares_inverter_cap_and_charges_from_clipped_dc(self):
         idx = pd.date_range("2025-01-01 00:00", periods=2, freq="h", tz="UTC")
         pv_dc = pd.Series([0.0, 3000.0], index=idx)

--- a/tests/test_inverter.py
+++ b/tests/test_inverter.py
@@ -3,7 +3,7 @@
 import pytest
 
 import breos
-from breos.inverter import calculate_dc_ac_power
+from breos.inverter import calculate_dc_ac_power, dc_power_for_ac_output
 
 
 def test_dc_ac_power_exposes_dc_side_clipping_losses():
@@ -29,6 +29,16 @@ def test_dc_ac_power_clips_negative_inputs_to_zero():
 
     assert result.ac_power_w == 0.0
     assert result.total_dc_input_w == 0.0
+
+
+@pytest.mark.parametrize("ac_fraction", [0.01, 0.1, 0.5, 0.9, 1.0])
+def test_dc_ac_inverse_round_trip(ac_fraction):
+    ac_rating = 5000.0
+    target = ac_rating * ac_fraction
+    dc_input = dc_power_for_ac_output(target, ac_rating, inverter_efficiency=0.96)
+    result = calculate_dc_ac_power(dc_input, ac_rating, inverter_efficiency=0.96)
+
+    assert result.ac_power_w == pytest.approx(target, rel=1e-12, abs=1e-9)
 
 
 def test_package_all_exports_stable_inverter_helpers():

--- a/tests/test_inverter.py
+++ b/tests/test_inverter.py
@@ -41,6 +41,15 @@ def test_dc_ac_inverse_round_trip(ac_fraction):
     assert result.ac_power_w == pytest.approx(target, rel=1e-12, abs=1e-9)
 
 
+def test_unity_nominal_efficiency_cannot_create_energy():
+    dc_input = dc_power_for_ac_output(600.0, 1000.0, inverter_efficiency=1.0)
+    result = calculate_dc_ac_power(dc_input, 1000.0, inverter_efficiency=1.0)
+
+    assert dc_input == pytest.approx(600.0)
+    assert result.ac_power_w == pytest.approx(600.0)
+    assert result.total_dc_input_w == pytest.approx(dc_input)
+
+
 def test_package_all_exports_stable_inverter_helpers():
     expected = {
         "calculate_dc_ac_power",


### PR DESCRIPTION
## Summary

- route `breos.App` dispatch through the shared PVWatts part-load inverter curve
- expose conversion and clipping loss buckets without changing the stable App entrypoint
- preserve lower-level unbounded inverter behavior when no finite nameplate is supplied
- enforce energy conservation for unity-efficiency and negative-PV edge cases
- update configuration/API documentation and changelog notes for the 0.4.0 work

## Implementation map

- `breos/inverter.py` owns the shared forward and inverse PVWatts conversion path.
- `breos/battery.py` uses that path for dispatch and loss bookkeeping.
- `tests/test_inverter.py`, `tests/test_battery.py`, and `tests/test_app.py` cover conversion, conservation, clipping, and facade behavior.

## Validation

- `uv run --offline --no-sync pytest -q tests/test_inverter.py tests/test_battery.py tests/test_app.py` — 150 passed
- `uv run --offline --no-sync ruff check breos tests tools`
- `uv run --offline --no-sync ruff format --check breos tests tools`
- independent unity-efficiency inverse round-trip check from 1% through 100% AC output

## Merge note

This change is the inverter/dispatch foundation for the remaining 0.4.0 battery-model work. It uses a merge commit so the later checkpoint ranges retain their original base history.
