### PR TITLE
Add BLAST model profiles and public discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 - App configuration now resolves user values over sourced battery-profile
   defaults over global defaults. Native Naumann/Lam remains the default;
   `blast_model` requires explicit `degradation_engine="blast"`. The ambiguous
-  App-level `battery_type` selector raises with migration guidance instead of
-  being repurposed for chemistry/model selection.
+  App-level `battery_type` selector, which strict App validation already
+  rejected as unknown in 0.3.4, now raises targeted migration guidance instead
+  of being repurposed for chemistry/model selection. The lower-level
+  `BatteryConfig(battery_type="LFP")` API remains supported.
 
 ## [0.3.4] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   (`lfp_gr_250ah_prismatic`, `nca_gr_panasonic_3ah`), and validation that keeps
   BLAST disabled for Monte Carlo and resistance-fade runs until those paths are
   explicitly supported.
+- A declarative 14-model BLAST registry with stable keys, chemistry and cell
+  metadata, experimental ranges, study citations, output capabilities,
+  upstream provenance, Python discovery (`list_battery_models()`), CLI
+  discovery (`breos list battery-models`), explicit CLI model selection, and
+  versioned JSON-safe engine snapshots. BLAST result/provenance blocks identify
+  the cell model, calibration basis, initial/final SOH, replacements, warnings,
+  and state schema.
 
 ### Changed
 - The App energy balance and public `dc_to_ac()` helper now share the same
@@ -21,6 +28,11 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   level `BatteryConfig` callers that omit an inverter nameplate retain the
   legacy unbounded flat-efficiency fallback because part load is undefined
   without a rated power.
+- App configuration now resolves user values over sourced battery-profile
+  defaults over global defaults. Native Naumann/Lam remains the default;
+  `blast_model` requires explicit `degradation_engine="blast"`. The ambiguous
+  App-level `battery_type` selector raises with migration guidance instead of
+  being repurposed for chemistry/model selection.
 
 ## [0.3.4] - 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -307,13 +307,15 @@ with `degradation_engine = "blast"` and a stable `blast_model` key. Discover
 the 14 scientifically identified vendored cell models with
 `breos.list_battery_models()` or `breos list battery-models`; the output
 includes chemistry, form factor, experimental range, citations, capabilities,
-and upstream provenance. App configs using the ambiguous legacy
-`battery_type` selector now receive an actionable migration error.
+and upstream provenance. Strict App config validation already rejected the
+ambiguous `battery_type` selector in 0.3.4; 0.4.0 gives that input an actionable
+migration error. Lower-level `BatteryConfig(battery_type="LFP")` remains
+supported for native degradation.
 
 BLAST model profiles never invent generic chemistry defaults. Resolution is
 user config over sourced profile defaults over global defaults. BLAST remains
 opt-in, and BLAST plus Monte Carlo is rejected explicitly rather than falling
-back to native degradation.
+back to native degradation. BLAST also requires a positive `battery_kwh`.
 
 For full control over individual simulation steps, use the lower-level modules directly:
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,21 @@ single representative tilt/azimuth.
 
 ## Advanced Usage
 
