### PR TITLE
Harden 0.4.0 release artifact validation

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -37,7 +37,32 @@ uv run --extra docs sphinx-build -b html docs docs/_build/html
 
 The release artifact verifier must build both wheel and sdist, confirm packaged
 runtime data is present, confirm generated docs are not shipped, and import
-BREOS from the installed wheel instead of the source checkout.
+BREOS from the installed wheel instead of the source checkout. It also imports
+all 14 vendored BLAST models and verifies the installed BLAST license, DOE
+notice, and pinned upstream provenance.
+
+## 0.4.0 Validation Matrix
+
+The `Tests` workflow runs the complete matrix on Python 3.11, 3.12, 3.13, and
+3.14. The following release claims must remain tied to executable checks:
+
+| Gate | Executable coverage |
+| --- | --- |
+| Native remains the default and matches an explicit native run | `tests/test_battery_profiles.py`, `tests/test_runners.py` |
+| Adapter parameters and trajectories match pinned upstream BLAST | `tests/test_blast_multicondition_parity.py` |
+| All 14 models execute and restore snapshots | `tests/test_blast_engine.py` |
+| One continuous run equals snapshot continuation | `tests/test_blast_engine.py`, `tests/test_runners.py` |
+| Leap-year and 15-minute behavior | `tests/test_load_profiles.py`, `tests/test_weather.py`, `tests/test_battery.py` |
+| Replacement resets model state and battery inventory | `tests/test_battery.py` |
+| Battery power limits and shared inverter interactions | `tests/test_battery.py`, `tests/test_inverter.py` |
+| Snapshot JSON round trips and schema rejection | `tests/test_battery_profiles.py` |
+| Range/horizon warnings deduplicate across continuation | `tests/test_blast_engine.py`, `tests/test_runners.py` |
+| Installed wheel contains models, provenance, license, and notice | `tools/verify_release_artifacts.py` |
+
+The upstream parity fixture records the generating Python and NumPy versions;
+it is a checked release artifact, not regenerated during CI. Regeneration must
+use the pinned unmodified BLAST-Lite source and be reviewed as a scientific
+data change.
 
 ## Publishing To PyPI
 

--- a/tools/verify_release_artifacts.py
+++ b/tools/verify_release_artifacts.py
@@ -25,7 +25,26 @@ REQUIRED_WHEEL_FILES = {
     "breos/data/configs/financials.json",
     "breos/data/rlp/h0SLP_demandlib_1000kwh_hourly.csv",
     "breos/data/rlp/h0SLP_demandlib_1000kwh_15min.csv",
+    "breos/degradation/blast/LICENSE",
+    "breos/degradation/blast/NOTICE",
 }
