### PR TITLE
Point README logo at develop so the cropped image renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Str4vinci/breos/main/docs/_static/BREOS.png">
-    <img alt="BREOS logo" src="https://raw.githubusercontent.com/Str4vinci/breos/main/docs/_static/BREOS_black.png" width="200">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Str4vinci/breos/develop/docs/_static/BREOS.png">
+    <img alt="BREOS logo" src="https://raw.githubusercontent.com/Str4vinci/breos/develop/docs/_static/BREOS_black.png" width="200">
   </picture>
 </p>
 


### PR DESCRIPTION
Temporary pointing logo to develop instead of main. Next version will go back to main. Whoopsie