### PR TITLE
Improve 0.4.2 onboarding and repository health

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/Lisbon"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,14 +44,62 @@ jobs:
         run: uv run ruff format --check breos/ tests/ tools/
 
       - name: Run tests
+        if: matrix.python-version != '3.12'
         # Slow tests are deselected by default (pyproject addopts: -m "not slow").
         run: uv run pytest tests/ -v
+
+      - name: Run tests with core coverage
+        if: matrix.python-version == '3.12'
+        # Vendored BLAST-Lite is excluded by the coverage configuration.
+        run: uv run pytest tests/ -v --cov=breos --cov-report=term-missing --cov-report=xml
+
+      - name: Upload core coverage report
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-coverage-python-3.12
+          path: coverage.xml
+          if-no-files-found: error
 
       - name: Verify release artifacts
         run: uv run python tools/verify_release_artifacts.py
 
       - name: Build docs
-        run: uv run --extra docs sphinx-build -b html docs docs/_build/html
+        run: uv run --extra docs sphinx-build -W -b html docs docs/_build/html
+
+  platform-smoke:
+    # Keep non-Linux coverage focused on installation and public entrypoints;
+    # the complete version matrix remains on Linux above.
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    env:
+      UV_PYTHON: "3.12"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Smoke-test public entrypoints
+        run: >-
+          uv run pytest
+          tests/test_public_api.py
+          tests/test_cli_correctness.py
+          tests/test_release_smoke.py::test_readme_quickstart_smoke
+          -q
 
   slow-tests:
     # Long-running endurance tests on Python 3.12. Release pushes and PRs run

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 dist/
 build/
 .cache/
+.coverage
+coverage.xml
 *.egg
 .venv/
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Changed
+- Deferred optional plotting imports until a plotting compatibility attribute
+  is first accessed, keeping core imports and non-plotting CLI commands quiet
+  while preserving existing top-level names.
+- Improved first-run onboarding with a no-file/no-network dry run,
+  troubleshooting guidance, corrected discovery commands, and synchronized
+  support and release documentation.
+- Added grouped weekly dependency updates, core-package coverage reporting that
+  excludes vendored BLAST-Lite, and lightweight macOS/Windows public-entrypoint
+  smoke tests.
+
 ## [0.4.1] - 2026-07-23
 
 ### Changed
@@ -16,15 +27,6 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 - Decomposed `breos.App` configuration validation into focused subsystem
   validators while preserving validation order, public errors, normalization,
   defaults, and resolution precedence.
-- Deferred optional plotting imports until a plotting compatibility attribute
-  is first accessed, keeping core imports and non-plotting CLI commands quiet
-  while preserving existing top-level names.
-- Improved first-run onboarding with a no-file/no-network dry run,
-  troubleshooting guidance, corrected discovery commands, and synchronized
-  support and release documentation.
-- Added grouped weekly dependency updates, core-package coverage reporting that
-  excludes vendored BLAST-Lite, and lightweight macOS/Windows public-entrypoint
-  smoke tests.
 
 ## [0.4.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 - Decomposed `breos.App` configuration validation into focused subsystem
   validators while preserving validation order, public errors, normalization,
   defaults, and resolution precedence.
+- Deferred optional plotting imports until a plotting compatibility attribute
+  is first accessed, keeping core imports and non-plotting CLI commands quiet
+  while preserving existing top-level names.
+- Improved first-run onboarding with a no-file/no-network dry run,
+  troubleshooting guidance, corrected discovery commands, and synchronized
+  support and release documentation.
+- Added grouped weekly dependency updates, core-package coverage reporting that
+  excludes vendored BLAST-Lite, and lightweight macOS/Windows public-entrypoint
+  smoke tests.
 
 ## [0.4.0] - 2026-07-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd breos
 
 ```bash
 # With uv (recommended)
-uv sync --extra dev
+uv sync --extra dev --extra docs
 
 # With pip
 pip install -e ".[dev]"
@@ -39,9 +39,10 @@ For release-style validation, run the same gates used by CI:
 ```bash
 uv run ruff check breos/ tests/ tools/
 uv run ruff format --check breos/ tests/ tools/
-uv run pytest tests/ -v
+uv run pytest tests/ -v --cov=breos --cov-report=term-missing
+uv run pytest tests/ -m slow -v
 uv run python tools/verify_release_artifacts.py
-uv run --extra docs sphinx-build -b html docs docs/_build/html
+uv run --extra docs sphinx-build -W -b html docs docs/_build/html
 ```
 
 ## Branching
@@ -84,8 +85,10 @@ uv run pytest tests/test_app.py -v
 
 - PRs should target `develop`, not `main`
 - Include a brief description of what changed and why
-- Make sure CI passes. It runs lint, format checks, tests, release artifact
-  verification, and the Sphinx docs build on every PR to `develop` or `main`.
+- Make sure CI passes. It runs lint, format checks, tests and core-package
+  coverage, release artifact verification, the Sphinx docs build, and
+  lightweight macOS/Windows public-entrypoint checks on every PR to `develop`
+  or `main`.
 - Keep PRs focused — one feature or fix per PR
 
 ## Reporting Issues

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ uv add breos          # as a project dependency
 uvx breos --version   # run the CLI without installing
 ```
 
+Verify the installation and inspect a complete resolved configuration without
+creating a file, fetching weather, or running a simulation:
+
+```bash
+breos run --location porto --n-modules 10 \
+  --annual-consumption-kwh 4000 --dry-run
+```
+
 The default install is a lean core. Some workflows need optional extras (e.g.
 optimization, historical weather, plots):
 
@@ -125,7 +133,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Feature work happens on branches off
 
 ## Contact
 
-For questions, collaboration, or access to additional modules: lrodrigues@fe.up.pt.
+For questions, research collaboration, or support: lrodrigues@fe.up.pt.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,12 @@ are intentions, not commitments — see GitHub issues for active work.
 Recorded 2026-07 after the 0.4.0 release. Like everything here these are
 intentions, not commitments; reassess after each release.
 
