### PR TITLE
Add inert bifacial module metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Added
+- Added optional, validated `PVModuleParams.bifaciality` metadata and a sourced
+  maximum-power bifaciality value for the generic 600 W bifacial catalog entry.
+  The metadata alone does not activate rear-gain modeling or change production.
+
 ## [0.4.2] - 2026-07-27
 
 ### Changed

--- a/breos/pv_modules.py
+++ b/breos/pv_modules.py
@@ -76,7 +76,11 @@ MODULES: Dict[str, PVModuleParams] = {
     ),
     # -------------------------------------------------------------------------
     # Generic 600W Bifacial Module (utility-scale, high-voltage 144-half-cell)
-    # Representative mono-PERC specs; the model treats it as a front-side module.
+    # Representative mono-PERC specs. The 0.70 maximum-power bifaciality is
+    # sourced from Trina Solar's 600 W Vertex TSM-DEG20C.20 datasheet
+    # (TSM_EN_2020_PA1): https://www.trinasolar.com/sites/default/files/600WVertex.pdf
+    # It remains inert metadata until bifacial modeling is explicitly activated
+    # by the caller.
     # -------------------------------------------------------------------------
     "Generic_600W_Bifacial": PVModuleParams(
         Mpp=600,
@@ -89,7 +93,8 @@ MODULES: Dict[str, PVModuleParams] = {
         T_Voc_pct=-0.26,
         T_Isc_pct=0.046,
         N_Cells=144,
-        Name="Generic 600W bifacial (utility-scale ref)",
+        bifaciality=0.70,
+        Name="Generic 600W bifacial (Trina Vertex bifaciality ref)",
     ),
 }
 
@@ -166,6 +171,7 @@ Cells:      {m.N_Cells}
 T_Pmax:     {m.T_Pmax_pct} %/°C
 Name:       {m.Name}
 Efficiency: {f"{m.Module_Efficiency * 100:.1f} %" if m.Module_Efficiency is not None else "n/a"}