+REQUIRED_BLAST_MODEL_FILES = {
+    "lfp_gr_250AhPrismatic_2019.py",
+    "lfp_gr_SonyMurata3Ah_2018.py",
+    "lmo_gr_NissanLeaf66Ah_2ndLife_2020.py",
+    "nca_gr_Panasonic3Ah_2018.py",
+    "nca_grsi_SonyMurata2p5Ah_2023.py",
+    "nmc111_gr_Kokam75Ah_2017.py",
+    "nmc111_gr_Sanyo2Ah_2014.py",
+    "nmc622_gr_DENSO50Ah_2021.py",
+    "nmc811_grSi_LGM50_5Ah_2021.py",
+    "nmc811_grSi_LGMJ1_4Ah_2020.py",
+    "nmc_gr_50Ah_B1_2020.py",
+    "nmc_gr_50Ah_B2_2020.py",
+    "nmc_gr_75Ah_A_2019.py",
+    "nmc_lto_10Ah_2020.py",
+}
+REQUIRED_WHEEL_FILES.update(f"breos/degradation/blast/models/{filename}" for filename in REQUIRED_BLAST_MODEL_FILES)
 REQUIRED_SDIST_FILES = {
     "docs/conf.py",
     "docs/index.md",
@@ -133,6 +152,7 @@ def _smoke_test_installed_wheel(wheel: Path, work_dir: Path) -> None:
         import json
         import os
         import sys
+        from importlib.resources import files
         from pathlib import Path
 
         repo_root = Path(os.environ["BREOS_REPO_ROOT"]).resolve()
@@ -150,6 +170,8 @@ def _smoke_test_installed_wheel(wheel: Path, work_dir: Path) -> None:
 
         import breos
         from breos.app import App
+        from breos.degradation.engine import BLAST_MODEL_CLASSES
+        from breos.degradation.profiles import BLAST_UPSTREAM_COMMIT, BLAST_UPSTREAM_VERSION
         from breos.load_profiles import load_profile
         from breos.resources import load_config_json, rlp_resource
 
@@ -173,7 +195,34 @@ def _smoke_test_installed_wheel(wheel: Path, work_dir: Path) -> None:
         if app._cfg["location"] != "porto":
             raise AssertionError("App did not resolve packaged configuration")
 
-        print(json.dumps({"breos_file": str(breos_file), "profile_rows": len(profile)}))
+        profiles = breos.list_battery_models()
+        if len(profiles) != 14 or set(BLAST_MODEL_CLASSES) != {profile["key"] for profile in profiles}:
+            raise AssertionError("installed wheel does not expose all 14 BLAST profiles and model classes")
+        for model_key, model_class in BLAST_MODEL_CLASSES.items():
+            model = model_class()
+            if "q" not in model.outputs:
+                raise AssertionError(f"installed BLAST model {model_key} has no capacity output")
+        if BLAST_UPSTREAM_VERSION != "1.1.0" or BLAST_UPSTREAM_COMMIT != "d789e00":
+            raise AssertionError("installed BLAST provenance does not match the vendored pin")
+
+        blast_package = files("breos.degradation.blast")
+        license_text = blast_package.joinpath("LICENSE").read_text(encoding="utf-8")
+        notice_text = blast_package.joinpath("NOTICE").read_text(encoding="utf-8")
+        if "Copyright (c) 2023, Alliance for Sustainable Energy" not in license_text:
+            raise AssertionError("installed BLAST license is missing or unexpected")
+        if "Alliance for Sustainable Energy" not in notice_text:
+            raise AssertionError("installed BLAST DOE attribution notice is missing or unexpected")
+
+        print(
+            json.dumps(
+                {
+                    "breos_file": str(breos_file),
+                    "profile_rows": len(profile),
+                    "blast_models": len(profiles),
+                    "blast_upstream": f"{BLAST_UPSTREAM_VERSION}@{BLAST_UPSTREAM_COMMIT}",
+                }
+            )
+        )
         """
     )
     env = os.environ.copy()

--- a/tools/verify_release_artifacts.py
+++ b/tools/verify_release_artifacts.py
@@ -202,7 +202,10 @@ def _smoke_test_installed_wheel(wheel: Path, work_dir: Path) -> None:
             model = model_class()
             if "q" not in model.outputs:
                 raise AssertionError(f"installed BLAST model {model_key} has no capacity output")
-        if BLAST_UPSTREAM_VERSION != "1.1.0" or BLAST_UPSTREAM_COMMIT != "d789e00":
+        if (
+            BLAST_UPSTREAM_VERSION != "1.1.0"
+            or BLAST_UPSTREAM_COMMIT != "d789e00bca60f628de640745c18eb724b07358bd"
+        ):
             raise AssertionError("installed BLAST provenance does not match the vendored pin")
 
         blast_package = files("breos.degradation.blast")


### PR DESCRIPTION
## Summary

- make the 0.4.0 validation matrix explicit and tie each release claim to an executable check
- require every vendored BLAST model module plus the upstream license and DOE notice in the wheel
- exercise all 14 installed model classes and verify the exact pinned BLAST-Lite provenance outside the source checkout

## Artifact contract

`tools/verify_release_artifacts.py` builds the source distribution and then its wheel, inspects both archives, installs the wheel into an isolated temporary environment, and imports BREOS after removing the repository from `sys.path`.

The installed-wheel smoke test now confirms:

- packaged configuration and hourly load-profile resources remain usable
- public model discovery and the installed model-class registry expose the same 14 BLAST profiles
- every installed model class initializes with a capacity output
- BLAST-Lite reports version `1.1.0` at exact upstream commit `d789e00bca60f628de640745c18eb724b07358bd`
- the installed package contains readable upstream `LICENSE` and DOE `NOTICE` files

## Validation

- `uv run pytest -q`: 539 passed, 7 skipped
- `uv run ruff check breos tests tools`
- `uv run ruff format --check breos tests tools`
- `uv run --extra docs sphinx-build -W -b html docs /tmp/breos-docs-pr5`: 127 sources, no warnings
- `uv run python tools/verify_release_artifacts.py`: sdist/wheel build and isolated installed-wheel smoke test passed
- `git diff --check origin/develop..HEAD`

This changes validation tooling and release documentation only. It does not change the package version, create release artifacts in the repository, publish a package, or reconcile the separate policy-documentation checkpoint.
