### PR TITLE
Document battery degradation policy gates

### DIFF
--- a/docs/architecture/battery-degradation-policy.md
+++ b/docs/architecture/battery-degradation-policy.md
@@ -1,0 +1,98 @@
+# Battery degradation policy
+
+This policy defines the scientific and public-API gates for battery-degradation
+changes. Implementation details and the current model catalog live in
+[BLAST Degradation Engine](blast-degradation-engine.md) and
+[Battery degradation models](../api/degradation-models.md).
+
+## Stable public behavior
+
+`breos.App` is the primary stable entry point. Native Naumann/Lam degradation
+remains its default; BLAST is an explicit opt-in through
+`degradation_engine="blast"` and a named `blast_model`. Unsupported
+combinations raise rather than silently falling back to native behavior.
+
+The App-level `battery_type` key was already rejected by strict validation in
+0.3.4. Its targeted 0.4.0 error is migration guidance, not a newly removed App
+feature. The lower-level `BatteryConfig(battery_type="LFP")` API remains
+supported for native degradation and is not a BLAST model selector.
+
+Changes to these selectors, documented result/provenance fields, or default
+behavior require focused `App` tests and an explicit changelog migration note.
+
+## Default-change evidence
+
+Keep `naumann_lam_field_calibrated` as the residential-LFP default. It maps to
+native v1; native v2 remains an explicit sensitivity model. The recorded
+calibration evidence is:
+
+| Native calibration | Full-fit RMSE | Leave-one-system-out result | Policy |
+| --- | ---: | ---: | --- |
+| v1 | 4.40 percentage points | mean RMSE 6.00 pp | Current default |
+| v2 | 4.65 percentage points | mean RMSE 5.49 pp; pooled RMSE 5.61 pp | Sensitivity model |
+
+V2's cross-validation result is encouraging, but the systems used in model
+selection are not a genuinely held-out validation set. Do not change the
+generic default based only on synthetic trajectories, in-sample fit, or
+upstream BLAST parity. A default change requires frozen model choices,
+pack-level field data excluded from fitting and model selection, per-system as
+well as pooled error reporting, and a documented impact on residential studies.
+
+The most interpretable native-versus-BLAST comparison uses BLAST's
+`lfp_gr_sonymurata_3ah` model because both paths ultimately relate to the
+Naumann Sony/Murata 3 Ah LFP data. The 250 Ah prismatic model is a useful
+stationary-cell sensitivity, not equivalent default-selection evidence.
+Upstream parity proves implementation fidelity; it does not prove real-world
+predictive validity.
+
+## Scientific interpretation
+
+A `blast_model` key identifies a particular empirical cell model, not a generic
+chemistry curve. Model identity, citations, experimental ranges, and output
+capabilities come from the single public registry. Experimental ranges drive
+warnings; they are not recommended pack settings. Operating defaults are added
+only when a source supports them, with precedence remaining explicit user
+configuration over sourced profile defaults over global defaults.
+
+BLAST outputs are cell-model projections, not pack-calibrated predictions.
+Thermal gradients, cell variation, imbalance, interconnects, and BMS behavior
+can all change pack-level capacity and power fade. Any future cell-to-pack layer
+must use an explicit documented mapping and validation on packs outside its fit
+set; an unexplained degradation multiplier is insufficient.
+
+Multi-decade SOH remains model-dependent. Preserve the selected model key and
+range/horizon warnings with the result. If a future API reports results across
+several plausible models, call that a **model sensitivity range**, not a
+statistical confidence interval unless a probabilistic model has been
+calibrated.
+
+## Resistance and screening paths
+
+BLAST resistance outputs are diagnostic only. They must not alter dispatch,
+efficiency, or charge/discharge power limits until each model's resistance
+metric and test protocol have a defensible, validated mapping to pack behavior.
+The executable isolation guard is
+`tests/test_battery.py::TestSimulateEnergyBalance::test_blast_resistance_output_is_diagnostic_only`.
+
+The reference Python path remains the accuracy and calibration basis. Optional
+Numba kernels are explicitly approximate screening tools and must not provide
+calibration evidence or replace the reference path in published accuracy
+comparisons merely because they are faster.
+
+## Provenance, legal records, and fixtures
+
+Keep these records separate:
+
+- `breos/degradation/blast/VENDORED.md` is the source/provenance authority for
+  the pinned upstream commit, transformations, and file hashes.
+- `ATTRIBUTIONS.md` plus the bundled `LICENSE` and `NOTICE` preserve legal and
+  scientific credits.
+- The BREOS adapter, dispatch integration, registry, and runners are original
+  BREOS code outside the vendored-source table.
+- Parity fixtures are derived scientific test data, not upstream source or
+  license artifacts. They stay fixed in CI. Regeneration must use the pinned,
+  unmodified BLAST-Lite source and be reviewed as a scientific data change.
+
+The executable artifact and fixture gates are maintained in
+[Public Release Checklist](../release.md); this policy does not duplicate that
+release procedure.