+### Opt-in BLAST degradation models
+
+Native Naumann/Lam degradation remains the default. Select BLAST explicitly
+with `degradation_engine = "blast"` and a stable `blast_model` key. Discover
+the 14 scientifically identified vendored cell models with
+`breos.list_battery_models()` or `breos list battery-models`; the output
+includes chemistry, form factor, experimental range, citations, capabilities,
+and upstream provenance. App configs using the ambiguous legacy
+`battery_type` selector now receive an actionable migration error.
+
+BLAST model profiles never invent generic chemistry defaults. Resolution is
+user config over sourced profile defaults over global defaults. BLAST remains
+opt-in, and BLAST plus Monte Carlo is rejected explicitly rather than falling
+back to native degradation.
+
 For full control over individual simulation steps, use the lower-level modules directly:
 
 ```python

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -93,6 +93,14 @@ from breos.constants import (
     Z_R,
 )
 
+# Battery degradation model discovery
+from breos.degradation import (
+    BATTERY_MODEL_REGISTRY,
+    BatteryModelProfile,
+    get_battery_model_profile,
+    list_battery_models,
+)
+
 # Economics
 from breos.economics import (
     CostParams,
@@ -323,6 +331,10 @@ __all__ = [
     # Battery
     "simulate_energy_balance",
     "apply_indoor_temperature_model",
+    "list_battery_models",
+    "get_battery_model_profile",
+    "BatteryModelProfile",
+    "BATTERY_MODEL_REGISTRY",
     # Emissions
     "calculate_co2_savings",
     "calculate_co2_projection",

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -310,6 +310,8 @@ def validate_config(cfg: dict[str, Any]) -> None:
     cfg["degradation_engine"] = degradation_engine
 
     if degradation_engine == "blast":
+        if cfg["battery_kwh"] <= 0:
+            raise ValueError("'degradation_engine=blast' requires 'battery_kwh' > 0")
         if "montecarlo" in cfg:
             raise ValueError("'degradation_engine=blast' is not supported with Monte Carlo yet")
         if cfg["enable_resistance_fade"]:
@@ -318,7 +320,7 @@ def validate_config(cfg: dict[str, Any]) -> None:
             available = ", ".join(CORE_BLAST_MODEL_KEYS)
             raise ValueError(f"Unknown blast_model {cfg['blast_model']!r}. Available: {available}")
     elif cfg["blast_model"] is not None:
-        raise ValueError("'blast_model' requires degradation_engine='blast'; native degradation remains the default")
+        raise ValueError("'blast_model' requires 'degradation_engine=blast'; native degradation remains the default")
 
 
 def _is_int(value: Any) -> bool:

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -9,7 +9,7 @@ from numbers import Real
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from breos.degradation.engine import P1_BLAST_MODEL_KEYS
+from breos.degradation.profiles import CORE_BLAST_MODEL_KEYS, apply_battery_profile_defaults
 from breos.economics import CostParams, calculate_costs
 from breos.emissions import EmissionsParams
 from breos.pv_modules import MODULES, PVModuleParams, get_module
@@ -89,6 +89,7 @@ ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(DEFAULTS) | {
     "annual_consumption_kwh",
     "n_modules",
     "montecarlo",
+    "battery_type",
 }
 
 
@@ -119,8 +120,8 @@ def load_json(name: str) -> dict[str, Any]:
 
 
 def merge_defaults(config: dict[str, Any]) -> dict[str, Any]:
-    """Return a mutable config with App defaults applied."""
-    return {**DEFAULTS, **config}
+    """Apply user values over BLAST profile defaults over global defaults."""
+    return apply_battery_profile_defaults(DEFAULTS, config)
 
 
 def _validate_sky_settings(
@@ -154,6 +155,11 @@ def _validate_sky_settings(
 
 def validate_config(cfg: dict[str, Any]) -> None:
     """Validate user-facing App config before resolving derived values."""
+    if "battery_type" in cfg:
+        raise ValueError(
+            "'battery_type' is an ambiguous legacy selector and is not supported by App. "
+            "Use degradation_engine='native' (default), or set degradation_engine='blast' with blast_model='<key>'."
+        )
     unknown = set(cfg) - ALLOWED_CONFIG_KEYS
     if unknown:
         available = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
@@ -308,11 +314,11 @@ def validate_config(cfg: dict[str, Any]) -> None:
             raise ValueError("'degradation_engine=blast' is not supported with Monte Carlo yet")
         if cfg["enable_resistance_fade"]:
             raise ValueError("'degradation_engine=blast' cannot be combined with 'enable_resistance_fade'")
-        if cfg["blast_model"] not in P1_BLAST_MODEL_KEYS:
-            available = ", ".join(P1_BLAST_MODEL_KEYS)
+        if cfg["blast_model"] not in CORE_BLAST_MODEL_KEYS:
+            available = ", ".join(CORE_BLAST_MODEL_KEYS)
             raise ValueError(f"Unknown blast_model {cfg['blast_model']!r}. Available: {available}")
     elif cfg["blast_model"] is not None:
-        raise ValueError("'blast_model' requires 'degradation_engine=blast'")
+        raise ValueError("'blast_model' requires degradation_engine='blast'; native degradation remains the default")
 
 
 def _is_int(value: Any) -> bool:

--- a/breos/app_results.py
+++ b/breos/app_results.py
@@ -142,6 +142,7 @@ def _provenance(cfg: dict[str, Any], resolved: ResolvedAppConfig, artifacts: Sim
         "resolution": cfg["resolution"],
         "timezone": resolved.timezone,
         "start_date": cfg["start_date"],
+        "degradation": artifacts.degradation_summary,
     }
 
 
@@ -190,15 +191,21 @@ def build_result(
         "financial": financial_to_dicts(artifacts.cost_projection, total_initial),
         "pv_loss_waterfall": artifacts.pv_loss_waterfall,
         "provenance": _provenance(cfg, resolved, artifacts),
+        "degradation": artifacts.degradation_summary,
     }
 
     if resolved.pv_arrays:
         result["pv_arrays"] = [dict(arr) for arr in resolved.pv_arrays]
 
     if cfg["battery_kwh"] > 0:
-        result["battery_soh_end_pct"] = round(float(artifacts.current_soh), 2)
+        soh_digits = 1 if cfg["degradation_engine"] == "blast" else 2
+        result["battery_soh_end_pct"] = round(float(artifacts.current_soh), soh_digits)
         result["battery_replacements"] = artifacts.total_replacements
         result["battery_replacement_cost_eur"] = round(float(artifacts.total_replacement_cost), 2)
+        if cfg["degradation_engine"] == "blast":
+            for row in result["yearly"]:
+                if "soh_pct" in row:
+                    row["soh_pct"] = round(float(row["soh_pct"]), 1)
 
     if resolved.emissions_params is not None:
         co2 = calculate_co2_savings(yr1_pv, self_consumption_kwh, resolved.emissions_params)

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -14,6 +14,7 @@ from typing import Any, Sequence
 
 from breos.app import App
 from breos.app_config import resolve_app_config
+from breos.degradation import get_battery_model_profile, list_battery_models
 from breos.load_profiles import PROFILE_ALIASES, PROFILE_NAMES
 from breos.pv_modules import MODULES
 from breos.resources import load_config_json
@@ -90,6 +91,8 @@ def _build_config(args: argparse.Namespace) -> dict[str, Any]:
     _add_override(overrides, "discount_rate", args.discount_rate)
     _add_override(overrides, "pv_degradation_rate", args.pv_degradation_rate)
     _add_override(overrides, "calendar_model", args.calendar_model)
+    _add_override(overrides, "degradation_engine", args.degradation_engine)
+    _add_override(overrides, "blast_model", args.blast_model)
     _add_override(overrides, "dc_coupled", args.dc_coupled)
     _add_override(overrides, "inverter_efficiency", args.inverter_efficiency)
     _add_override(overrides, "inverter_loading_ratio", args.inverter_loading_ratio)
@@ -174,6 +177,11 @@ def _resolved_config_summary(config: dict[str, Any]) -> dict[str, Any]:
             "max_soc": cfg["battery_max_soc"],
             "eol_percentage": cfg["battery_eol_percentage"],
             "round_trip_efficiency": cfg["battery_rte"] if cfg["battery_rte"] is not None else 0.95,
+            "degradation_engine": cfg["degradation_engine"],
+            "blast_model": cfg["blast_model"],
+            "model_profile": (
+                get_battery_model_profile(cfg["blast_model"]).as_dict() if cfg["blast_model"] is not None else None
+            ),
         },
         "economics": {
             "cost_preset": cfg["cost_preset"],
@@ -259,6 +267,9 @@ def _load_options(category: str) -> list[dict[str, Any]]:
             for key, name in sorted(PROFILE_NAMES.items())
         ]
 
+    if category == "battery-models":
+        return list_battery_models()
+
     raise ValueError(f"Unknown list category: {category}")
 
 
@@ -287,6 +298,11 @@ def _format_options(category: str, rows: list[dict[str, Any]]) -> str:
             alias_text = f"; aliases: {row['aliases']}" if row.get("aliases") else ""
             lines.append(f"{row['key']}: {name} ({status}{alias_text})")
         return "\n".join(lines)
+    if category == "battery-models":
+        return "\n".join(
+            f"{row['key']}: {row['name']} ({row['chemistry']}, {row['cell_format']}; {row['release_phase']})"
+            for row in rows
+        )
     raise ValueError(f"Unknown list category: {category}")
 
 
@@ -562,6 +578,12 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--pv-degradation-rate", type=float, help="Annual PV degradation rate.")
     run.add_argument("--calendar-model", help="Battery calendar aging model.")
     run.add_argument(
+        "--degradation-engine",
+        choices=("native", "blast"),
+        help="Battery degradation engine (default: native Naumann/Lam).",
+    )
+    run.add_argument("--blast-model", help="Stable BLAST battery-model key; requires --degradation-engine blast.")
+    run.add_argument(
         "--dc-coupled",
         dest="dc_coupled",
         action="store_true",
@@ -579,7 +601,7 @@ def build_parser() -> argparse.ArgumentParser:
     list_parser = subparsers.add_parser("list", help="List packaged option keys.")
     list_parser.add_argument(
         "category",
-        choices=("locations", "modules", "cost-presets", "emissions", "load-profiles"),
+        choices=("locations", "modules", "cost-presets", "emissions", "load-profiles", "battery-models"),
         help="Packaged option category to list.",
     )
     list_parser.add_argument("--json", action="store_true", help="Write machine-readable JSON.")

--- a/breos/degradation/__init__.py
+++ b/breos/degradation/__init__.py
@@ -1,1 +1,15 @@
-"""Battery degradation engines and vendored model code."""
+"""Battery degradation engines, vendored models, and public discovery."""
+
+from breos.degradation.profiles import (
+    BATTERY_MODEL_REGISTRY,
+    BatteryModelProfile,
+    get_battery_model_profile,
+    list_battery_models,
+)
+
+__all__ = [
+    "BATTERY_MODEL_REGISTRY",
+    "BatteryModelProfile",
+    "get_battery_model_profile",
+    "list_battery_models",
+]

--- a/breos/degradation/engine.py
+++ b/breos/degradation/engine.py
@@ -13,25 +13,12 @@ from typing import Any
 import numpy as np
 
 from breos.degradation.blast import models
+from breos.degradation.profiles import BATTERY_MODEL_REGISTRY, BLAST_STATE_SCHEMA_VERSION, CORE_BLAST_MODEL_KEYS
 
-BLAST_MODEL_CLASSES = {
-    "lfp_gr_250ah_prismatic": models.Lfp_Gr_250AhPrismatic,
-    "nca_gr_panasonic_3ah": models.Nca_Gr_Panasonic3Ah_Battery,
-    "lmo_gr_nissanleaf_66ah_2nd": models.Lmo_Gr_NissanLeaf66Ah_2ndLife_Battery,
-    "nmc811_grsi_lgm50_5ah": models.Nmc811_GrSi_LGM50_5Ah_Battery,
-    "nmc811_grsi_lgmj1_4ah": models.Nmc811_GrSi_LGMJ1_4Ah_Battery,
-    "nmc_gr_50ah_b1": models.NMC_Gr_50Ah_B1,
-    "nmc_gr_50ah_b2": models.NMC_Gr_50Ah_B2,
-    "nmc_gr_75ah_a": models.NMC_Gr_75Ah_A,
-    "nmc111_gr_sanyo_2ah": models.Nmc111_Gr_Sanyo2Ah_Battery,
-    "nmc_lto_10ah": models.Nmc_Lto_10Ah_Battery,
-    "lfp_gr_sonymurata_3ah": models.Lfp_Gr_SonyMurata3Ah_Battery,
-    "nca_grsi_sonymurata_2p5ah": models.NCA_GrSi_SonyMurata2p5Ah_Battery,
-    "nmc111_gr_kokam_75ah": models.Nmc111_Gr_Kokam75Ah_Battery,
-    "nmc622_gr_denso_50ah": models.Nmc622_Gr_DENSO50Ah_Battery,
-}
+BLAST_MODEL_CLASSES = {key: getattr(models, profile.class_name) for key, profile in BATTERY_MODEL_REGISTRY.items()}
 
-P1_BLAST_MODEL_KEYS = ("lfp_gr_250ah_prismatic", "nca_gr_panasonic_3ah")
+# Backwards-compatible internal name used by the replayed Phase 1 tests.
+P1_BLAST_MODEL_KEYS = CORE_BLAST_MODEL_KEYS
 
 
 def _as_1d_float_array(name: str, values: Any) -> np.ndarray:
@@ -135,6 +122,7 @@ class BlastEngine:
         """Copy the model state required for cross-year threading."""
 
         snapshot: dict[str, Any] = {
+            "schema_version": BLAST_STATE_SCHEMA_VERSION,
             "blast_model_key": self.blast_model_key,
             "model_kwargs": deepcopy(self._model_kwargs),
         }
@@ -152,6 +140,11 @@ class BlastEngine:
         snapshot_key = snapshot.get("blast_model_key")
         if snapshot_key is not None and snapshot_key != blast_model_key:
             raise ValueError(f"Snapshot blast_model_key {snapshot_key!r} does not match {blast_model_key!r}")
+        schema_version = snapshot.get("schema_version", BLAST_STATE_SCHEMA_VERSION)
+        if schema_version != BLAST_STATE_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported BLAST state schema {schema_version!r}; expected {BLAST_STATE_SCHEMA_VERSION!r}"
+            )
 
         engine = cls(blast_model_key, **snapshot.get("model_kwargs", {}))
         for group_name in cls._ARRAY_GROUPS:

--- a/breos/degradation/profiles.py
+++ b/breos/degradation/profiles.py
@@ -1,0 +1,407 @@
+"""Declarative metadata and discovery for vendored BLAST cell models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+BLAST_UPSTREAM_VERSION = "1.1.0"
+BLAST_UPSTREAM_COMMIT = "d789e00"
+BLAST_STATE_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class BatteryModelProfile:
+    """Stable public identity and scientific scope of one BLAST cell model."""
+
+    key: str
+    name: str
+    source_module: str
+    class_name: str
+    chemistry: str
+    cell_format: str
+    nominal_capacity_ah: float
+    experimental_range: Mapping[str, Any]
+    citations: tuple[str, ...]
+    output_keys: tuple[str, ...]
+    operating_defaults: Mapping[str, Any]
+    release_phase: str
+    notes: str = ""
+
+    @property
+    def supports_capacity(self) -> bool:
+        return "q" in self.output_keys
+
+    @property
+    def supports_resistance(self) -> bool:
+        return "r" in self.output_keys
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "name": self.name,
+            "source_module": self.source_module,
+            "class_name": self.class_name,
+            "chemistry": self.chemistry,
+            "cell_format": self.cell_format,
+            "nominal_capacity_ah": self.nominal_capacity_ah,
+            "experimental_range": dict(self.experimental_range),
+            "citations": list(self.citations),
+            "output_keys": list(self.output_keys),
+            "operating_defaults": dict(self.operating_defaults),
+            "release_phase": self.release_phase,
+            "notes": self.notes,
+            "supports_capacity": self.supports_capacity,
+            "supports_resistance": self.supports_resistance,
+            "calibration_basis": "cell-model",
+            "pack_calibrated": False,
+            "upstream": {
+                "project": "BLAST-Lite",
+                "version": BLAST_UPSTREAM_VERSION,
+                "commit": BLAST_UPSTREAM_COMMIT,
+            },
+        }
+
+
+def _profile(
+    key: str,
+    name: str,
+    source_module: str,
+    class_name: str,
+    chemistry: str,
+    cell_format: str,
+    nominal_capacity_ah: float,
+    experimental_range: dict[str, Any],
+    citations: tuple[str, ...],
+    output_keys: tuple[str, ...],
+    release_phase: str = "phase3",
+    notes: str = "",
+) -> BatteryModelProfile:
+    # BLAST model papers do not define pack-level operating defaults. Keep the
+    # mapping empty rather than inventing generic chemistry assumptions.
+    return BatteryModelProfile(
+        key=key,
+        name=name,
+        source_module=source_module,
+        class_name=class_name,
+        chemistry=chemistry,
+        cell_format=cell_format,
+        nominal_capacity_ah=nominal_capacity_ah,
+        experimental_range=MappingProxyType(experimental_range),
+        citations=citations,
+        output_keys=output_keys,
+        operating_defaults=MappingProxyType({}),
+        release_phase=release_phase,
+        notes=notes,
+    )
+
+
+_COMMON_EST_2023 = ("https://doi.org/10.1016/j.est.2023.109042",)
+
+BATTERY_MODEL_REGISTRY: Mapping[str, BatteryModelProfile] = MappingProxyType(
+    {
+        "lfp_gr_250ah_prismatic": _profile(
+            "lfp_gr_250ah_prismatic",
+            "LFP-Gr 250 Ah prismatic",
+            "lfp_gr_250AhPrismatic_2019",
+            "Lfp_Gr_250AhPrismatic",
+            "LFP/graphite",
+            "prismatic",
+            250.0,
+            {
+                "cycling_temperature_c": [10, 45],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 0.65,
+                "max_c_rate_discharge": 1.0,
+            },
+            _COMMON_EST_2023,
+            ("q", "q_t", "q_EFC"),
+            release_phase="core",
+        ),
+        "nca_gr_panasonic_3ah": _profile(
+            "nca_gr_panasonic_3ah",
+            "NCA-Gr Panasonic 3.2 Ah",
+            "nca_gr_Panasonic3Ah_2018",
+            "Nca_Gr_Panasonic3Ah_Battery",
+            "NCA/graphite",
+            "cylindrical",
+            3.2,
+            {
+                "cycling_temperature_c": [15, 35],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 0.5,
+                "max_c_rate_discharge": 2.0,
+            },
+            ("https://doi.org/10.1149/2.0411609jes", "https://doi.org/10.1149/1945-7111/abae37"),
+            ("q", "q_t", "q_EFC"),
+            release_phase="core",
+        ),
+        "lmo_gr_nissanleaf_66ah_2nd": _profile(
+            "lmo_gr_nissanleaf_66ah_2nd",
+            "LMO-Gr Nissan Leaf 66 Ah second-life",
+            "lmo_gr_NissanLeaf66Ah_2ndLife_2020",
+            "Lmo_Gr_NissanLeaf66Ah_2ndLife_Battery",
+            "LMO/graphite",
+            "pouch",
+            66.0,
+            {
+                "cycling_temperature_c": [20, 30],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 1.0,
+                "max_c_rate_discharge": 1.0,
+            },
+            ("https://doi.org/10.1109/EEEIC/ICPSEUROPE54979.2022.9854784", "https://doi.org/10.1016/j.est.2020.101695"),
+            ("q", "q_t", "q_EFC", "qNew"),
+        ),
+        "nmc811_grsi_lgm50_5ah": _profile(
+            "nmc811_grsi_lgm50_5ah",
+            "NMC811-GrSi LG M50 5 Ah",
+            "nmc811_grSi_LGM50_5Ah_2021",
+            "Nmc811_GrSi_LGM50_5Ah_Battery",
+            "NMC811/graphite-silicon",
+            "cylindrical 21700",
+            5.0,
+            {
+                "cycling_temperature_c": [0, 25],
+                "dod": [1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 0.3,
+                "max_c_rate_discharge": 2.0,
+            },
+            (
+                "https://ieeexplore.ieee.org/document/9617644",
+                "https://www.sciencedirect.com/science/article/pii/S0013468622008593",
+            ),
+            ("q", "q_t", "q_EFC"),
+        ),
+        "nmc811_grsi_lgmj1_4ah": _profile(
+            "nmc811_grsi_lgmj1_4ah",
+            "NMC811-GrSi LG MJ1 3.5 Ah",
+            "nmc811_grSi_LGMJ1_4Ah_2020",
+            "Nmc811_GrSi_LGMJ1_4Ah_Battery",
+            "NMC811/graphite-silicon",
+            "cylindrical 18650",
+            3.5,
+            {
+                "cycling_temperature_c": [0, 50],
+                "dod": [0.2, 0.8],
+                "soc": [0.1, 0.9],
+                "max_c_rate_charge": 1.0,
+                "max_c_rate_discharge": 3.0,
+            },
+            ("https://everlasting-project.eu/wp-content/uploads/2020/03/EVERLASTING_D2.3_final_20200228.pdf",),
+            ("q", "q_t", "q_EFC"),
+        ),
+        "nmc_gr_50ah_b1": _profile(
+            "nmc_gr_50ah_b1",
+            "NMC-Gr B1 50 Ah",
+            "nmc_gr_50Ah_B1_2020",
+            "NMC_Gr_50Ah_B1",
+            "NMC/graphite",
+            "not stated",
+            50.0,
+            {
+                "cycling_temperature_c": [10, 45],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 1.75,
+                "max_c_rate_discharge": 1.75,
+            },
+            _COMMON_EST_2023,
+            ("q", "q_t", "q_EFC"),
+        ),
+        "nmc_gr_50ah_b2": _profile(
+            "nmc_gr_50ah_b2",
+            "NMC-Gr B2 50 Ah",
+            "nmc_gr_50Ah_B2_2020",
+            "NMC_Gr_50Ah_B2",
+            "NMC/graphite",
+            "not stated",
+            50.0,
+            {
+                "cycling_temperature_c": [10, 45],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 1.75,
+                "max_c_rate_discharge": 1.75,
+            },
+            _COMMON_EST_2023,
+            ("q", "q_t", "q_EFC"),
+        ),
+        "nmc_gr_75ah_a": _profile(
+            "nmc_gr_75ah_a",
+            "NMC-Gr A 75 Ah",
+            "nmc_gr_75Ah_A_2019",
+            "NMC_Gr_75Ah_A",
+            "NMC/graphite",
+            "not stated",
+            75.0,
+            {
+                "cycling_temperature_c": [10, 45],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 2.0,
+                "max_c_rate_discharge": 2.0,
+            },
+            _COMMON_EST_2023,
+            ("q", "q_t", "q_EFC"),
+        ),
+        "nmc111_gr_sanyo_2ah": _profile(
+            "nmc111_gr_sanyo_2ah",
+            "NMC111-Gr Sanyo 2.15 Ah",
+            "nmc111_gr_Sanyo2Ah_2014",
+            "Nmc111_Gr_Sanyo2Ah_Battery",
+            "NMC111/graphite",
+            "cylindrical 18650",
+            2.15,
+            {
+                "cycling_temperature_c": [20, 40],
+                "dod": [0, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 1.0,
+                "max_c_rate_discharge": 1.0,
+            },
+            ("https://doi.org/10.1016/j.jpowsour.2014.02.012", "https://doi.org/10.1016/j.jpowsour.2013.09.143"),
+            ("q", "q_t", "q_EFC", "r", "r_t", "r_EFC"),
+        ),
+        "nmc_lto_10ah": _profile(
+            "nmc_lto_10ah",
+            "NMC-LTO 10.2 Ah",
+            "nmc_lto_10Ah_2020",
+            "Nmc_Lto_10Ah_Battery",
+            "NMC/LTO",
+            "not stated",
+            10.2,
+            {
+                "cycling_temperature_c": [30, 60],
+                "dod": [0, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 10.0,
+                "max_c_rate_discharge": 10.0,
+            },
+            ("https://doi.org/10.1016/j.jpowsour.2020.228566",),
+            ("q", "q_t_loss", "q_t_gain", "q_EFC"),
+        ),
+        "lfp_gr_sonymurata_3ah": _profile(
+            "lfp_gr_sonymurata_3ah",
+            "LFP-Gr Sony-Murata 3 Ah",
+            "lfp_gr_SonyMurata3Ah_2018",
+            "Lfp_Gr_SonyMurata3Ah_Battery",
+            "LFP/graphite",
+            "cylindrical",
+            3.0,
+            {
+                "cycling_temperature_c": [20, 40],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 1.0,
+                "max_c_rate_discharge": 2.0,
+            },
+            (
+                "https://doi.org/10.1016/j.est.2018.01.019",
+                "https://doi.org/10.1016/j.jpowsour.2019.227666",
+                "https://doi.org/10.1149/1945-7111/ac86a8",
+            ),
+            ("q", "q_LLI_t", "q_LLI_EFC", "q_BreakIn_EFC", "r", "r_LLI_t", "r_LLI_EFC"),
+        ),
+        "nca_grsi_sonymurata_2p5ah": _profile(
+            "nca_grsi_sonymurata_2p5ah",
+            "NCA-GrSi Sony-Murata 2.5 Ah",
+            "nca_grsi_SonyMurata2p5Ah_2023",
+            "NCA_GrSi_SonyMurata2p5Ah_Battery",
+            "NCA/graphite-silicon",
+            "cylindrical",
+            2.5,
+            {
+                "cycling_temperature_c": [5, 35],
+                "dod": [0.2, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 2.0,
+                "max_c_rate_discharge": 10.0,
+            },
+            (
+                "https://doi.org/10.1016/j.jpowsour.2022.232498",
+                "https://doi.org/10.1016/j.jpowsour.2023.233947",
+                "https://doi.org/10.1016/j.jpowsour.2023.233208",
+            ),
+            ("q", "q_t", "q_EFC"),
+        ),
+        "nmc111_gr_kokam_75ah": _profile(
+            "nmc111_gr_kokam_75ah",
+            "NMC111-Gr Kokam 75 Ah",
+            "nmc111_gr_Kokam75Ah_2017",
+            "Nmc111_Gr_Kokam75Ah_Battery",
+            "NMC111/graphite",
+            "pouch",
+            75.0,
+            {
+                "cycling_temperature_c": [0, 45],
+                "dod": [0.8, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 1.0,
+                "max_c_rate_discharge": 1.0,
+            },
+            ("https://ieeexplore.ieee.org/iel7/7951530/7962914/07963578.pdf",),
+            ("q", "q_LLI", "q_LLI_t", "q_LLI_EFC", "q_LAM", "r", "r_LLI", "r_LLI_t", "r_LLI_EFC", "r_LAM"),
+        ),
+        "nmc622_gr_denso_50ah": _profile(
+            "nmc622_gr_denso_50ah",
+            "NMC622-Gr DENSO 50 Ah",
+            "nmc622_gr_DENSO50Ah_2021",
+            "Nmc622_Gr_DENSO50Ah_Battery",
+            "NMC622/graphite",
+            "not stated",
+            50.0,
+            {
+                "cycling_temperature_c": [10, 60],
+                "dod": [0.1, 1.0],
+                "soc": [0, 1],
+                "max_c_rate_charge": 1.0,
+                "max_c_rate_discharge": 1.0,
+            },
+            ("https://doi.org/10.1149/1945-7111/ac2ebd",),
+            ("q", "q_t", "q_EFC", "q_BreakIn"),
+        ),
+    }
+)
+
+CORE_BLAST_MODEL_KEYS = tuple(key for key, profile in BATTERY_MODEL_REGISTRY.items() if profile.release_phase == "core")
+
+
+def get_battery_model_profile(key: str) -> BatteryModelProfile:
+    """Return one stable battery-model profile by key."""
+    try:
+        return BATTERY_MODEL_REGISTRY[key]
+    except KeyError as exc:
+        available = ", ".join(BATTERY_MODEL_REGISTRY)
+        raise KeyError(f"Unknown battery model {key!r}. Available: {available}") from exc
+
+
+def list_battery_models(*, enabled_only: bool = False) -> list[dict[str, Any]]:
+    """Return JSON-serializable discovery metadata for BLAST battery models."""
+    return [
+        profile.as_dict()
+        for profile in BATTERY_MODEL_REGISTRY.values()
+        if not enabled_only or profile.release_phase == "core"
+    ]
+
+
+def apply_battery_profile_defaults(
+    global_defaults: Mapping[str, Any], user_config: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Resolve configuration as user values > profile defaults > globals."""
+    model_key = user_config.get("blast_model")
+    profile = BATTERY_MODEL_REGISTRY.get(str(model_key)) if model_key is not None else None
+    profile_defaults = profile.operating_defaults if profile is not None else {}
+    return merge_battery_config_layers(global_defaults, profile_defaults, user_config)
+
+
+def merge_battery_config_layers(
+    global_defaults: Mapping[str, Any], profile_defaults: Mapping[str, Any], user_config: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Merge the documented config precedence without mutating any input."""
+    return {**global_defaults, **profile_defaults, **user_config}

--- a/breos/degradation/profiles.py
+++ b/breos/degradation/profiles.py
@@ -7,8 +7,26 @@ from types import MappingProxyType
 from typing import Any, Mapping
 
 BLAST_UPSTREAM_VERSION = "1.1.0"
-BLAST_UPSTREAM_COMMIT = "d789e00"
+BLAST_UPSTREAM_COMMIT = "d789e00bca60f628de640745c18eb724b07358bd"
 BLAST_STATE_SCHEMA_VERSION = "1.0"
+
+
+def _freeze_metadata(value: Any) -> Any:
+    """Recursively freeze registry metadata without changing its values."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_metadata(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_metadata(item) for item in value)
+    return value
+
+
+def _json_metadata(value: Any) -> Any:
+    """Return fresh JSON-safe containers for frozen registry metadata."""
+    if isinstance(value, Mapping):
+        return {key: _json_metadata(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_metadata(item) for item in value]
+    return value
 
 
 @dataclass(frozen=True)
@@ -46,10 +64,10 @@ class BatteryModelProfile:
             "chemistry": self.chemistry,
             "cell_format": self.cell_format,
             "nominal_capacity_ah": self.nominal_capacity_ah,
-            "experimental_range": dict(self.experimental_range),
+            "experimental_range": _json_metadata(self.experimental_range),
             "citations": list(self.citations),
             "output_keys": list(self.output_keys),
-            "operating_defaults": dict(self.operating_defaults),
+            "operating_defaults": _json_metadata(self.operating_defaults),
             "release_phase": self.release_phase,
             "notes": self.notes,
             "supports_capacity": self.supports_capacity,
@@ -88,10 +106,10 @@ def _profile(
         chemistry=chemistry,
         cell_format=cell_format,
         nominal_capacity_ah=nominal_capacity_ah,
-        experimental_range=MappingProxyType(experimental_range),
+        experimental_range=_freeze_metadata(experimental_range),
         citations=citations,
         output_keys=output_keys,
-        operating_defaults=MappingProxyType({}),
+        operating_defaults=_freeze_metadata({}),
         release_phase=release_phase,
         notes=notes,
     )

--- a/breos/runners/app.py
+++ b/breos/runners/app.py
@@ -11,6 +11,7 @@ import pandas as pd
 from breos.app_config import ResolvedAppConfig, build_costs_dict
 from breos.app_inputs import AppRuntimeDependencies, prepare_simulation_inputs
 from breos.battery import BatteryConfig, simulate_energy_balance
+from breos.degradation.profiles import BLAST_STATE_SCHEMA_VERSION, get_battery_model_profile
 from breos.economics import calculate_lcoe_from_projection, cost_analysis_projection, find_payback_year
 from breos.solar import PVProductionBreakdown
 from breos.utils import get_hours_per_step
@@ -31,6 +32,7 @@ class SimulationArtifacts:
     total_replacement_cost: float
     pv_loss_waterfall: dict[str, Any]
     weather_metadata: dict[str, Any]
+    degradation_summary: dict[str, Any]
 
 
 LEDGER_SCHEMA_VERSION = "1.0"
@@ -389,6 +391,33 @@ def run_app_simulation(
         discount_rate=cfg["discount_rate"],
     )
 
+    replacement_events = [
+        {"year": int(row["Year"]), "count": int(row["Replacements"])} for row in yearly_summaries if row["Replacements"]
+    ]
+    if degradation_engine == "blast":
+        profile = get_battery_model_profile(str(blast_model))
+        degradation_summary = {
+            "engine": "blast",
+            "model_key": blast_model,
+            "model_profile": profile.as_dict(),
+            "initial_soh_pct": 100.0,
+            "final_soh_pct": round(float(current_soh), 1),
+            "replacement_events": replacement_events,
+            "calibration_basis": "cell-model",
+            "pack_calibrated": False,
+            "experimental_range_warnings": [],
+            "aging_horizon_extrapolation_warnings": [],
+            "state_schema_version": BLAST_STATE_SCHEMA_VERSION,
+        }
+    else:
+        degradation_summary = {
+            "engine": "native",
+            "model_key": cfg["calendar_model"],
+            "initial_soh_pct": 100.0,
+            "final_soh_pct": round(float(current_soh), 2),
+            "replacement_events": replacement_events,
+        }
+
     return SimulationArtifacts(
         yearly_df=yearly_df,
         first_year_results_df=first_year_results_df,
@@ -409,4 +438,5 @@ def run_app_simulation(
                 },
             )
         ),
+        degradation_summary=degradation_summary,
     )

--- a/configs/examples/pv-plus-battery.toml
+++ b/configs/examples/pv-plus-battery.toml
@@ -17,6 +17,8 @@ annual_consumption_kwh = 4000      # yearly household demand
 
 # --- Storage ----------------------------------------------------------------
 battery_kwh = 5.0                  # [0.0] usable capacity; 0 = PV-only
+degradation_engine = "native"      # ["native"] Naumann/Lam; use "blast" explicitly
+# blast_model = "lfp_gr_250ah_prismatic"  # required when degradation_engine = "blast"
 
 # --- Catalogue selections ---------------------------------------------------
 pv_module = "Suntech_STP550S_STC"  # [first catalogue module]; `breos list modules`

--- a/docs/api/degradation-models.md
+++ b/docs/api/degradation-models.md
@@ -1,0 +1,77 @@
+# Battery degradation models
+
+Native Naumann/Lam degradation remains the default. BLAST-Lite is an explicit
+opt-in cell-model engine:
+
+```toml
+degradation_engine = "blast"
+blast_model = "lfp_gr_250ah_prismatic"
+```
+
+The same selection is available from the CLI:
+
+```bash
+breos run --config config.toml \
+  --degradation-engine blast \
+  --blast-model lfp_gr_250ah_prismatic
+```
+
+Discover model identities and scientific scope from Python or the CLI:
+
+```python
+from breos import get_battery_model_profile, list_battery_models
+
+models = list_battery_models()
+lfp = get_battery_model_profile("lfp_gr_250ah_prismatic")
+```
+
+```bash
+breos list battery-models
+breos list battery-models --json
+```
+
+The registry reports stable keys, readable names, chemistry, cell form factor,
+nominal cell capacity, experimental ranges, study citations, capacity and
+resistance outputs, upstream BLAST provenance, and whether the model is enabled
+in the current integration phase. All 14 vendored models are discoverable;
+the profile-layer PR enables only the two core models end to end. The remaining
+models are enabled by the separately validated all-model parity phase.
+
+## Configuration precedence
+
+Resolved settings use this order:
+
+1. explicit user configuration;
+2. sourced model-profile defaults;
+3. global BREOS defaults.
+
+No BLAST paper bundled here defines generic pack operating limits, so the
+profiles currently contain no invented SOC, efficiency, power, or replacement
+defaults. Existing global settings therefore remain unchanged unless a user
+overrides them.
+
+## Migration from `battery_type`
+
+Do not use the legacy `battery_type` selector in `App` configuration. It was
+ambiguous: it mixed chemistry identity with degradation-model selection.
+Choose `degradation_engine="native"` (or omit it) for the existing LFP
+Naumann/Lam model. Choose `degradation_engine="blast"` together with one
+stable `blast_model` key for BLAST. Supplying `blast_model` while the native
+engine is active raises instead of silently changing behavior.
+
+The lower-level `BatteryConfig.battery_type` field remains temporarily limited
+to `"lfp"` for native cycle-aging compatibility; it does not select BLAST.
+
+## Result interpretation
+
+BLAST results include a `degradation` block and matching provenance with the
+engine, stable model key, complete model profile, initial/final SOH,
+replacement events, cell-model versus pack-calibrated status, warning lists,
+and serialized state-schema version. These are empirical **cell models**, not
+pack-calibrated field models. Long-horizon BLAST SOH is rounded to one decimal
+place to avoid implying unsupported precision.
+
+BLAST plus Monte Carlo is rejected explicitly in 0.4.0. It never falls back to
+native degradation. BLAST resistance outputs are reported as capabilities but
+do not alter dispatch efficiency or power limits.
+

--- a/docs/api/degradation-models.md
+++ b/docs/api/degradation-models.md
@@ -54,6 +54,9 @@ overrides them.
 
 Do not use the legacy `battery_type` selector in `App` configuration. It was
 ambiguous: it mixed chemistry identity with degradation-model selection.
+Strict `App` validation already rejected this key as unknown in 0.3.4; 0.4.0
+adds targeted migration guidance rather than introducing a new breaking
+change.
 Choose `degradation_engine="native"` (or omit it) for the existing LFP
 Naumann/Lam model. Choose `degradation_engine="blast"` together with one
 stable `blast_model` key for BLAST. Supplying `blast_model` while the native
@@ -61,6 +64,9 @@ engine is active raises instead of silently changing behavior.
 
 The lower-level `BatteryConfig.battery_type` field remains temporarily limited
 to `"lfp"` for native cycle-aging compatibility; it does not select BLAST.
+
+BLAST selection requires `battery_kwh > 0`; PV-only configurations should keep
+the default native engine and omit `blast_model`.
 
 ## Result interpretation
 
@@ -74,4 +80,3 @@ place to avoid implying unsupported precision.
 BLAST plus Monte Carlo is rejected explicitly in 0.4.0. It never falls back to
 native degradation. BLAST resistance outputs are reported as capabilities but
 do not alter dispatch efficiency or power limits.
-

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -53,6 +53,13 @@ Per-timestep PV, load, battery, and grid energy flows.
 Configuration, indoor temperature model, calendar and cycle degradation.
 :::
 
+:::{grid-item-card} Degradation models
+:link: degradation-models
+:link-type: doc
+
+Native and BLAST model selection, discovery, provenance, and migration.
+:::
+
 :::{grid-item-card} Cost analysis
 :link: cost-analysis
 :link-type: doc
@@ -91,6 +98,7 @@ pv
 load-profiles
 energy-balance
 battery
+degradation-models
 cost-analysis
 optimization
 plotting

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -52,6 +52,8 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `export_emissions_factor_gco2_kwh` | `None` | Optional displacement factor for exported PV. `None` uses the preset's avoided-grid factor and reports that fallback explicitly |
 | `pv_degradation_rate` | `0.005` | Annual PV degradation rate (0.5% / year) |
 | `calendar_model` | `"naumann_lam_field_calibrated"` | Battery calendar aging model. Default is the v1 field calibration; use `"naumann_lam_field_calibrated_v2"` for the v2 field-calibrated fit with Lam `Ea`/`n` fixed and `k0`/`b` fitted |
+| `degradation_engine` | `"native"` | `"native"` keeps Naumann/Lam; `"blast"` explicitly opts into a vendored BLAST cell model |
+| `blast_model` | `None` | Stable BLAST model key; required with `degradation_engine="blast"` and invalid with the native engine |
 | `battery_min_soc` | `0.10` | Battery SOC floor (fraction of nominal, SOH-derated capacity) |
 | `battery_max_soc` | `0.90` | Battery SOC ceiling (same basis as `battery_min_soc`) |
 | `battery_eol_percentage` | `0.70` | SOH fraction that triggers battery replacement |
@@ -104,10 +106,14 @@ maps to the v1 field calibration. The explicit
 `"naumann_lam_field_calibrated_v2"` for the v2 field-calibrated fit with Lam
 `Ea`/`n` fixed and `k0`/`b` fitted to field data.
 
-The native BREOS degradation path is currently calibrated for LFP cells only.
-Lower-level `BatteryConfig(battery_type="LFP")` normalizes to `"lfp"`; other
-chemistries raise instead of silently reusing LFP cycle-aging parameters. See
-the roadmap for the planned opt-in multi-chemistry degradation engine.
+The native BREOS degradation path is calibrated for LFP cells only. App config
+must not use the ambiguous legacy `battery_type` selector: omit
+`degradation_engine` for native behavior, or set `degradation_engine="blast"`
+and a stable `blast_model` key. Lower-level
+`BatteryConfig(battery_type="LFP")` still normalizes to `"lfp"` for native
+compatibility; it does not select BLAST. See the
+[degradation model reference](../api/degradation-models.md) for discovery,
+precedence, provenance, and migration details.
 
 ## Discovering available options
 
@@ -118,6 +124,7 @@ breos list locations
 breos list modules
 breos list cost-presets
 breos list emissions
+breos list battery-models
 breos list load-profiles
 ```
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -665,6 +665,33 @@ class TestAppSimulateNoBattery:
         assert r["provenance"]["timezone"] == "Europe/Lisbon"
         json.dumps(r["provenance"])
 