+Bifaciality: {f"{m.bifaciality * 100:.1f} %" if m.bifaciality is not None else "n/a"}
 """
 
 

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -279,8 +279,13 @@ class PVModuleParams:
     alpha_sc_abs: Optional[float] = None  # A/°C - if provided, overrides T_Isc_pct conversion
     beta_voc_abs: Optional[float] = None  # V/°C - if provided, overrides T_Voc_pct conversion
     gamma_pmp: Optional[float] = None
+    # Appended after all pre-0.5 fields to preserve positional construction.
+    bifaciality: Optional[float] = None  # Metadata: rear/front maximum-power ratio (inert by itself)
 
     def __post_init__(self):
+        if self.bifaciality is not None and not 0.0 < self.bifaciality <= 1.0:
+            raise ValueError("bifaciality must be between 0 (exclusive) and 1 (inclusive)")
+
         # 1. HANDLE CURRENT (alpha_sc)
         if self.alpha_sc_abs is not None:
             # User provided absolute A/C directly

--- a/docs/getting-started/options.md
+++ b/docs/getting-started/options.md
@@ -33,7 +33,7 @@ Catalogue keys for the `pv_module` config key, from `breos.pv_modules.MODULES`.
 |---|---|---|---|
 | `Erlangen_445W` | 445 | Erlangen_445W | monoSi |
 | `Generic_400W` | 400 | Generic 400W (LONGi LR4-72HPH-400M ref) | monoSi |
-| `Generic_600W_Bifacial` | 600 | Generic 600W bifacial (utility-scale ref) | monoSi |
+| `Generic_600W_Bifacial` | 600 | Generic 600W bifacial (Trina Vertex bifaciality ref) | monoSi |
 | `Suntech_STP550S_STC` | 550 | Suntech_STP550S-C72/Vmh | monoSi |
 
 ## Cost presets

--- a/tests/test_pv_modules.py
+++ b/tests/test_pv_modules.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from breos.pv_modules import MODULES, get_module, list_modules
+from breos.pv_modules import MODULES, get_module, get_module_info, list_modules
 
 
 class TestCatalog:
@@ -14,6 +14,12 @@ class TestCatalog:
     def test_unknown_module_error_lists_available(self):
         with pytest.raises(KeyError, match="not found. Available:"):
             get_module("No_Such_Module")
+
+    def test_bifacial_module_exposes_sourced_inert_metadata(self):
+        module = get_module("Generic_600W_Bifacial")
+
+        assert module.bifaciality == pytest.approx(0.70)
+        assert "Bifaciality: 70.0 %" in get_module_info("Generic_600W_Bifacial")
 
     def test_nomt_entry_removed(self):
         # The Suntech_STP550S_NOMT entry fed NMOT datasheet points (800 W/m2,

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -46,6 +46,25 @@ class TestPVModuleParams:
         params = _module_params(gamma_pmp=-0.30)
         assert params.gamma_pmp == -0.30
 
+    def test_bifaciality_is_optional_metadata(self):
+        assert _module_params().bifaciality is None
+        assert _module_params(bifaciality=0.8).bifaciality == 0.8
+
+    def test_bifaciality_does_not_shift_existing_positional_fields(self):
+        required = [400, 41.0, 9.76, 49.3, 10.30, -0.35, -0.265, 0.05, 144]
+        params = PVModuleParams(*required, "Existing name", 0.21, "monoSi", None, None, -0.30)
+
+        assert params.Name == "Existing name"
+        assert params.Module_Efficiency == 0.21
+        assert params.celltype == "monoSi"
+        assert params.gamma_pmp == -0.30
+        assert params.bifaciality is None
+
+    @pytest.mark.parametrize("bifaciality", [0.0, -0.1, 1.01])
+    def test_bifaciality_must_be_a_physical_ratio(self, bifaciality):
+        with pytest.raises(ValueError, match="bifaciality must be between"):
+            _module_params(bifaciality=bifaciality)
+
 
 class TestDcToAc:
     def _dc(self, watts, periods=4):
@@ -89,6 +108,21 @@ class TestTiltAndAzimuth:
 
 
 class TestPVProduction:
+    def test_bifaciality_metadata_does_not_activate_rear_gain(self, synthetic_weather, porto_location):
+        kwargs = dict(
+            weather_data=synthetic_weather.iloc[:48],
+            location=porto_location,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            freq="h",
+        )
+
+        front_only = calculate_pv_production_dc(**kwargs, pv_params=_module_params())
+        bifacial_metadata = calculate_pv_production_dc(**kwargs, pv_params=_module_params(bifaciality=0.8))
+
+        pd.testing.assert_series_equal(front_only, bifacial_metadata)
+
     def test_output_shape(self, synthetic_weather, porto_location, pv_params):
         dc = calculate_pv_production_dc(
             weather_data=synthetic_weather,


### PR DESCRIPTION
A bifacial module's rear face contributes power in proportion to a ratio the manufacturer publishes: 0.70 for the generic 600 W entry in the BREOS catalog, per its Trina Vertex datasheet. Until now BREOS had nowhere to put that number. This PR adds a validated `bifaciality` field to `PVModuleParams`, records the catalog entry's value with its source, and exposes it in module information.

Nothing reads it yet — rear-side gain arrives later as an explicit opt-in — so no PV result moves. Existing positional construction of `PVModuleParams` still works, and non-physical ratios are rejected at construction.

## What

Records the bifaciality of the modules. Needed for work on subsequent PRs.

- Adds optional, validated `PVModuleParams.bifaciality` metadata, appended after the existing fields to preserve positional construction.
- Records the generic 600 W bifacial catalog entry's 0.70 maximum-power bifaciality with its Trina Vertex datasheet source.
- Exposes the metadata in module information, documents the catalog reference, and adds release notes and focused tests.

## Why

This establishes sourced module metadata needed by the 0.5.0 bifacial work while keeping rear-side modeling as an explicit later opt-in.

## Impact

`bifaciality` alone does not enable rear-gain modeling or alter PV production. Existing module construction remains compatible; non-physical ratios are rejected.

## Checks

- `uv run pytest -q tests/test_pv_modules.py tests/test_solar.py` — 70 passed
- `uv run pytest -q` — 583 passed, 7 skipped, 2 deselected (21 existing BLAST experimental-range warnings)
- `uv run ruff check breos tests` — passed
- `uv run ruff format --check breos tests` — passed
- `uv build` — source distribution and wheel built