--- a/docs/architecture/blast-degradation-engine.md
+++ b/docs/architecture/blast-degradation-engine.md
@@ -4,6 +4,9 @@
 **Relates to:** ROADMAP "Additional Li-ion battery chemistries"
 **Owner:** BREOS maintainers
 
+The cross-cutting default, validation, cell-to-pack, resistance, and provenance
+rules are maintained in [Battery degradation policy](battery-degradation-policy.md).
+
 ## Problem
 
 BREOS's battery degradation is calibrated for **LFP only**. Calendar aging uses
@@ -179,9 +182,11 @@ accumulators. BLAST path instead calls `blast_engine.reset()` (fresh instance).
 
 ### Resistance fade
 
-Phase 1: **disable `enable_resistance_fade` for the BLAST path** (raise if both
-set) — BLAST multi-mode models expose `outputs['r']`, but mapping resistance→RTE
-derate is its own task. Defer to Phase 4.
+BLAST multi-mode models expose resistance outputs, but those values are
+diagnostic only: they do not alter dispatch, efficiency, or power limits.
+`enable_resistance_fade` remains incompatible with the BLAST path and raises if
+both are selected. A future coupling requires the model-specific validation
+defined in [Battery degradation policy](battery-degradation-policy.md#resistance-and-screening-paths).
 
 ## Config plumbing
 
@@ -196,18 +201,17 @@ drift-prone — keep additions minimal until that lands):
    `degradation_engine="blast"` together with Monte Carlo** until Phase 4 — raise
    a clear error, never silently fall back to native (see the Monte Carlo note in
    Performance / Phasing).
-3. `breos/runners/app.py`: pass both into `BatteryConfig`. **Retire or fully
-   deprecate the legacy `battery_type` field** (see Open decisions) — the new
-   `degradation_engine` / `blast_model` keys replace it; don't overload a field
-   that currently means native-LFP-only.
+3. `breos/runners/app.py`: pass both into the energy-balance path. Do not
+   repurpose lower-level `BatteryConfig.battery_type`, which remains a guarded
+   native-LFP selector; App migration guidance points callers to the explicit
+   `degradation_engine` / `blast_model` keys.
 4. `breos/cli.py`: `--degradation-engine` / `--blast-model` flags via
    `_add_override`.
 
 `degradation_engine="native"` (default) ⇒ existing behavior, **bit-for-bit**.
 
-When `blast_model` is set, its chemistry profile (see below) is resolved into the
-`BatteryConfig` defaults *before* user overrides are applied, following the
-precedence rule in "Chemistry profile registry."
+When `blast_model` is set, its cell-model profile (see below) is resolved before
+user overrides are applied, following the profile-registry precedence rule.
 
 ## Model catalog (vendor all 14, enable in phases)
 
@@ -243,57 +247,33 @@ Note: several keys (Panasonic, Sony-Murata cylindrical, the NMC fast-charge
 pouches) are EV / high-power cells tested well above stationary C-rates — they
 run, but lean on the out-of-range warning below.
 
-## Chemistry profile registry (per-chemistry settings)
+## Cell-model profile registry
 
-There are **three tiers** of per-chemistry data; only the third is a user
-*setting*. Conflating them is the trap to avoid.
+There are **three tiers** of profile data; only the third can be a user
+*setting*. A named cell model is not a generic chemistry profile.
 
 1. **Degradation parameters** (`qcal_*` / `qcyc_*`) — baked into the vendored
    BLAST class, calibrated to papers. **Never user-tunable.**
 2. **Validity ranges** (`experimental_range`, e.g. the 250Ah LFP declares
    `cycling_temperature: [10, 45]`, `dod: [0.8, 1]`, `max_rate_charge: 0.65`) —
    also baked in; drives **warnings, not tuning**.