+    def test_blast_result_reports_model_identity_and_state_provenance(self):
+        app = App(
+            {
+                "location": "porto",
+                "n_modules": 6,
+                "annual_consumption_kwh": 3000,
+                "battery_kwh": 5.0,
+                "projection_years": 1,
+                "degradation_engine": "blast",
+                "blast_model": "lfp_gr_250ah_prismatic",
+            }
+        )
+        app.simulate()
+        result = app.result()
+
+        degradation = result["degradation"]
+        assert degradation["engine"] == "blast"
+        assert degradation["model_key"] == "lfp_gr_250ah_prismatic"
+        assert degradation["model_profile"]["calibration_basis"] == "cell-model"
+        assert degradation["pack_calibrated"] is False
+        assert degradation["initial_soh_pct"] == 100.0
+        assert degradation["final_soh_pct"] == round(result["battery_soh_end_pct"], 1)
+        assert degradation["state_schema_version"] == "1.0"
+        assert degradation["experimental_range_warnings"] == []
+        assert degradation["aging_horizon_extrapolation_warnings"] == []
+        assert result["provenance"]["degradation"] == degradation
+
     def test_investment_positive(self):
         assert self.result["total_investment_eur"] > 0
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -683,6 +683,8 @@ class TestAppSimulateNoBattery:
         degradation = result["degradation"]
         assert degradation["engine"] == "blast"
         assert degradation["model_key"] == "lfp_gr_250ah_prismatic"
