### PR TITLE
Refactor degradation and config boundaries for 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Changed
+- Extracted BLAST experimental-range and aging-horizon validation into a focused
+  internal warning collector while preserving warning records, snapshot
+  continuation, replacement-reset behavior, and the `breos.App` result schema.
+- Centralized native and BLAST degradation-result construction in a focused
+  schema-aware builder while preserving public fields, engine-specific SOH
+  precision, and shared result/provenance data.
+- Decomposed `breos.App` configuration validation into focused subsystem
+  validators while preserving validation order, public errors, normalization,
+  defaults, and resolution precedence.
+
 ## [0.4.0] - 2026-07-20
 
 ### Added

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -155,6 +155,15 @@ def _validate_sky_settings(
 
 def validate_config(cfg: dict[str, Any]) -> None:
     """Validate user-facing App config before resolving derived values."""
+    has_arrays = _validate_structure_and_location(cfg)
+    _validate_pv_and_inverter(cfg, has_arrays)
+    _validate_time_and_weather(cfg)
+    _validate_economics(cfg)
+    _validate_battery_and_degradation(cfg)
+
+
+def _validate_structure_and_location(cfg: dict[str, Any]) -> bool:
+    """Validate top-level keys, required inputs, and location structure."""
     if "battery_type" in cfg:
         raise ValueError(
             "'battery_type' is an ambiguous legacy selector and is not supported by App. "
@@ -193,6 +202,11 @@ def validate_config(cfg: dict[str, Any]) -> None:
     elif not isinstance(loc, str):
         raise TypeError("'location' must be a string key or a dict with latitude/longitude/timezone")
 
+    return has_arrays
+
+
+def _validate_pv_and_inverter(cfg: dict[str, Any], has_arrays: bool) -> None:
+    """Validate PV sizing, array geometry, sky models, and inverter inputs."""
     if not has_arrays and (not _is_int(cfg["n_modules"]) or cfg["n_modules"] < 1):
         raise ValueError("'n_modules' must be >= 1")
     if has_arrays:
@@ -238,6 +252,10 @@ def validate_config(cfg: dict[str, Any]) -> None:
         raise ValueError("'inverter_efficiency' must be between 0 (exclusive) and 1 (inclusive)")
     if _finite_real(cfg["inverter_loading_ratio"], "inverter_loading_ratio") <= 0:
         raise ValueError("'inverter_loading_ratio' must be > 0")
+
+
+def _validate_time_and_weather(cfg: dict[str, Any]) -> None:
+    """Validate simulation horizon, resolution, and solar-model selections."""
     if not _is_int(cfg["projection_years"]) or cfg["projection_years"] < 1:
         raise ValueError("'projection_years' must be >= 1")
     if not 0 <= _finite_real(cfg["pv_degradation_rate"], "pv_degradation_rate") < 1:
@@ -261,6 +279,10 @@ def validate_config(cfg: dict[str, Any]) -> None:
         for name, value in overrides.items():
             if not isinstance(value, (int, float)) or not 0 <= value <= 100:
                 raise ValueError(f"'pv_loss_overrides[{name!r}]' must be a percentage between 0 and 100")
+
+
+def _validate_economics(cfg: dict[str, Any]) -> None:
+    """Validate financial and optional export-emissions inputs."""
     for key in ("inflation_rate", "discount_rate"):
         if _finite_real(cfg[key], key) <= -1:
             raise ValueError(f"'{key}' must be greater than -1")
@@ -269,6 +291,10 @@ def validate_config(cfg: dict[str, Any]) -> None:
     if cfg["export_emissions_factor_gco2_kwh"] is not None:
         if _finite_real(cfg["export_emissions_factor_gco2_kwh"], "export_emissions_factor_gco2_kwh") < 0:
             raise ValueError("'export_emissions_factor_gco2_kwh' must be >= 0 when configured")
+
+
+def _validate_battery_and_degradation(cfg: dict[str, Any]) -> None:
+    """Validate battery dispatch and explicit degradation-engine selection."""
     min_soc = _finite_real(cfg["battery_min_soc"], "battery_min_soc")
     max_soc = _finite_real(cfg["battery_max_soc"], "battery_max_soc")
     if not 0 <= min_soc < max_soc <= 1:

--- a/breos/degradation/engine.py
+++ b/breos/degradation/engine.py
@@ -7,7 +7,6 @@ configuration, or replacement behavior.
 
 from __future__ import annotations
 
-import warnings
 from copy import deepcopy
 from typing import Any
 
@@ -15,6 +14,11 @@ import numpy as np
 
 from breos.degradation.blast import models
 from breos.degradation.profiles import BATTERY_MODEL_REGISTRY, BLAST_STATE_SCHEMA_VERSION, CORE_BLAST_MODEL_KEYS
+from breos.degradation.validation import (
+    BlastAgingHorizonWarning,
+    BlastExperimentalRangeWarning,
+    BlastWarningCollector,
+)
 
 BLAST_MODEL_CLASSES = {key: getattr(models, profile.class_name) for key, profile in BATTERY_MODEL_REGISTRY.items()}
 
@@ -24,14 +28,6 @@ P1_BLAST_MODEL_KEYS = CORE_BLAST_MODEL_KEYS
 
 class BlastNumericalError(RuntimeError):
     """A BLAST model produced a non-finite state; results are unusable."""
-
-
-class BlastExperimentalRangeWarning(UserWarning):
-    """A BLAST input falls outside conditions represented by its test data."""
-
-
-class BlastAgingHorizonWarning(UserWarning):
-    """A BLAST simulation extends beyond a sourced aging-data horizon."""
 
 
 def _as_1d_float_array(name: str, values: Any) -> np.ndarray:
@@ -110,7 +106,7 @@ class BlastEngine:
         self.blast_model_key = blast_model_key
         self._model_kwargs = dict(model_kwargs)
         self.model = self._new_model()
-        self._warning_records: dict[str, dict[str, Any]] = {}
+        self._warning_collector = BlastWarningCollector(blast_model_key)
 
     def _new_model(self):
         return BLAST_MODEL_CLASSES[self.blast_model_key](**self._model_kwargs)
@@ -119,9 +115,9 @@ class BlastEngine:
         """Update by one time chunk and return current SoH fraction."""
 
         t_secs, soc, temperature_c = normalize_step_inputs(t_secs_day, soc_abs_day, t_cell_day_c)
-        self._check_experimental_range(t_secs, soc, temperature_c)
+        self._warning_collector.check_experimental_range(t_secs, soc, temperature_c)
         self.model.update_battery_state(t_secs, soc, temperature_c)
-        self._check_aging_horizon()
+        self._warning_collector.check_aging_horizon(float(self.model.stressors["t_days"][-1]))
         self._check_finite_update()
         return self.soh()
 
@@ -151,105 +147,9 @@ class BlastEngine:
                 "the simulation cannot continue."
             )
 
-    def _record_warning(
-        self,
-        code: str,
-        message: str,
-        category: str,
-        warning_class: type[Warning],
-        **details: Any,
-    ) -> None:
-        if code in self._warning_records:
-            return
-        self._warning_records[code] = {
-            "code": code,
-            "message": message,
-            "category": category,
-            **details,
-        }
-        warnings.warn(message, warning_class, stacklevel=3)
-
-    def _check_experimental_range(self, t_secs: np.ndarray, soc: np.ndarray, temperature_c: np.ndarray) -> None:
-        limits = BATTERY_MODEL_REGISTRY[self.blast_model_key].experimental_range
-        checks = [
-            (
-                "temperature_c",
-                float(np.min(temperature_c)),
-                float(np.max(temperature_c)),
-                limits["cycling_temperature_c"],
-            ),
-            ("soc", float(np.min(soc)), float(np.max(soc)), limits["soc"]),
-        ]
-        observed_dod = float(np.ptp(soc))
-        if observed_dod > 1e-12:
-            checks.append(("dod", observed_dod, observed_dod, limits["dod"]))
-        for field, observed_min, observed_max, supported in checks:
-            supported_min = float(min(supported))
-            supported_max = float(max(supported))
-            if observed_min < supported_min - 1e-12 or observed_max > supported_max + 1e-12:
-                message = (
-                    f"BLAST model {self.blast_model_key!r} received {field} range "
-                    f"[{observed_min:.6g}, {observed_max:.6g}] outside experimental range "
-                    f"[{supported_min:.6g}, {supported_max:.6g}]."
-                )
-                self._record_warning(
-                    f"experimental_range.{field}",
-                    message,
-                    "experimental_range",
-                    BlastExperimentalRangeWarning,
-                    field=field,
-                    observed=[observed_min, observed_max],
-                    supported=[supported_min, supported_max],
-                )
-
-        elapsed_hours = np.diff(t_secs) / 3600.0
-        rates = np.diff(soc) / elapsed_hours
-        rate_checks = (
-            ("c_rate_charge", float(max(0.0, np.max(rates))), float(limits["max_c_rate_charge"])),
-            ("c_rate_discharge", float(max(0.0, -np.min(rates))), float(limits["max_c_rate_discharge"])),
-        )
-        for field, observed, supported in rate_checks:
-            if observed > supported + 1e-12:
-                message = (
-                    f"BLAST model {self.blast_model_key!r} received {field} {observed:.6g} C "
-                    f"above experimental maximum {supported:.6g} C."
-                )
-                self._record_warning(
-                    f"experimental_range.{field}",
-                    message,
-                    "experimental_range",
-                    BlastExperimentalRangeWarning,
-                    field=field,
-                    observed=observed,
-                    supported=supported,
-                )
-
-    def _check_aging_horizon(self) -> None:
-        horizon_days = BATTERY_MODEL_REGISTRY[self.blast_model_key].aging_horizon_days
-        if horizon_days is None:
-            return
-        simulated_days = float(self.model.stressors["t_days"][-1])
-        if simulated_days > horizon_days + 1e-12:
-            message = (
-                f"BLAST model {self.blast_model_key!r} is at {simulated_days:.6g} simulated days, "
-                f"beyond its sourced {horizon_days:.6g}-day aging-data horizon."
-            )
-            self._record_warning(
-                "aging_horizon.days",
-                message,
-                "aging_horizon",
-                BlastAgingHorizonWarning,
-                observed_days=simulated_days,
-                supported_days=horizon_days,
-            )
-
     def warning_records(self, category: str | None = None) -> list[dict[str, Any]]:
         """Return JSON-safe, deduplicated warnings accumulated by this run."""
-        return [
-            deepcopy(record)
-            for record in self._warning_records.values()
-            if category is None or record["category"] == category
-        ]
+        return self._warning_collector.records(category)
 
     def soh(self) -> float:
         """Return current BLAST capacity fraction."""
@@ -291,7 +191,10 @@ class BlastEngine:
             )
 
         engine = cls(blast_model_key, **snapshot.get("model_kwargs", {}))