-3. **Operating-envelope defaults** — RTE, SoC window (`min_soc`/`max_soc`),
-   `eol_percentage`, C-rate limits, energy density. These **differ by chemistry**
-   (LFP tolerates 0–100% DoD + long calendar life; NMC/NCA prefer narrower
-   windows; LTO huge cycle life / low energy density; 2nd-life Leaf starts below
-   100% SoH) and **are the legitimate "settings per chemistry."**
+3. **Operating-envelope defaults** — pack-level RTE, SoC window
+   (`min_soc`/`max_soc`), EOL threshold, and power limits. The bundled studies
+   do not source generic pack defaults, so the current profiles leave this tier
+   empty instead of inferring values from chemistry labels.
 
-### Design: a declarative registry feeding existing `BatteryConfig` fields
+`breos/degradation/profiles.py` is the single declarative registry for Python
+and CLI discovery, engine class lookup, model identity, citations, ranges, and
+output capabilities. Configuration resolves in this order:
 
-A small `breos/degradation/chemistry_profiles.py` (or JSON in `breos/data/configs/`,
-mirroring the existing `costs.json` / `emissions.json` preset pattern) keyed by
-`blast_model`, supplying **only tier-3 defaults**. Selecting a model auto-loads
-its profile; every field stays independently overridable.
-
-Precedence (explicit, least-surprising):
-
-```
-explicit user config  >  chemistry profile default  >  global BatteryConfig default
+```text
+explicit user config > sourced profile default > global App default
 ```
 
-**Merge-order implementation note.** `resolve_app_config` currently does
-`merge_defaults(config)` *then* validates (`app_config.py:382-385`), so by
-validation time the raw user keys are indistinguishable from defaults. To honor
-the precedence above, capture the **raw user key set** before merging and resolve
-as `{**DEFAULTS, **chemistry_profile, **raw_user_config}` — the profile fills only
-keys the user did not set. (This is also a prerequisite the ROADMAP "declarative
-schema" item will need.)
-
-### Rules
-
-- **Don't fabricate tier-3 numbers.** Ship a per-chemistry default only where a
-  source supports it; otherwise inherit the global default. (Same "documented
-  source" bar the ROADMAP sets — a made-up per-chemistry RTE is worse than the
-  honest global default.)
-- **Cost stays out of the chemistry profile.** $/kWh already lives in the
-  cost-preset system; duplicating it here creates two sources of truth. The
-  profile owns the *electrochemical* envelope only.
-- **Warn, don't block, on conflicts.** If a user picks NMC and forces
-  `max_soc=1.0`, emit an `experimental_range` warning — don't reject it.
-
-Net: BLAST class owns the *physics*, the chemistry profile owns *policy
-defaults*, the user keeps the final say.
+Cost remains in the cost-preset system. Experimental-range conflicts warn
+rather than rewriting a user's operating configuration. The full scientific
+and default-change rules are in
+[Battery degradation policy](battery-degradation-policy.md#scientific-interpretation).
 
 ## Known integration risks to verify
 
@@ -362,10 +342,10 @@ Phase 4 wires that loop — never silently run as native.
   resets BLAST. Enable the two simple 2-bucket-power models end-to-end —
   **LFP 250Ah prismatic (flagship)** + **NCA Panasonic (POC)**; default path
   untouched. Adapter-parity, cross-year-continuity, and regression tests.
-- **Phase 2** — The **chemistry profile registry** (precedence + raw-key
+- **Phase 2** — The **cell-model profile registry** (precedence + raw-key
   merge-order) + full config/CLI plumbing (`--degradation-engine` /
-  `--blast-model`; **retire** the legacy `battery_type` selector — see the
-  resolved decision below).
+  `--blast-model`) and targeted App migration guidance for the unsupported
+  `battery_type` key without removing the lower-level native-LFP field.
 - **Phase 3a** — Enable the remaining **power-law** chemistries (LMO 2nd-life,
   NMC811 M50/MJ1, NMC 50Ah B1/B2, NMC 75Ah A, NMC111 Sanyo, NMC-LTO);
   per-chemistry smoke tests + `experimental_range` out-of-bounds warnings.
@@ -393,10 +373,10 @@ Resolved:
   Carlo a picklable representation. Prototype tests in the BLAST-Lite prep
   branch proved snapshot continuity across all 14 BLAST models, including the
   P3b multi-mode models.
-- **[DECIDED] Do not repurpose `battery_type` for BLAST chemistry.** In 0.3.3 it
-  became a guarded native-LFP selector instead of a silent no-op for non-LFP
-  values. The new `degradation_engine` / `blast_model` keys should select BLAST
-  chemistry rather than overloading `battery_type`.
+- **[DECIDED] Do not repurpose `battery_type` for BLAST chemistry.** At the
+  lower level it is a guarded native-LFP selector. Strict App validation already
+  rejected the key in 0.3.4; 0.4.0 adds a targeted migration error. The explicit
+  `degradation_engine` / `blast_model` keys select BLAST instead.
 
 ## Non-goals
 

--- a/docs/architecture/blast-degradation-engine.md
+++ b/docs/architecture/blast-degradation-engine.md
@@ -323,8 +323,10 @@ Phase 4 wires that loop — never silently run as native.
 
 ## Licensing / attribution
 
-- Preserve the BSD-3 copyright header (`Alliance for Energy Innovation, LLC`) and
-  the DOE-contract `NOTICE` text in every vendored file.
+- Preserve the upstream copyright headers carried by the transformed source
+  files. Bundle the upstream BSD-3 license and DOE-contract notice unchanged as
+  `breos/degradation/blast/LICENSE` and `breos/degradation/blast/NOTICE`, as
+  recorded in the vendoring manifest.
 - Add a BLAST-Lite entry to `ATTRIBUTIONS.md` (source, commit/version vendored,
   DOIs of the model papers).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,7 @@ resources
 release
 architecture/third-party-wrapping
 architecture/string-inverter-sizing
+architecture/battery-degradation-policy
 architecture/blast-degradation-engine
 legal/load-profile-data
 adr/index


### PR DESCRIPTION
## Summary

- define the evidence required before changing BREOS's native residential-LFP degradation default
- distinguish upstream parity from real-world predictive validity and cell-model outputs from pack-calibrated predictions
- record the diagnostic-only resistance invariant, reference-versus-screening policy, and provenance/legal/fixture boundaries
- reconcile the existing BLAST architecture note with the selectors, registry, inventory continuity, and legal artifacts implemented for 0.4.0

## Policy boundaries

Native Naumann/Lam remains the default. BLAST remains an explicit opt-in through `degradation_engine="blast"` and a named `blast_model`; unsupported combinations raise rather than silently falling back.

The new policy page records that:

- a default change requires frozen model choices and genuinely held-out pack-level field evidence
- a BLAST key identifies a particular empirical cell model, not a generic chemistry curve
- experimental ranges are extrapolation diagnostics, not recommended operating settings
- BLAST resistance outputs do not affect efficiency, power limits, dispatch, or economics without a model-specific validated mapping
- reference Python results remain the calibration/accuracy basis; approximate Numba kernels are screening tools
- vendored-source provenance, legal artifacts, original BREOS integration code, and derived parity fixtures remain separate records

## Documentation reconciliation

The architecture note now reflects the implemented cell-model registry and configuration precedence, preserves lower-level native `BatteryConfig.battery_type` compatibility, and describes the exact standalone BLAST-Lite `LICENSE` and `NOTICE` artifacts consistently with the vendoring manifest.

Obsolete release ordering, transfer-branch status, implementation code, duplicate model catalogs, version changes, and publishing work are intentionally excluded.

## Validation

- `uv run --extra docs sphinx-build -W -b html docs /tmp/breos-docs-pr6-review`: 128 sources, no warnings
- `uv run pytest -q tests/test_battery.py::TestSimulateEnergyBalance::test_blast_resistance_output_is_diagnostic_only tests/test_battery_profiles.py`: 9 passed
- `git diff --check origin/develop..HEAD`

This is documentation-only. It does not change runtime behavior, the package version, release artifacts, or publishing state.