-- **0.4.1 / 0.4.2** — maintainability refactors only, following a separate
-  working refactor plan for selected BREOS functions. No feature or behavior
-  changes.
+- **0.4.1** — behavior-preserving degradation and configuration refactors
+  (warning collection, public degradation results, and validation boundaries).
+- **0.4.2** — remaining behavior-preserving maintainability work plus onboarding
+  hygiene: lazy optional imports, a quiet no-network installation check,
+  first-run troubleshooting, dependency/coverage automation, and lightweight
+  portability evidence. No scientific-model, dispatch, or result changes.
 - **0.5.0** — bifacial rear-gain is the firm scope (activation key, explicit
   rear-gain loss-waterfall stage, benchmark rows). Independently complete
   PV-fidelity items (the pvsyst real-efficiency fix, additional IAM and
@@ -94,7 +97,7 @@ documentation live in one place.
   deliberately scheduled *before* the 0.6.0 TOU/currency work adds another
   cluster of config keys, and deserves its own release slot rather than
   riding along a feature release.
-- **Coordination with the function-level refactor plan:** earlier internal
+- **Coordination with the [function-level refactor plan](docs/architecture/0.4x-refactor-plan.md):** earlier internal
   validation cleanup should create reusable boundaries for the full schema,
   not throwaway helpers that need another rewrite in 0.5.x.
 - **The hard part is error-message parity**, not the schema itself: the
@@ -144,10 +147,35 @@ Ongoing docs hygiene:
   `pv_loss_overrides`.
 - Keep the representative quickstart output excerpt in the docs close to what
   current dependency versions actually produce.
+- Keep security support tables, release-matrix headings, example commands, and
+  version-specific limitation text aligned with the latest release.
+
+Immediate 0.4.2 onboarding work:
+
+- Put a no-file, no-network `breos run ... --dry-run` installation check next
+  to the install command.
+- Keep optional plotting imports lazy so core imports, `--help`, option
+  discovery, and configuration validation do not initialize Matplotlib.
+- Maintain a short first-run troubleshooting page covering weather/network
+  failures, preset discovery, optional extras, cache behavior, and expected
+  runtimes.
+- Maintain weekly grouped dependency updates, core-package coverage that does
+  not treat vendored BLAST as ordinary application code, and lightweight
+  macOS/Windows public-API smoke checks.
 
 Option discovery work:
 
 - Add matching Python helpers where useful, building on `list_modules()`.
+- Curate small `good first issue` tasks around docs, examples, and tooling so
+  the contribution guide leads to approachable work.
+
+Future additive onboarding work:
+
+- Consider a deterministic offline `breos demo` command using clearly labeled
+  synthetic inputs. Because this adds a public CLI surface, schedule it for a
+  feature release (0.5.x) rather than forcing it into a 0.4.x patch.
+- Consider a compact human-readable completion summary while retaining the
+  full JSON result as the machine-readable output contract.
 
 Agent and contributor setup:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ release before reporting an issue.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.x   | :white_check_mark: |
-| < 0.2   | :x:                |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
 
 ## Reporting a vulnerability
 

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -27,6 +27,7 @@ Usage:
 # the version declared in pyproject.toml (the single source of truth). This is
 # the same mechanism used by breos/cli.py and docs/conf.py, which keeps the
 # literal from drifting out of sync with the distribution version on a release.
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version
 
@@ -226,59 +227,72 @@ from breos.weather import (
     select_random_year_and_replace_datetime,
 )
 
-# Plotting (try to import, skip if matplotlib not installed)
-try:
-    from breos.plotting import (
-        create_cost_plots,
-        degradation_plots,
-        monthly_graphs,
-        plot_azitilt_ew_1d,
-        plot_azitilt_landscape_2d,
-        plot_azitilt_landscape_3d,
-        plot_battery_soh_timeseries,
-        plot_breakeven,
-        plot_breakeven_comparison,
-        plot_breakeven_two,
-        # Sensitivity analysis
-        plot_calendar_aging_sensitivity,
-        plot_cell_temperature,
-        # CO2 savings
-        plot_co2_savings,
-        # Polysun vs BREOS comparison
-        plot_degradation_methodology_comparison,
-        # Batch comparison
-        plot_grid_independence_heatmap,
-        plot_lifetime_prediction_comparison,
-        plot_location_comparison_delta,
-        plot_loo_cv_summary,
-        plot_loo_param_stability,
-        plot_loo_predictions,
-        # Monte Carlo distributions
-        plot_montecarlo_final_soh_distribution,
-        plot_montecarlo_grid_independence_distribution,
-        plot_montecarlo_npv_distribution,
-        plot_montecarlo_simulation,
-        plot_monthly_balance,
-        plot_monthly_comparison,
-        plot_pareto_front_analysis,
-        plot_pv_loss_waterfall,
-        plot_resistance_and_efficiency,
-        plot_temperature_sensitivity_comparison,
-        plot_tilt_optimization,
-        plot_timeseries,
-        plot_validation_degradation_split,
-        plot_validation_multi_system,
-        plot_validation_parity,
-        plot_validation_residuals,
-        plot_validation_soh_comparison,
-        plot_weather_annual_ghi_distribution,
-        plot_weather_monthly_comparison,
-        set_presentation_mode,
-        weekly_graphs,
-        yearly_graphs,
-    )
-except ImportError:
-    pass  # matplotlib not installed
+# Plotting functions historically remain available as top-level attributes, but
+# importing core BREOS or invoking a non-plotting CLI command must not initialize
+# Matplotlib. PEP 562 module attribute hooks preserve those compatibility names
+# while deferring the optional plotting stack until a caller actually uses it.
+_LAZY_PLOTTING_EXPORTS = frozenset(
+    {
+        "create_cost_plots",
+        "degradation_plots",
+        "monthly_graphs",
+        "plot_azitilt_ew_1d",
+        "plot_azitilt_landscape_2d",
+        "plot_azitilt_landscape_3d",
+        "plot_battery_soh_timeseries",
+        "plot_breakeven",
+        "plot_breakeven_comparison",
+        "plot_breakeven_two",
+        "plot_calendar_aging_sensitivity",
+        "plot_cell_temperature",
+        "plot_co2_savings",
+        "plot_degradation_methodology_comparison",
+        "plot_grid_independence_heatmap",
+        "plot_lifetime_prediction_comparison",
+        "plot_location_comparison_delta",
+        "plot_loo_cv_summary",
+        "plot_loo_param_stability",
+        "plot_loo_predictions",
+        "plot_montecarlo_final_soh_distribution",
+        "plot_montecarlo_grid_independence_distribution",
+        "plot_montecarlo_npv_distribution",
+        "plot_montecarlo_simulation",
+        "plot_monthly_balance",
+        "plot_monthly_comparison",
+        "plot_pareto_front_analysis",
+        "plot_pv_loss_waterfall",
+        "plot_resistance_and_efficiency",
+        "plot_temperature_sensitivity_comparison",
+        "plot_tilt_optimization",
+        "plot_timeseries",
+        "plot_validation_degradation_split",
+        "plot_validation_multi_system",
+        "plot_validation_parity",
+        "plot_validation_residuals",
+        "plot_validation_soh_comparison",
+        "plot_weather_annual_ghi_distribution",
+        "plot_weather_monthly_comparison",
+        "set_presentation_mode",
+        "weekly_graphs",
+        "yearly_graphs",
+    }
+)
+
+
+def __getattr__(name: str):
+    """Resolve compatibility plotting attributes without eager imports."""
+
+    if name not in _LAZY_PLOTTING_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module("breos.plotting"), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include lazy compatibility attributes in interactive discovery."""
+
+    return sorted(set(globals()) | _LAZY_PLOTTING_EXPORTS)
 
 
 # Numba kernels (lazy import to avoid slow import at package load)

--- a/configs/README.md
+++ b/configs/README.md
@@ -53,7 +53,11 @@ The catalogue keys used in a config (`location`, `pv_module`, `cost_preset`,
 valid values with:
 
 ```bash
-breos list locations | modules | cost-presets | emissions | load-profiles
+breos list locations
+breos list modules
+breos list cost-presets
+breos list emissions
+breos list load-profiles
 ```
 
 ## Example configs
@@ -84,7 +88,7 @@ any example and edit it for your own scenario.
   recognised table for `breos run` is `[[pv_arrays]]`. The `[sweep]` and
   `[montecarlo]` tables are read by their dedicated CLI commands.
 - Configs written for the research `pvbat` engine — with nested model sections,
-  inheritance, or simulation-type blocks — are **not** compatible: BREOS
-  silently ignores keys it does not recognise, so those sections would be dropped
-  and defaults used instead. Translate the values you need into the flat keys
-  shown in `pv-plus-battery.toml` (and `[montecarlo]` for MC studies).
+  inheritance, or simulation-type blocks — are **not** compatible. BREOS
+  rejects unknown top-level keys rather than silently applying defaults.
+  Translate the values you need into the flat keys shown in
+  `pv-plus-battery.toml` (and `[montecarlo]` for MC studies).

--- a/docs/architecture/0.4x-refactor-plan.md
+++ b/docs/architecture/0.4x-refactor-plan.md
@@ -1,0 +1,319 @@
+# BREOS 0.4.x Refactor and Onboarding Plan
+
+## Purpose
+
+This plan covers maintainability work to begin after the 0.4.0 feature stack is
+merged and stable. Refactors should preserve public behavior, especially the
+`breos.App` facade, the corrected 0.3.4 energy ledger, BLAST parity, and
+serialized continuation semantics.
+
+The work is deliberately split into small PRs. Do not combine these refactors
+with new scientific models, dispatch behavior, or release-default changes.
+
+## Invariants for every PR
+
+- Native Naumann/Lam remains the default degradation engine.
+- BLAST remains explicit opt-in and never silently falls back to native.
+- Existing `breos.App` configuration and result fields remain compatible.
+- The 0.3.4 energy ledger and cross-year stored-energy/PV-origin continuity
+  remain unchanged.
+- Shared inverter headroom, battery power limits, replacement energy, and
+  replacement accounting remain unchanged.
+- BLAST parameters and trajectories continue to match the pinned upstream
+  parity fixtures.
+- Snapshot JSON round trips and split-versus-continuous simulations remain
+  equivalent.
+- Experimental-range and aging-horizon warnings remain deduplicated across
+  continuation snapshots.
+- No resistance-to-efficiency or resistance-to-power coupling is introduced.
+- No generic chemistry or pack-calibration defaults are invented.
+
+Before each PR, run the focused tests for the affected subsystem. Before
+handoff, run:
+
+```bash
+uv run pytest -q
+uv run ruff check breos tests tools
+uv run ruff format --check breos tests tools
+uv run python tools/verify_release_artifacts.py
+uv run --extra docs sphinx-build -W -b html docs docs/_build/html
+```
+
+## Phase R1 — Extract BLAST validity checking
+
+### Objective
+
+Move experimental-range and aging-horizon evaluation out of `BlastEngine` into
+a focused internal validator and warning collector. Keep warning records and
+public result output identical.
+
+### Proposed shape
+
+- Add a module such as `breos/degradation/validation.py`.
+- Define stable warning categories and codes in one place.
+- Give the collector responsibility for range checks, horizon checks,
+  deduplication, JSON-safe records, and snapshot restore.
+- Keep `BlastEngine` responsible for input normalization, model stepping,
+  reset, SOH access, and scientific-state serialization.
+- Preserve warning history when a battery replacement resets the BLAST model.
+
+### Acceptance criteria
+
+- Existing warning records are byte-for-byte equivalent after JSON encoding,
+  unless a schema change is intentionally documented.
+- A restored snapshot does not emit an already-recorded warning.
+- Replacement resets model state without discarding run-level warnings.
+- Profiles without a sourced numeric horizon do not receive an invented one.
+- Focused warning, snapshot, runner-continuation, and public-result tests pass.
+
+### Suggested PR
+
+`refactor/0.4.1-degradation-validation`
+
+Risk: low to moderate.
+
+## Phase R2 — Centralize public degradation results
+
+### Objective
+
+Extract native and BLAST degradation-result construction from the app runner
+into a single schema-aware builder.
+
+### Proposed shape
+
+- Add an internal result builder, preferably under `breos/degradation/`.
+- Accept resolved engine identity, profile/provenance, SOH, replacement events,
+  warnings, and state-schema version as explicit inputs.
+- Keep native and BLAST precision policies explicit and tested.
+- Use the same constructed degradation block for results and provenance.
+
+### Acceptance criteria
+
+- Public result dictionaries remain unchanged.
+- BLAST results still report model identity, profile provenance, initial/final
+  SOH, replacements, calibration basis, warnings, and state schema.
+- Native result output remains backwards compatible.
+- Result and provenance blocks cannot diverge.
+
+### Suggested PR
+
+`refactor/0.4.1-degradation-results`
+
+Risk: low.
+
+## Phase R3 — Decompose configuration validation
+
+### Objective
+
+Split `app_config.py` validation into focused subsystem functions without
+changing public keys, resolution precedence, defaults, or exception behavior.
+
+### Proposed shape
+
+- Separate battery/degradation, PV/inverter, time/weather, and economics
+  validation functions.
+- Keep final resolution orchestration and the resolved configuration object in
+  the current public path.
+- Preserve precedence: user configuration, then sourced model-profile defaults,
+  then global defaults.
+- Keep the explicit migration error for legacy `battery_type`.
+
+### Acceptance criteria
+
+- Existing valid configurations resolve identically.
+- Existing invalid configurations raise the same exception type with equally
+  actionable messages.
+- CLI overrides and resolved-configuration output remain identical.
+- BLAST plus Monte Carlo and BLAST plus native resistance fade remain explicit
+  errors.
+
+### Suggested PR
+
+`refactor/0.4.1-config-validation`
+
+Risk: low to moderate.
+
+## Phase R4 — Add a narrow internal degradation protocol
+
+### Objective
+
+Replace scattered engine-specific branches with a small internal contract for
+degradation lifecycle operations. Do not expose a general third-party adapter
+API in 0.4.x.
+
+### Candidate operations
+
+```python
+step(...)
+soh()
+reset()
+snapshot()
+warnings()
+provenance()
+```
+
+Restoration may be a class method or factory rather than part of the instance
+protocol.
+
+### Proposed shape
+
+- Define a typing `Protocol` or small abstract internal interface.
+- Implement adapters for native state handling and BLAST.
+- Introduce the abstraction at the degradation boundary only.
+- Avoid changing the energy-dispatch API or `breos.App` facade.
+
+### Acceptance criteria
+
+- Native and BLAST paths pass the same lifecycle contract tests.
+- The runner no longer needs repeated BLAST-specific state/provenance branches.
+- Native 0.3.4 regression outputs remain exact.
+- All 14 BLAST parity and snapshot-continuation tests remain unchanged.
+
+### Suggested PR
+
+`refactor/0.4.2-degradation-protocol`
+
+Risk: moderate.
+
+## Phase R5 — Formalize snapshot codecs
+
+### Objective
+
+Introduce typed internal snapshot state and explicit encoding/decoding while
+retaining JSON dictionaries as the serialized public representation.
+
+### Proposed shape
+
+- Define typed state containers for engine state, daily boundary anchors,
+  inventory continuity, and warning history.
+- Add explicit `to_dict()` and `from_dict()` codecs.
+- Validate required fields and model identity at restoration.
+- Add migration hooks before changing the public schema version.
+- Continue accepting current schema `1.0` snapshots.
+
+### Acceptance criteria
+
+- Current snapshots round-trip through JSON without numerical drift.
+- Unknown future schema versions fail with an actionable error.
+- Missing optional fields from older compatible snapshots receive documented
+  defaults.
+- Split-versus-continuous simulations remain equivalent for all 14 models.
+
+### Suggested PR
+
+`refactor/0.4.2-snapshot-codec`
+
+Risk: moderate.
+
+## Phase R6 — Extract a degradation session from the energy loop
+
+### Objective
+
+Move day buffering, degradation updates, replacement resets, warning
+accumulation, and final degradation-state construction out of
+`simulate_energy_balance()` into a dedicated internal session object.
+
+This phase should start only after R1–R5 are merged and the 0.4.x regression
+suite has been stable across at least one patch release.
+
+### Proposed responsibilities
+
+- Own start-of-day SOC and temperature anchors.
+- Buffer daily endpoint samples.
+- Update the selected degradation engine at daily boundaries.
+- Coordinate replacement resets with battery inventory resets.
+- Track SOH, FEC, calendar time, and resistance output provenance.
+- Produce final continuation state and warnings.
+
+The energy loop must retain authority over physical dispatch, energy inventory,
+and ledger fields.
+
+### Acceptance criteria
+
+- No dispatch or ledger equations move into the degradation session.
+- Replacement timing and replacement-added energy remain exact.
+- Cross-year energy, PV-origin, and degradation continuity remain exact.
+- Hourly, 15-minute, leap-year, replacement, inverter, and power-limit tests
+  pass without tolerance relaxation.
+
+### Suggested PR
+
+`refactor/0.4.3-degradation-session`
+
+Risk: moderate to high.
+
+## Phase R7 — Make parity-fixture generation reproducible
+
+### Objective
+
+Turn BLAST parity-fixture generation into a maintained, reviewable process
+without regenerating scientific fixtures during ordinary CI.
+
+### Proposed shape
+
+- Add a documented generator or wrapper under `tools/`.
+- Require an explicit path to a clean BLAST-Lite checkout at the pinned commit.
+- Record source commit, Python version, NumPy version, fixture schema, profile
+  definitions, and generation command.
+- Refuse generation from an unexpected upstream commit unless explicitly
+  overridden for an upstream-update PR.
+- Keep generated fixtures committed and reviewed as scientific artifacts.
+
+### Acceptance criteria
+
+- Regeneration at the current pin reproduces the committed fixture.
+- Ordinary tests consume fixtures without requiring the BLAST repository.
+- Updating the upstream pin produces a clear, reviewable fixture diff.
+
+### Suggested PR
+
+`refactor/0.4.2-blast-parity-tooling`
+
+Risk: low; scientific fixture diffs require careful review.
+
+## Explicitly out of scope for this refactor plan
+
+- Changing the native or BLAST default engine.
+- BLAST resistance affecting efficiency or power limits.
+- Pack-level calibration without suitable data.
+- Generic chemistry defaults.
+- Monte Carlo BLAST implementation, except internal groundwork that preserves
+  the current explicit rejection.
+- The broad third-party adapter refactor from issue #11.
+- Bifacial modeling, TOU dispatch, horizon profiles, or string/MPPT modeling.
+- Rewriting the corrected dispatch ledger or inverter allocation solely for
+  architectural symmetry.
+
+## Recommended execution order
+
+Completed for 0.4.1:
+
+1. R1 — validity checking
+2. R2 — public degradation results
+3. R3 — configuration validation
+
+Completed for 0.4.2:
+
+1. U1 — onboarding hygiene: correct documentation drift, document a
+   no-network dry run and first-run troubleshooting, and lazy-load plotting
+   compatibility exports. Behavior preserving; suitable for 0.4.2.
+2. Repository-health automation — grouped dependency updates, core coverage
+   reporting, and lightweight cross-platform smoke tests.
+
+Planned after the onboarding boundary has settled:
+
+1. R7 — parity tooling (independent after R1)
+2. R4 — internal degradation protocol
+3. R5 — snapshot codecs
+4. R6 — degradation session
+
+Newcomer-friendly issue curation can proceed independently when each change
+remains small. A deterministic offline `breos demo` command is additive public
+CLI work and belongs in 0.5.x rather than this behavior-preserving refactor
+series.
+
+R1–R3 shipped to `develop` as the 0.4.1 refactor set. U1 and repository-health
+automation form the onboarding slice for 0.4.2; R4, R5, and R7 also fit 0.4.2
+when kept in focused PRs. R6 should wait for 0.4.3 or later. Reassess the plan
+after each phase rather than assuming later interfaces before earlier refactors
+have settled.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -60,7 +60,7 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `battery_rte` | `None` | Battery round-trip efficiency (`None` = 0.95), split evenly across charge/discharge |
 | `battery_max_charge_power_w` | `None` | Maximum DC power entering the battery charge path; `None` is unlimited |
 | `battery_max_discharge_power_w` | `None` | Maximum battery AC power delivered to load; `None` is unlimited |
-| `dc_coupled` | `True` | DC-coupled / hybrid inverter. `False` is unsupported in 0.3.x and raises |
+| `dc_coupled` | `True` | DC-coupled / hybrid inverter. `False` is currently unsupported and raises |
 | `inverter_efficiency` | `0.96` | Nominal inverter efficiency used by the PVWatts part-load curve |
 | `inverter_loading_ratio` | `1.25` | DC/AC oversizing ratio; also sets the inverter AC rating that clips production |
 | `pv_loss_overrides` | `None` | Per-component overrides (percent) for the fixed PVWatts system losses, e.g. `{"shading": 0.0}` |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -8,6 +8,7 @@ what the result dict contains.
 
 installation
 quickstart
+troubleshooting
 inputs
 recipes
 configuration

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -74,7 +74,14 @@ uv sync --extra dev --extra docs     # development plus documentation
 
 ## Verifying the install
 
-```python
-import breos
-print(breos.__version__)
+Check the installed version, then resolve a complete configuration without
+creating a file, fetching weather, or running a simulation:
+
+```bash
+breos --version
+breos run --location porto --n-modules 10 \
+  --annual-consumption-kwh 4000 --dry-run
 ```
+
+See [Troubleshooting](troubleshooting.md) if the command fails or a later
+weather-backed simulation cannot reach its data source.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,6 +8,20 @@ result dict.
 The example uses packaged defaults and public weather access. For real
 projects, review [Required Inputs](inputs.md) before interpreting results.
 
+## Verify the installation without network access
+
+Before creating a config file, run a complete configuration dry run:
+
+```bash
+breos run --location porto --n-modules 10 \
+  --annual-consumption-kwh 4000 --dry-run
+```
+
+This validates the installation and prints the resolved location, PV sizing,
+inverter, load, battery, economics, emissions, and loss assumptions. It does
+not fetch weather or start a simulation. If it fails, see
+[Troubleshooting](troubleshooting.md).
+
 ## A 10-minute first run
 
 Create a small `quickstart.toml` config:
@@ -161,5 +175,7 @@ The CLI writes the same JSON-serializable dict that `App.result()` returns.
 - See [Configuration](configuration.md) for every option `App` accepts.
 - See [Interpreting results](interpreting-results.md) for what each result
   key means.
+- See [Troubleshooting](troubleshooting.md) for weather access, preset,
+  optional-dependency, cache, and runtime problems.
 - See the [API reference](../api/index.md) for the lower-level functions
   the `App` calls under the hood.

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -1,0 +1,93 @@
+# Troubleshooting
+
+Start with a configuration dry run. It needs no config file, weather download,
+or simulation:
+
+```bash
+breos run --location porto --n-modules 10 \
+  --annual-consumption-kwh 4000 --dry-run
+```
+
+If this succeeds, BREOS is installed and its packaged presets are readable.
+
+## A config key or preset is rejected
+
+BREOS rejects unknown top-level keys instead of silently applying a default.
+Check packaged option names with:
+
+```bash
+breos list locations
+breos list modules
+breos list cost-presets
+breos list emissions
+breos list load-profiles
+breos list battery-models
+```
+
+Use `breos validate-config config.toml` to see a concise resolved summary, or
+`breos run --config config.toml --dry-run` for the complete JSON form. Config
+files are flat TOML or JSON mappings except for supported `[[pv_arrays]]`,
+`[sweep]`, and `[montecarlo]` sections.
+
+## Weather download fails
+
+The quickstart simulation loads a matching file from the current working
+directory's `weather/` folder when available; otherwise it fetches PVGIS TMY
+weather. Check internet access and retry before changing model settings.
+
+For repeatable or offline work, seed the weather cache as shown in
+[Offline runs with cached weather](recipes.md#offline-runs-with-cached-weather).
+NSRDB access requires an NREL API key. Custom coordinate-dict locations do not
+use a preset cache key and therefore fetch weather when used through `App`.
+
+## An optional command cannot import a dependency
+
+The base package contains the simulation core. Install only the extras needed
+by the workflow:
+
+```bash
+pip install "breos[plots]"          # Matplotlib plotting helpers
+pip install "breos[optimization]"   # pymoo optimization
+pip install "breos[weather]"        # Open-Meteo historical weather
+pip install "breos[fast]"           # Numba acceleration
+pip install "breos[validation]"     # Excel and Arrow validation tools
+```
+
+Core imports, help, option discovery, and configuration validation do not load
+Matplotlib. If an actual plotting command reports that its configuration
+directory is not writable, point Matplotlib at a writable cache location:
+
+```bash
+export MPLCONFIGDIR="/tmp/matplotlib-cache"
+```
+
+## A run takes longer than expected
+
+The first run may spend time downloading weather. Hourly simulations are the
+fastest normal path; 15-minute simulations process four times as many steps.
+Long projection horizons, Monte Carlo runs, parameter sweeps, and optimizers
+repeat the core simulation and can take substantially longer.
+
+Validate with `--dry-run` first. For an initial real run, use hourly resolution,
+a one-year projection, and no sweep or Monte Carlo section, then restore the
+study settings after the basic workflow succeeds.
+
+## Results look surprising
+
+Inspect the dry-run output before interpreting the result. It shows the chosen
+module, array geometry, inverter rating, battery SOC window, loss assumptions,
+cost preset, and emissions preset. Packaged values make examples runnable; they
+are not substitutes for project-specific weather, demand, equipment, tariff,
+and emissions inputs.
+
+Typical Meteorological Year weather is representative rather than a forecast
+for a particular year. See [Required Inputs](inputs.md) and
+[Interpreting results](interpreting-results.md) for the assumptions and output
+definitions that most often explain unexpected values.
+
+## Reporting a reproducible problem
+
+Include the BREOS version (`breos --version`), Python version, operating system,
+the smallest config that reproduces the problem, the complete error, and whether
+the no-network dry run succeeds. Do not include private API keys or licensed
+load-profile data in a public issue.

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,7 @@ api/index
 resources
 release
 architecture/third-party-wrapping
+architecture/0.4x-refactor-plan
 architecture/string-inverter-sizing
 architecture/battery-degradation-policy
 architecture/blast-degradation-engine

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,7 +32,7 @@ uv run ruff check breos/ tests/ tools/
 uv run ruff format --check breos/ tests/ tools/
 uv run pytest tests/ -v
 uv run python tools/verify_release_artifacts.py
-uv run --extra docs sphinx-build -b html docs docs/_build/html
+uv run --extra docs sphinx-build -W -b html docs docs/_build/html
 ```
 
 The release artifact verifier must build both wheel and sdist, confirm packaged
@@ -41,10 +41,13 @@ BREOS from the installed wheel instead of the source checkout. It also imports
 all 14 vendored BLAST models and verifies the installed BLAST license, DOE
 notice, and pinned upstream provenance.
 
-## 0.4.0 Validation Matrix
+## 0.4.x Validation Matrix
 
 The `Tests` workflow runs the complete matrix on Python 3.11, 3.12, 3.13, and
-3.14. The following release claims must remain tied to executable checks:
+3.14. Python 3.12 also reports branch-aware core-package coverage, excluding
+the vendored BLAST-Lite implementation, while macOS and Windows run a focused
+public-entrypoint smoke suite. The following release claims must remain tied to
+executable checks:
 
 | Gate | Executable coverage |
 | --- | --- |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
 Homepage = "https://github.com/Str4vinci/breos"
 Documentation = "https://breos.readthedocs.io/"
 Repository = "https://github.com/Str4vinci/breos"
+Issues = "https://github.com/Str4vinci/breos/issues"
+Changelog = "https://github.com/Str4vinci/breos/blob/main/CHANGELOG.md"
 
 [project.scripts]
 breos = "breos.cli:main"
@@ -54,6 +56,7 @@ location-tools = [
 ]
 dev = [
     "pytest>=8.0",
+    "pytest-cov>=7.0",
     "ruff>=0.15",
     "matplotlib>=3.10.8",
     "numba>=0.63.1",
@@ -83,6 +86,15 @@ addopts = ["-m", "not slow"]
 markers = [
     "slow: long-running endurance and multi-year integration tests; deselected by default, run with -m slow",
 ]
+
+[tool.coverage.run]
+branch = true
+source = ["breos"]
+omit = ["breos/degradation/blast/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -56,7 +56,7 @@ def test_existing_top_level_attributes_remain_importable():
 def test_top_level_plotting_compatibility_is_lazy(tmp_path):
     """Core imports stay quiet while historical plotting attributes still work."""
 
-    code = """
+    core_import_code = """
 import sys
 
 import breos
@@ -64,14 +64,22 @@ import breos
 assert "breos.plotting" not in sys.modules
 assert "matplotlib" not in sys.modules
 assert "plot_co2_savings" in dir(breos)
+"""
+    plotting_import_code = """
+import sys
+
+import breos
+
+assert "breos.plotting" not in sys.modules
+assert "matplotlib" not in sys.modules
 assert callable(breos.plot_co2_savings)
 assert "breos.plotting" in sys.modules
 assert "matplotlib" in sys.modules
 """
     env = os.environ.copy()
     env["MPLCONFIGDIR"] = str(tmp_path)
-    completed = subprocess.run(
-        [sys.executable, "-c", code],
+    core_import = subprocess.run(
+        [sys.executable, "-c", core_import_code],
         cwd=tmp_path,
         env=env,
         text=True,
@@ -79,5 +87,18 @@ assert "matplotlib" in sys.modules
         check=False,
     )
 
-    assert completed.returncode == 0, completed.stderr
-    assert completed.stderr == ""
+    assert core_import.returncode == 0, core_import.stderr
+    assert core_import.stderr == ""
+
+    plotting_import = subprocess.run(
+        [sys.executable, "-c", plotting_import_code],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    # A fresh Matplotlib installation may announce font-cache creation on
+    # stderr. The quiet-import contract applies before plotting is requested.
+    assert plotting_import.returncode == 0, plotting_import.stderr

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,5 +1,9 @@
 """Tests for the documented top-level BREOS API surface."""
 
+import os
+import subprocess
+import sys
+
 import breos
 
 
@@ -47,3 +51,33 @@ def test_existing_top_level_attributes_remain_importable():
     assert breos.R_GAS > 0
     assert callable(breos.build_battery_temperature_series)
     assert callable(breos.compute_dod_histogram)
+
+
+def test_top_level_plotting_compatibility_is_lazy(tmp_path):
+    """Core imports stay quiet while historical plotting attributes still work."""
+
+    code = """
+import sys
+
+import breos
+
+assert "breos.plotting" not in sys.modules
+assert "matplotlib" not in sys.modules
+assert "plot_co2_savings" in dir(breos)
+assert callable(breos.plot_co2_savings)
+assert "breos.plotting" in sys.modules
+assert "matplotlib" in sys.modules
+"""
+    env = os.environ.copy()
+    env["MPLCONFIGDIR"] = str(tmp_path)
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stderr == ""

--- a/uv.lock
+++ b/uv.lock
@@ -120,6 +120,7 @@ dev = [
     { name = "pyarrow" },
     { name = "pymoo" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "requests-cache" },
     { name = "ruff" },
     { name = "timezonefinder" },
@@ -178,6 +179,7 @@ requires-dist = [
     { name = "pymoo", marker = "extra == 'dev'", specifier = ">=0.6.1.6" },
     { name = "pymoo", marker = "extra == 'optimization'", specifier = ">=0.6.1.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "rainflow", specifier = ">=3.2.0" },
     { name = "requests-cache", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "requests-cache", marker = "extra == 'weather'", specifier = ">=1.2.1" },
@@ -475,6 +477,95 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", size = 302202, upload-time = "2025-07-26T12:02:55.947Z" },
     { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207, upload-time = "2025-07-26T12:02:57.468Z" },
     { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315, upload-time = "2025-07-26T12:02:58.801Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d3/13ac97b4370640ba3452fc8559b06cc2f479ce3ba4a0b632a73e44c38a7d/coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee", size = 254243, upload-time = "2026-07-15T18:53:57.055Z" },
+    { url = "https://files.pythonhosted.org/packages/88/83/5eca144942d8d0659d3f55176517f4a59cdc65eefd17146a0770935a3ebd/coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0", size = 256352, upload-time = "2026-07-15T18:53:58.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ba/d3db2e01a50fc88cdb4c0f19542bcf6f61489e34dc9aa3538413e2459a38/coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487", size = 258313, upload-time = "2026-07-15T18:54:00.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b3/aba83416e9177df28e5186d856c19158c59fc0e7e814aaa61a4a2354ad1b/coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f", size = 252449, upload-time = "2026-07-15T18:54:02.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a5/4b00ecac0194431ab451b0f6710f8e2517d04cef60f821b14dec4637d575/coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1", size = 254043, upload-time = "2026-07-15T18:54:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b6/cfa209b4313ee7f1b34da47efcd789ea51c024ad35af390e00f5a3c10a2e/coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5", size = 252107, upload-time = "2026-07-15T18:54:06.745Z" },
+    { url = "https://files.pythonhosted.org/packages/36/67/e8cac5a6954038c98d7fe7eb9802afe7ab3ecb637bb7cc00e69b4148b56d/coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0", size = 255873, upload-time = "2026-07-15T18:54:08.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/92/395cca9f330a86c3fe3471d73e2c102116c4c58fdc619dbbc125c6e93a54/coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad", size = 251826, upload-time = "2026-07-15T18:54:10.083Z" },
+    { url = "https://files.pythonhosted.org/packages/51/60/3e91b20295439652424f426b7086ec5bf4fbe3f604c73eda22b986c4fd6b/coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db", size = 252735, upload-time = "2026-07-15T18:54:11.878Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/8c07839005e5e3c6b3877d3a6e2a80ce766589f31dd2b6882b78d59a7b8c/coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9", size = 223500, upload-time = "2026-07-15T18:54:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/98/59d83c257cd59f0fbaf9d9ddb26b744a576760dfd1ae16e516408894a02b/coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688", size = 223973, upload-time = "2026-07-15T18:54:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/2d285c8bef5c4f695d120c1c96dc11715638aa8e134069f210bb6a62a9fe/coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934", size = 223519, upload-time = "2026-07-15T18:54:16.803Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/50/eb5bf42e531611a9f8d272556b1ed4de503f84a91413584094487cf69f8f/coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9", size = 221587, upload-time = "2026-07-15T18:54:18.439Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/da99af464c335d4e023a6efcd7ec30f63b88a43c93745154ab74ffb31cea/coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73", size = 221943, upload-time = "2026-07-15T18:54:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8a/13c42723d61ca447eafa18732e8141dd6a63f2732e1c7e1502c182dd88d7/coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d", size = 253450, upload-time = "2026-07-15T18:54:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/29/99021303f98fbdcb63504b4d07bea4cc025b9b2dd907c4f07c85d50a0dab/coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b", size = 256187, upload-time = "2026-07-15T18:54:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a8/fd503715ed6ca9c5d742923aa5209257340b367a867b2ced0c7d4ba8a0b9/coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296", size = 257301, upload-time = "2026-07-15T18:54:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/da/40/3f4b8fb409810036ebc2857d36adc0498c6e957b5df0290c5036b2e143f1/coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6", size = 259562, upload-time = "2026-07-15T18:54:27.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8a/9bdffbef47db77cce3d6b02a28f7e919b19f0106c4b080c2c2246040f885/coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098", size = 253841, upload-time = "2026-07-15T18:54:29.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1e/9031efde019d31a06646261fce6dfc5c3c74e951e27a71e5c9a424563178/coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a", size = 255221, upload-time = "2026-07-15T18:54:31.142Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/787acde872389fc84a9ef9d8cd1ccc658e391ab4cb5b28092a714426a394/coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b", size = 253366, upload-time = "2026-07-15T18:54:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9b/6f57bc4b93c842eef1695f8cdaf2318e35e7ba54f5ba80d84be213ab7858/coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2", size = 257434, upload-time = "2026-07-15T18:54:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/b3186a21b2acc83e451118978905c81c7072c3333707804db09a78c096a2/coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440", size = 252935, upload-time = "2026-07-15T18:54:36.548Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/c9f3376b2e717ea69ed7a6e9a5fcab968fb0b290db6cf4bd9a1fc7541b75/coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e", size = 254807, upload-time = "2026-07-15T18:54:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e1/dfc15401f4a8aaeb486e1ba3e9e3c40522a6e38bd0ecf0b3f29cb8082957/coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd", size = 223641, upload-time = "2026-07-15T18:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/81b6d809d320cd366ec5bdf8176575e897dcb8efe7fb4b489ef9e93e4d13/coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40", size = 224172, upload-time = "2026-07-15T18:54:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/28/9f14ec438149f7de557f45518f09b4a7917b795cc37083aa7db482693f8c/coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3", size = 223556, upload-time = "2026-07-15T18:54:43.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -1660,6 +1751,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1990,23 +2095,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -2026,23 +2131,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -2059,7 +2164,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
 wheels = [
@@ -2079,7 +2184,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/75/9a5695b3d3b848a43cfe91c7d7d3c5ab543eb3bc5c2a12ffaf5003a2a4f6/sphinx_autodoc_typehints-3.10.2.tar.gz", hash = "sha256:34db651eb14343ba16bd9c03e0f5093971f9bbd3cc6b0a1470adecd578940b9c", size = 74241, upload-time = "2026-04-15T22:09:48.87Z" }
 wheels = [
@@ -2180,6 +2285,60 @@ sdist = { url = "https://files.pythonhosted.org/packages/22/78/7959800dd3c8eb2ce
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/30/770a072831fe83f98b67b565176b9353dd6a7494268070117e040b2589a8/timezonefinder-8.2.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fe1c6dd2a6c3996472ae6917a7544d765bd74e84db2a9496942af55f60a0791", size = 53953449, upload-time = "2026-03-29T08:45:38.844Z" },
     { url = "https://files.pythonhosted.org/packages/1e/8f/28a9efd809eb197abe3688b60e192318f2f25ac6bc6c0e53812100af078e/timezonefinder-8.2.2-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:98c9cf6ff71e07629388533518ec5871d4764800c2bb6b9284981f9ac466c6f7", size = 53955422, upload-time = "2026-03-29T08:45:42.604Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- lazy-load historical top-level plotting helpers so core imports and non-plotting CLI commands do not initialize Matplotlib
- add a no-file, no-network installation check and focused first-run troubleshooting
- synchronize security, release, configuration, contributor, roadmap, and package metadata
- add weekly grouped Dependabot updates for uv and GitHub Actions
- report branch-aware core coverage on Python 3.12 while excluding vendored BLAST-Lite
- add lightweight macOS and Windows public-entrypoint smoke checks and make Sphinx warnings fail CI
- publish the 0.4.x refactor/onboarding plan in the documentation

## Why

This is the behavior-preserving onboarding and repository-health slice planned for 0.4.2. It makes the first BREOS interaction quieter and easier to diagnose, removes documentation drift, and adds maintenance and portability evidence before the deeper degradation refactors continue.

## Impact

The stable `breos.App` facade and scientific behavior are unchanged. Existing top-level plotting attributes remain available and load their optional dependency only when first accessed. Coverage is reported as a baseline (currently 58% branch-aware coverage) without introducing a pass threshold.

## Validation

- `567 passed, 7 skipped, 2 deselected` with coverage; 21 expected BLAST experimental-range warnings
- slow suite: `2 passed`
- local platform smoke selection: `6 passed`
- Ruff lint and format checks pass
- Sphinx HTML build passes with `-W`
- release artifact verification passes
- Dependabot and workflow YAML parse successfully
- `uv lock --check` passes