+        assert degradation["model_profile"]["key"] == degradation["model_key"]
+        assert degradation["model_profile"]["upstream"]["commit"] == "d789e00bca60f628de640745c18eb724b07358bd"
         assert degradation["model_profile"]["calibration_basis"] == "cell-model"
         assert degradation["pack_calibrated"] is False
         assert degradation["initial_soh_pct"] == 100.0

--- a/tests/test_battery_profiles.py
+++ b/tests/test_battery_profiles.py
@@ -1,0 +1,94 @@
+"""Public discovery, metadata, and configuration semantics for BLAST models."""
+
+import json
+
+import pytest
+
+import breos
+from breos.app_config import resolve_app_config
+from breos.degradation.engine import BLAST_MODEL_CLASSES, BlastEngine
+from breos.degradation.profiles import (
+    BATTERY_MODEL_REGISTRY,
+    BLAST_STATE_SCHEMA_VERSION,
+    CORE_BLAST_MODEL_KEYS,
+    get_battery_model_profile,
+    merge_battery_config_layers,
+)
+
+
+def _base_config(**overrides):
+    return {
+        "location": "porto",
+        "n_modules": 10,
+        "annual_consumption_kwh": 4000,
+        "battery_kwh": 5.0,
+        **overrides,
+    }
+
+
+def test_registry_is_the_single_catalog_for_all_vendored_models():
+    assert len(BATTERY_MODEL_REGISTRY) == 14
+    assert tuple(BLAST_MODEL_CLASSES) == tuple(BATTERY_MODEL_REGISTRY)
+    assert CORE_BLAST_MODEL_KEYS == ("lfp_gr_250ah_prismatic", "nca_gr_panasonic_3ah")
+
+    for key, profile in BATTERY_MODEL_REGISTRY.items():
+        model = BLAST_MODEL_CLASSES[key]()
+        assert profile.nominal_capacity_ah == model.cap
+        assert profile.experimental_range["cycling_temperature_c"] == model.experimental_range["cycling_temperature"]
+        assert profile.experimental_range["dod"] == model.experimental_range["dod"]
+        assert profile.experimental_range["soc"] == model.experimental_range["soc"]
+        assert profile.experimental_range["max_c_rate_charge"] == model.experimental_range["max_rate_charge"]
+        assert profile.experimental_range["max_c_rate_discharge"] == model.experimental_range["max_rate_discharge"]
+        assert profile.output_keys == tuple(model.outputs)
+        assert profile.citations
+        assert profile.operating_defaults == {}
+
+
+def test_python_discovery_is_public_and_json_serializable():
+    models = breos.list_battery_models()
+    assert len(models) == 14
+    assert get_battery_model_profile("lfp_gr_250ah_prismatic").supports_capacity is True
+    assert get_battery_model_profile("nmc111_gr_sanyo_2ah").supports_resistance is True
+    assert models[0]["calibration_basis"] == "cell-model"
+    assert models[0]["pack_calibrated"] is False
+    json.dumps(models)
+
+
+def test_config_precedence_is_user_then_profile_then_global():
+    resolved = merge_battery_config_layers(
+        {"battery_min_soc": 0.1, "battery_max_soc": 0.9, "source": "global"},
+        {"battery_min_soc": 0.2, "source": "profile"},
+        {"battery_min_soc": 0.3},
+    )
+    assert resolved == {"battery_min_soc": 0.3, "battery_max_soc": 0.9, "source": "profile"}
+
+
+def test_native_is_default_and_blast_is_explicit_opt_in():
+    native = resolve_app_config(_base_config()).cfg
+    assert native["degradation_engine"] == "native"
+    assert native["blast_model"] is None
+
+    blast = resolve_app_config(_base_config(degradation_engine="blast", blast_model="lfp_gr_250ah_prismatic")).cfg
+    assert blast["degradation_engine"] == "blast"
+    assert blast["blast_model"] == "lfp_gr_250ah_prismatic"
+
+
+def test_config_rejects_ambiguous_or_incomplete_model_selection():
+    with pytest.raises(ValueError, match="ambiguous legacy selector"):
+        resolve_app_config(_base_config(battery_type="lfp"))
+    with pytest.raises(ValueError, match="requires degradation_engine='blast'"):
+        resolve_app_config(_base_config(blast_model="lfp_gr_250ah_prismatic"))
+    with pytest.raises(ValueError, match="Available"):
+        resolve_app_config(_base_config(degradation_engine="blast", blast_model="nmc622_gr_denso_50ah"))
+
+
+def test_snapshot_schema_survives_json_round_trip_and_rejects_unknown_versions():
+    engine = BlastEngine("lfp_gr_250ah_prismatic")
+    snapshot = json.loads(json.dumps(engine.state_snapshot()))
+    assert snapshot["schema_version"] == BLAST_STATE_SCHEMA_VERSION
+    restored = BlastEngine.from_snapshot("lfp_gr_250ah_prismatic", snapshot)
+    assert restored.soh() == pytest.approx(1.0)
+
+    snapshot["schema_version"] = "999"
+    with pytest.raises(ValueError, match="Unsupported BLAST state schema"):
+        BlastEngine.from_snapshot("lfp_gr_250ah_prismatic", snapshot)