-        engine._warning_records = {record["code"]: deepcopy(record) for record in snapshot.get("warnings", [])}
+        engine._warning_collector = BlastWarningCollector.from_snapshot(
+            blast_model_key,
+            snapshot.get("warnings", []),
+        )
         for group_name in cls._ARRAY_GROUPS:
             group = snapshot[group_name]
             setattr(

--- a/breos/degradation/results.py
+++ b/breos/degradation/results.py
@@ -1,0 +1,65 @@
+"""Construction of public degradation result blocks.
+
+This module owns the small, stable schema exposed by :class:`breos.App`.
+Keeping it separate from the simulation runner makes the engine-specific
+precision and provenance policy explicit without moving any degradation
+physics or continuation-state handling.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, Literal
+
+DegradationEngineName = Literal["blast", "native"]
+
+
+def build_degradation_summary(
+    *,
+    engine: DegradationEngineName,
+    model_key: str,
+    final_soh_pct: float,
+    replacement_events: list[dict[str, int]],
+    initial_soh_pct: float = 100.0,
+    model_profile: Mapping[str, Any] | None = None,
+    warning_records: Iterable[Mapping[str, Any]] = (),
+    state_schema_version: str | None = None,
+) -> dict[str, Any]:
+    """Build the public, JSON-serializable degradation summary.
+
+    ``model_profile``, warnings, and state schema are meaningful only for the
+    explicit BLAST engine. Native output deliberately retains its smaller,
+    backwards-compatible schema and two-decimal SOH precision.
+    """
+    if engine == "native":
+        return {
+            "engine": "native",
+            "model_key": model_key,
+            "initial_soh_pct": initial_soh_pct,
+            "final_soh_pct": round(float(final_soh_pct), 2),
+            "replacement_events": replacement_events,
+        }
+
+    if model_profile is None:
+        raise ValueError("BLAST degradation results require model_profile")
+    if state_schema_version is None:
+        raise ValueError("BLAST degradation results require state_schema_version")
+
+    warnings = list(warning_records)
+    return {
+        "engine": "blast",
+        "model_key": model_key,
+        "model_profile": dict(model_profile),
+        "initial_soh_pct": initial_soh_pct,
+        "final_soh_pct": round(float(final_soh_pct), 1),
+        "replacement_events": replacement_events,
+        "calibration_basis": "cell-model",
+        "pack_calibrated": False,
+        "experimental_range_warnings": [
+            warning for warning in warnings if warning.get("category") == "experimental_range"
+        ],
+        "aging_horizon_extrapolation_warnings": [
+            warning for warning in warnings if warning.get("category") == "aging_horizon"
+        ],
+        "state_schema_version": state_schema_version,
+    }

--- a/breos/degradation/validation.py
+++ b/breos/degradation/validation.py
@@ -1,0 +1,163 @@
+"""BLAST experimental-validity checks and run-level warning collection."""
+
+from __future__ import annotations
+
+import warnings
+from copy import deepcopy
+from typing import Any, Iterable, Mapping
+
+import numpy as np
+
+from breos.degradation.profiles import BATTERY_MODEL_REGISTRY
+
+EXPERIMENTAL_RANGE_CATEGORY = "experimental_range"
+AGING_HORIZON_CATEGORY = "aging_horizon"
+AGING_HORIZON_CODE = "aging_horizon.days"
+
+
+class BlastExperimentalRangeWarning(UserWarning):
+    """A BLAST input falls outside conditions represented by its test data."""
+
+
+class BlastAgingHorizonWarning(UserWarning):
+    """A BLAST simulation extends beyond a sourced aging-data horizon."""
+
+
+def experimental_range_code(field: str) -> str:
+    """Return the stable warning code for one experimental-range field."""
+
+    return f"{EXPERIMENTAL_RANGE_CATEGORY}.{field}"
+
+
+class BlastWarningCollector:
+    """Evaluate BLAST validity limits and retain deduplicated JSON-safe warnings.
+
+    Warning history belongs to the simulation run rather than the current cell.
+    Callers can therefore reset the scientific model after a battery replacement
+    without resetting this collector.
+    """
+
+    def __init__(
+        self,
+        blast_model_key: str,
+        records: Iterable[Mapping[str, Any]] = (),
+    ) -> None:
+        self.blast_model_key = blast_model_key
+        self._profile = BATTERY_MODEL_REGISTRY[blast_model_key]
+        self._records = {str(record["code"]): deepcopy(dict(record)) for record in records}
+
+    @classmethod
+    def from_snapshot(
+        cls,
+        blast_model_key: str,
+        records: Iterable[Mapping[str, Any]],
+    ) -> BlastWarningCollector:
+        """Restore warning history from a serialized engine snapshot."""
+
+        return cls(blast_model_key, records)
+
+    def _record(
+        self,
+        code: str,
+        message: str,
+        category: str,
+        warning_class: type[Warning],
+        **details: Any,
+    ) -> None:
+        if code in self._records:
+            return
+        self._records[code] = {
+            "code": code,
+            "message": message,
+            "category": category,
+            **details,
+        }
+        warnings.warn(message, warning_class, stacklevel=3)
+
+    def check_experimental_range(
+        self,
+        t_secs: np.ndarray,
+        soc: np.ndarray,
+        temperature_c: np.ndarray,
+    ) -> None:
+        """Record any input conditions outside the model's sourced test range."""
+
+        limits = self._profile.experimental_range
+        checks = [
+            (
+                "temperature_c",
+                float(np.min(temperature_c)),
+                float(np.max(temperature_c)),
+                limits["cycling_temperature_c"],
+            ),
+            ("soc", float(np.min(soc)), float(np.max(soc)), limits["soc"]),
+        ]
+        observed_dod = float(np.ptp(soc))
+        if observed_dod > 1e-12:
+            checks.append(("dod", observed_dod, observed_dod, limits["dod"]))
+        for field, observed_min, observed_max, supported in checks:
+            supported_min = float(min(supported))
+            supported_max = float(max(supported))
+            if observed_min < supported_min - 1e-12 or observed_max > supported_max + 1e-12:
+                message = (
+                    f"BLAST model {self.blast_model_key!r} received {field} range "
+                    f"[{observed_min:.6g}, {observed_max:.6g}] outside experimental range "
+                    f"[{supported_min:.6g}, {supported_max:.6g}]."
+                )
+                self._record(
+                    experimental_range_code(field),
+                    message,
+                    EXPERIMENTAL_RANGE_CATEGORY,
+                    BlastExperimentalRangeWarning,
+                    field=field,
+                    observed=[observed_min, observed_max],
+                    supported=[supported_min, supported_max],
+                )
+
+        elapsed_hours = np.diff(t_secs) / 3600.0
+        rates = np.diff(soc) / elapsed_hours
+        rate_checks = (
+            ("c_rate_charge", float(max(0.0, np.max(rates))), float(limits["max_c_rate_charge"])),
+            ("c_rate_discharge", float(max(0.0, -np.min(rates))), float(limits["max_c_rate_discharge"])),
+        )
+        for field, observed, supported in rate_checks:
+            if observed > supported + 1e-12:
+                message = (
+                    f"BLAST model {self.blast_model_key!r} received {field} {observed:.6g} C "
+                    f"above experimental maximum {supported:.6g} C."
+                )
+                self._record(
+                    experimental_range_code(field),
+                    message,
+                    EXPERIMENTAL_RANGE_CATEGORY,
+                    BlastExperimentalRangeWarning,
+                    field=field,
+                    observed=observed,
+                    supported=supported,
+                )
+
+    def check_aging_horizon(self, simulated_days: float) -> None:
+        """Record extrapolation beyond a sourced numeric aging-data horizon."""
+
+        horizon_days = self._profile.aging_horizon_days
+        if horizon_days is None or simulated_days <= horizon_days + 1e-12:
+            return
+        message = (
+            f"BLAST model {self.blast_model_key!r} is at {simulated_days:.6g} simulated days, "
+            f"beyond its sourced {horizon_days:.6g}-day aging-data horizon."
+        )
+        self._record(
+            AGING_HORIZON_CODE,
+            message,
+            AGING_HORIZON_CATEGORY,
+            BlastAgingHorizonWarning,
+            observed_days=simulated_days,
+            supported_days=horizon_days,
+        )
+
+    def records(self, category: str | None = None) -> list[dict[str, Any]]:
+        """Return copied, JSON-safe warning records in first-observed order."""
+
+        return [
+            deepcopy(record) for record in self._records.values() if category is None or record["category"] == category
+        ]

--- a/breos/runners/app.py
+++ b/breos/runners/app.py
@@ -12,6 +12,7 @@ from breos.app_config import ResolvedAppConfig, build_costs_dict
 from breos.app_inputs import AppRuntimeDependencies, prepare_simulation_inputs
 from breos.battery import BatteryConfig, simulate_energy_balance
 from breos.degradation.profiles import BLAST_STATE_SCHEMA_VERSION, get_battery_model_profile
+from breos.degradation.results import build_degradation_summary
 from breos.economics import calculate_lcoe_from_projection, cost_analysis_projection, find_payback_year
 from breos.solar import PVProductionBreakdown
 from breos.utils import get_hours_per_step
@@ -397,31 +398,22 @@ def run_app_simulation(
     if degradation_engine == "blast":
         profile = get_battery_model_profile(str(blast_model))
         warning_records = degradation_state.get("blast_engine", {}).get("warnings", []) if degradation_state else []
-        degradation_summary = {
-            "engine": "blast",
-            "model_key": blast_model,
-            "model_profile": profile.as_dict(),
-            "initial_soh_pct": 100.0,
-            "final_soh_pct": round(float(current_soh), 1),
-            "replacement_events": replacement_events,
-            "calibration_basis": "cell-model",
-            "pack_calibrated": False,
-            "experimental_range_warnings": [
-                warning for warning in warning_records if warning.get("category") == "experimental_range"
-            ],
-            "aging_horizon_extrapolation_warnings": [
-                warning for warning in warning_records if warning.get("category") == "aging_horizon"
-            ],
-            "state_schema_version": BLAST_STATE_SCHEMA_VERSION,
-        }
+        degradation_summary = build_degradation_summary(
+            engine="blast",
+            model_key=str(blast_model),
+            model_profile=profile.as_dict(),
+            final_soh_pct=current_soh,
+            replacement_events=replacement_events,
+            warning_records=warning_records,
+            state_schema_version=BLAST_STATE_SCHEMA_VERSION,
+        )
     else:
-        degradation_summary = {
-            "engine": "native",
-            "model_key": cfg["calendar_model"],
-            "initial_soh_pct": 100.0,
-            "final_soh_pct": round(float(current_soh), 2),
-            "replacement_events": replacement_events,
-        }
+        degradation_summary = build_degradation_summary(
+            engine="native",
+            model_key=cfg["calendar_model"],
+            final_soh_pct=current_soh,
+            replacement_events=replacement_events,
+        )
 
     return SimulationArtifacts(
         yearly_df=yearly_df,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -695,6 +695,7 @@ class TestAppSimulateNoBattery:
         assert len({warning["code"] for warning in range_warnings}) == len(range_warnings)
         assert degradation["aging_horizon_extrapolation_warnings"] == []
         assert result["provenance"]["degradation"] == degradation
+        assert result["provenance"]["degradation"] is degradation
 
     def test_investment_positive(self):
         assert self.result["total_investment_eur"] > 0

--- a/tests/test_app_validation_correctness.py
+++ b/tests/test_app_validation_correctness.py
@@ -5,6 +5,7 @@ import math
 import pytest
 
 from breos.app import App
+from breos.app_config import merge_defaults, validate_config
 
 
 def _config(**overrides):
@@ -72,3 +73,51 @@ def test_ac_coupling_is_an_explicitly_unsupported_public_configuration():
         App(_config(dc_coupled=False))
     with pytest.raises(TypeError, match="dc_coupled"):
         App(_config(dc_coupled="true"))
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error_type", "message"),
+    [
+        (
+            {"location": {"latitude": 91, "longitude": 0, "timezone": "UTC"}},
+            ValueError,
+            "'location.latitude' must be between -90 and 90",
+        ),
+        ({"pv_arrays": [{"modules": 0}]}, ValueError, "'pv_arrays[0].modules' must be >= 1"),
+        (
+            {"inverter_efficiency": 0},
+            ValueError,
+            "'inverter_efficiency' must be between 0 (exclusive) and 1 (inclusive)",
+        ),
+        ({"resolution": "30min"}, ValueError, "'resolution' must be 'h' or '15min'"),
+        ({"discount_rate": -1}, ValueError, "'discount_rate' must be greater than -1"),
+        (
+            {"battery_min_soc": 0.9, "battery_max_soc": 0.2},
+            ValueError,
+            "'battery_min_soc' and 'battery_max_soc' must satisfy 0 <= min < max <= 1",
+        ),
+    ],
+)
+def test_validation_subsystems_preserve_public_error_contract(overrides, error_type, message):
+    """Characterize exact public errors at each validation subsystem boundary."""
+    cfg = merge_defaults(_config(**overrides))
+
+    with pytest.raises(error_type) as exc_info:
+        validate_config(cfg)
+
+    assert str(exc_info.value) == message
+
+
+def test_validation_preserves_blast_normalization_and_conflict_errors():
+    cfg = merge_defaults(_config(degradation_engine=" BLAST ", blast_model="lfp_gr_250ah_prismatic", battery_kwh=5.0))
+
+    validate_config(cfg)
+
+    assert cfg["degradation_engine"] == "blast"
+
+    invalid = merge_defaults(
+        _config(degradation_engine="blast", blast_model="lfp_gr_250ah_prismatic", battery_kwh=5.0, montecarlo={})
+    )
+    with pytest.raises(ValueError) as exc_info:
+        validate_config(invalid)
+    assert str(exc_info.value) == "'degradation_engine=blast' is not supported with Monte Carlo yet"

--- a/tests/test_blast_engine.py
+++ b/tests/test_blast_engine.py
@@ -213,6 +213,92 @@ def test_sourced_aging_horizon_warns_once_and_survives_snapshot():
     assert len([item for item in caught if item.category is BlastAgingHorizonWarning]) == 1
 
 
+def test_warning_records_have_stable_json_shape_and_order():
+    engine = BlastEngine("nmc811_grsi_lgmj1_4ah")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        engine.step(
+            np.array([0.0, 900.0, 1800.0]),
+            np.array([0.0, 1.0, 0.0]),
+            np.array([60.0, 60.0, 60.0]),
+        )
+
+    expected = [
+        {
+            "code": "experimental_range.temperature_c",
+            "message": (
+                "BLAST model 'nmc811_grsi_lgmj1_4ah' received temperature_c range "
+                "[60, 60] outside experimental range [0, 50]."
+            ),
+            "category": "experimental_range",
+            "field": "temperature_c",
+            "observed": [60.0, 60.0],
+            "supported": [0.0, 50.0],
+        },
+        {
+            "code": "experimental_range.soc",
+            "message": (
+                "BLAST model 'nmc811_grsi_lgmj1_4ah' received soc range [0, 1] outside experimental range [0.1, 0.9]."
+            ),
+            "category": "experimental_range",
+            "field": "soc",
+            "observed": [0.0, 1.0],
+            "supported": [0.1, 0.9],
+        },
+        {
+            "code": "experimental_range.dod",
+            "message": (
+                "BLAST model 'nmc811_grsi_lgmj1_4ah' received dod range [1, 1] outside experimental range [0.2, 0.8]."
+            ),
+            "category": "experimental_range",
+            "field": "dod",
+            "observed": [1.0, 1.0],
+            "supported": [0.2, 0.8],
+        },
+        {
+            "code": "experimental_range.c_rate_charge",
+            "message": (
+                "BLAST model 'nmc811_grsi_lgmj1_4ah' received c_rate_charge 4 C above experimental maximum 1 C."
+            ),
+            "category": "experimental_range",
+            "field": "c_rate_charge",
+            "observed": 4.0,
+            "supported": 1.0,
+        },
+        {
+            "code": "experimental_range.c_rate_discharge",
+            "message": (
+                "BLAST model 'nmc811_grsi_lgmj1_4ah' received c_rate_discharge 4 C above experimental maximum 3 C."
+            ),
+            "category": "experimental_range",
+            "field": "c_rate_discharge",
+            "observed": 4.0,
+            "supported": 3.0,
+        },
+    ]
+
+    assert json.dumps(engine.warning_records(), separators=(",", ":")) == json.dumps(
+        expected,
+        separators=(",", ":"),
+    )
+
+
+def test_reset_preserves_run_level_warning_history():
+    profile = (np.array([0.0, 86400.0]), np.array([0.5, 0.5]), np.array([55.0, 55.0]))
+    engine = BlastEngine("lfp_gr_250ah_prismatic")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        engine.step(*profile)
+        records_before_reset = engine.warning_records()
+        engine.reset()
+        engine.step(*profile)
+
+    assert engine.warning_records() == records_before_reset
+    assert len([item for item in caught if item.category is BlastExperimentalRangeWarning]) == 1
+
+
 def test_all_models_stay_finite_when_daily_stressors_soften():
     """Deep-cycling days followed by light low-SOC days must not NaN.
 

--- a/tests/test_degradation_results.py
+++ b/tests/test_degradation_results.py
@@ -1,0 +1,55 @@
+"""Tests for the public degradation-result schema builder."""
+
+from breos.degradation.results import build_degradation_summary
+
+
+def test_native_summary_preserves_legacy_schema_and_precision():
+    replacements = [{"year": 2, "count": 1}]
+
+    summary = build_degradation_summary(
+        engine="native",
+        model_key="naumann_lam_field_calibrated",
+        final_soh_pct=93.456,
+        replacement_events=replacements,
+    )
+
+    assert summary == {
+        "engine": "native",
+        "model_key": "naumann_lam_field_calibrated",
+        "initial_soh_pct": 100.0,
+        "final_soh_pct": 93.46,
+        "replacement_events": replacements,
+    }
+
+
+def test_blast_summary_preserves_schema_precision_and_warning_categories():
+    profile = {"key": "lfp_gr_250ah_prismatic", "upstream": {"commit": "abc"}}
+    warnings = [
+        {"category": "experimental_range", "code": "temperature"},
+        {"category": "aging_horizon", "code": "horizon"},
+        {"category": "other", "code": "ignored"},
+    ]
+
+    summary = build_degradation_summary(
+        engine="blast",
+        model_key="lfp_gr_250ah_prismatic",
+        model_profile=profile,
+        final_soh_pct=93.456,
+        replacement_events=[{"year": 3, "count": 2}],
+        warning_records=warnings,
+        state_schema_version="1.0",
+    )
+
+    assert summary == {
+        "engine": "blast",
+        "model_key": "lfp_gr_250ah_prismatic",
+        "model_profile": profile,
+        "initial_soh_pct": 100.0,
+        "final_soh_pct": 93.5,
+        "replacement_events": [{"year": 3, "count": 2}],
+        "calibration_basis": "cell-model",
+        "pack_calibrated": False,
+        "experimental_range_warnings": [warnings[0]],
+        "aging_horizon_extrapolation_warnings": [warnings[1]],
+        "state_schema_version": "1.0",
+    }

--- a/tests/test_degradation_validation.py
+++ b/tests/test_degradation_validation.py
@@ -1,0 +1,47 @@
+"""Focused tests for BLAST validity warning collection."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+from breos.degradation.validation import (
+    AGING_HORIZON_CATEGORY,
+    EXPERIMENTAL_RANGE_CATEGORY,
+    BlastExperimentalRangeWarning,
+    BlastWarningCollector,
+)
+
+
+def test_unsourced_aging_horizon_does_not_emit_or_record_warning():
+    collector = BlastWarningCollector("lfp_gr_250ah_prismatic")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        collector.check_aging_horizon(1_000_000.0)
+
+    assert caught == []
+    assert collector.records(AGING_HORIZON_CATEGORY) == []
+
+
+def test_restored_collector_deduplicates_and_returns_defensive_copies():
+    collector = BlastWarningCollector("lfp_gr_250ah_prismatic")
+    t_secs = np.array([0.0, 86400.0])
+    soc = np.array([0.5, 0.5])
+    temperature_c = np.array([55.0, 55.0])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        collector.check_experimental_range(t_secs, soc, temperature_c)
+        restored = BlastWarningCollector.from_snapshot(
+            "lfp_gr_250ah_prismatic",
+            collector.records(),
+        )
+        restored.check_experimental_range(t_secs, soc, temperature_c)
+
+    copied_records = restored.records(EXPERIMENTAL_RANGE_CATEGORY)
+    copied_records[0]["observed"][0] = -999.0
+
+    assert len([item for item in caught if item.category is BlastExperimentalRangeWarning]) == 1
+    assert restored.records(EXPERIMENTAL_RANGE_CATEGORY)[0]["observed"] == [55.0, 55.0]


### PR DESCRIPTION
## Summary

- extract BLAST experimental-range and aging-horizon warnings into a run-level collector
- centralize native and BLAST degradation-result construction in a schema-aware builder
- decompose App configuration validation into focused subsystem validators
- add characterization coverage for warning records, result/provenance identity, precision, validation errors, snapshots, and replacement resets

## Why

The 0.4.0 degradation integration left warning collection, public result construction, and configuration validation embedded in larger orchestration modules. These behavior-preserving boundaries make the code easier to maintain while keeping `breos.App`, dispatch behavior, degradation trajectories, snapshots, and public schemas stable.

## User impact

No intended behavior or API change. Native degradation remains the default, BLAST remains explicit opt-in, and existing configuration/result fields retain their current values and precision.

## Validation

- `uv run pytest -q` — 566 passed, 7 skipped, 2 deselected
- `uv run pytest -q -m slow` — 2 passed
- `uv run ruff check breos tests tools`
- `uv run ruff format --check breos tests tools`
- `uv run python tools/verify_release_artifacts.py`
- `uv run --extra docs sphinx-build -W -b html docs docs/_build/html`