--- a/tests/test_battery_profiles.py
+++ b/tests/test_battery_profiles.py
@@ -1,6 +1,7 @@
 """Public discovery, metadata, and configuration semantics for BLAST models."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -10,6 +11,7 @@ from breos.degradation.engine import BLAST_MODEL_CLASSES, BlastEngine
 from breos.degradation.profiles import (
     BATTERY_MODEL_REGISTRY,
     BLAST_STATE_SCHEMA_VERSION,
+    BLAST_UPSTREAM_COMMIT,
     CORE_BLAST_MODEL_KEYS,
     get_battery_model_profile,
     merge_battery_config_layers,
@@ -34,9 +36,11 @@ def test_registry_is_the_single_catalog_for_all_vendored_models():
     for key, profile in BATTERY_MODEL_REGISTRY.items():
         model = BLAST_MODEL_CLASSES[key]()
         assert profile.nominal_capacity_ah == model.cap
-        assert profile.experimental_range["cycling_temperature_c"] == model.experimental_range["cycling_temperature"]
-        assert profile.experimental_range["dod"] == model.experimental_range["dod"]
-        assert profile.experimental_range["soc"] == model.experimental_range["soc"]
+        assert profile.experimental_range["cycling_temperature_c"] == tuple(
+            model.experimental_range["cycling_temperature"]
+        )
+        assert profile.experimental_range["dod"] == tuple(model.experimental_range["dod"])
+        assert profile.experimental_range["soc"] == tuple(model.experimental_range["soc"])
         assert profile.experimental_range["max_c_rate_charge"] == model.experimental_range["max_rate_charge"]
         assert profile.experimental_range["max_c_rate_discharge"] == model.experimental_range["max_rate_discharge"]
         assert profile.output_keys == tuple(model.outputs)
@@ -52,6 +56,28 @@ def test_python_discovery_is_public_and_json_serializable():
     assert models[0]["calibration_basis"] == "cell-model"
     assert models[0]["pack_calibrated"] is False
     json.dumps(models)
+
+
+def test_registry_metadata_is_immutable_and_discovery_results_are_isolated():
+    profile = get_battery_model_profile("lfp_gr_250ah_prismatic")
+    with pytest.raises(TypeError):
+        profile.experimental_range["soc"][0] = -1
+
+    discovered = breos.list_battery_models()
+    lfp = next(model for model in discovered if model["key"] == profile.key)
+    lfp["experimental_range"]["soc"][0] = -1
+    lfp["upstream"]["commit"] = "changed"
+
+    fresh_lfp = next(model for model in breos.list_battery_models() if model["key"] == profile.key)
+    assert profile.experimental_range["soc"] == (0, 1)
+    assert fresh_lfp["experimental_range"]["soc"] == [0, 1]
+    assert fresh_lfp["upstream"]["commit"] == BLAST_UPSTREAM_COMMIT
+
+
+def test_registry_upstream_identity_matches_vendoring_manifest():
+    manifest = (Path(__file__).parents[1] / "breos/degradation/blast/VENDORED.md").read_text(encoding="utf-8")
+    assert len(BLAST_UPSTREAM_COMMIT) == 40
+    assert BLAST_UPSTREAM_COMMIT in manifest
 
 
 def test_config_precedence_is_user_then_profile_then_global():
@@ -76,16 +102,25 @@ def test_native_is_default_and_blast_is_explicit_opt_in():
 def test_config_rejects_ambiguous_or_incomplete_model_selection():
     with pytest.raises(ValueError, match="ambiguous legacy selector"):
         resolve_app_config(_base_config(battery_type="lfp"))
-    with pytest.raises(ValueError, match="requires degradation_engine='blast'"):
+    with pytest.raises(ValueError, match="requires.*degradation_engine=blast"):
         resolve_app_config(_base_config(blast_model="lfp_gr_250ah_prismatic"))
     with pytest.raises(ValueError, match="Available"):
         resolve_app_config(_base_config(degradation_engine="blast", blast_model="nmc622_gr_denso_50ah"))
+    with pytest.raises(ValueError, match="battery_kwh.*> 0"):
+        resolve_app_config(
+            _base_config(
+                battery_kwh=0,
+                degradation_engine="blast",
+                blast_model="lfp_gr_250ah_prismatic",
+            )
+        )
 
 
 def test_snapshot_schema_survives_json_round_trip_and_rejects_unknown_versions():
     engine = BlastEngine("lfp_gr_250ah_prismatic")
     snapshot = json.loads(json.dumps(engine.state_snapshot()))
     assert snapshot["schema_version"] == BLAST_STATE_SCHEMA_VERSION
+    assert snapshot["blast_model_key"] == "lfp_gr_250ah_prismatic"
     restored = BlastEngine.from_snapshot("lfp_gr_250ah_prismatic", snapshot)
     assert restored.soh() == pytest.approx(1.0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,6 +147,45 @@ def test_list_modules_json_outputs_catalog(capsys):
     assert any(row["key"] == "Generic_400W" and row["power_w"] == 400 for row in output)
 
 
+def test_list_battery_models_exposes_scientific_metadata(capsys):
+    exit_code = cli.main(["list", "battery-models", "--json"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert len(output) == 14
+    lfp = next(row for row in output if row["key"] == "lfp_gr_250ah_prismatic")
+    assert lfp["chemistry"] == "LFP/graphite"
+    assert lfp["cell_format"] == "prismatic"
+    assert lfp["experimental_range"]["cycling_temperature_c"] == [10, 45]
+    assert lfp["release_phase"] == "core"
+
+
+def test_run_cli_threads_blast_selection(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "App", FakeApp)
+    FakeApp.seen_config = None
+    config_path = tmp_path / "quickstart.toml"
+    config_path.write_text(
+        'location = "porto"\nn_modules = 10\nannual_consumption_kwh = 4000\nbattery_kwh = 5.0\n',
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(
+        [
+            "run",
+            "--config",
+            str(config_path),
+            "--degradation-engine",
+            "blast",
+            "--blast-model",
+            "lfp_gr_250ah_prismatic",
+        ]
+    )
+
+    assert exit_code == 0
+    assert FakeApp.seen_config["degradation_engine"] == "blast"
+    assert FakeApp.seen_config["blast_model"] == "lfp_gr_250ah_prismatic"
+
+
 def test_validate_config_summarizes_without_simulation(tmp_path, capsys):
     config_path = tmp_path / "quickstart.toml"
     config_path.write_text(
@@ -196,6 +235,8 @@ battery_kwh = 5.0
     assert output["pv"]["n_modules"] == 10
     assert output["pv"]["losses"]["components_pct"]["shading"] == 3.0
     assert 14.0 < output["pv"]["losses"]["combined_pct"] < 15.0
+    assert output["battery"]["degradation_engine"] == "native"
+    assert output["battery"]["blast_model"] is None
 
 
 def test_sweep_expands_grid_and_writes_combined_csv(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary

- add one immutable registry for all 14 vendored BLAST cell-model identities and sourced metadata
- expose the same registry through `breos.list_battery_models()`, `breos.get_battery_model_profile()`, and `breos list battery-models`
- keep App enablement limited to the two core models while making the complete catalog discoverable
- resolve configuration as explicit user values over sourced profile defaults over global defaults
- add degradation identity, cell-model calibration scope, upstream provenance, and snapshot schema information to public results
- give the already-unsupported App-level `battery_type` key targeted migration guidance while retaining lower-level `BatteryConfig(battery_type="LFP")`
- reject BLAST without positive battery capacity and reject contradictory native/BLAST selection at configuration time

Native Naumann/Lam degradation remains the default. BLAST remains an explicit opt-in and does not silently fall back to native behavior.

## Public surface

- `BATTERY_MODEL_REGISTRY` is the single catalog used by the adapter and discovery APIs.
- Registry metadata is recursively immutable; each discovery call returns fresh JSON-safe containers.
- Python and CLI discovery expose chemistry, cell format, capacity, experimental range, citations, capabilities, release phase, and the full pinned upstream commit.
- No generic chemistry, pack-calibration, or operating defaults are invented. Current model `operating_defaults` mappings are empty.
- BLAST results and their provenance carry the same model key/profile identity and distinguish cell-model projection from pack calibration.
- BLAST snapshots carry a schema version and model key through JSON serialization and reject unsupported schema versions.

## Configuration note

Strict App validation already rejected `battery_type` as an unknown key in 0.3.4. This change replaces the generic unknown-key error with migration guidance; it is not a newly introduced 0.4.0 break. The lower-level native `BatteryConfig.battery_type` field remains supported.

## Validation

- focused profiles/CLI/App/runner suite: 105 passed
- full suite: 450 passed, 7 skipped
- Ruff lint and format checks passed
- strict Sphinx build passed
- cumulative `git diff --check` passed

## Merge note

This change uses a merge commit so the remaining 0.4.0 checkpoint changes can be applied against the resulting `develop` history.
