### PR TITLE
Add opt-in bifacial rear-gain modeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 - Added optional, validated `PVModuleParams.bifaciality` metadata and a sourced
   maximum-power bifaciality value for the generic 600 W bifacial catalog entry.
   The metadata alone does not activate rear-gain modeling or change production.
+- Added opt-in `bifacial_model="infinite_sheds"` rear-gain modeling for fixed,
+  tracking, and mixed multi-array systems. The App/CLI path requires explicit
+  row height and pitch plus sourced module bifaciality; the default `"none"`
+  path preserves front-only production.
 
 ## [0.4.2] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   The metadata alone does not activate rear-gain modeling or change production.
 - Added opt-in `bifacial_model="infinite_sheds"` rear-gain modeling for fixed,
   tracking, and mixed multi-array systems. The App/CLI path requires explicit
-  row height and pitch plus sourced module bifaciality; the default `"none"`
-  path preserves front-only production.
+  row height and pitch plus sourced module bifaciality. Rear irradiance feeds
+  both DC power and the cell-temperature model, following pvlib's
+  `poa_front + poa_back * bifaciality` convention, so rear gain is not credited
+  with power but no heat. With the default `bifacial_model="none"` the rear
+  term is zero and front-side irradiance, cell temperature, and DC production
+  are bit-for-bit unchanged.
 
 ## [0.4.2] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,20 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   `poa_front + poa_back * bifaciality` convention, so rear gain is not credited
   with power but no heat. With the default `bifacial_model="none"` the rear
   term is zero and front-side irradiance, cell temperature, and DC production
-  are bit-for-bit unchanged.
+  are bit-for-bit unchanged. That guarantee covers the rear-gain model only,
+  not the `gcr` forwarding change noted below.
+
+### Changed
+- Multi-array systems now honour the top-level `gcr` when placing per-array
+  tracking geometry. `calculate_multi_array_production_breakdown` takes a
+  function-level `gcr` and the App/CLI path forwards the configured `gcr`;
+  previously per-array tracking fell back to a hardcoded `0.35` and a
+  non-default top-level `gcr` never reached it. Existing multi-array tracking
+  configurations that set a non-default top-level `gcr` without a per-array
+  `gcr` now backtrack with different row geometry and produce slightly
+  different production. Set `gcr` explicitly on each entry in `pv_arrays` to
+  keep the previous geometry. Single-array systems and per-array `gcr`
+  overrides are unaffected.
 
 ## [0.4.2] - 2026-07-27
 

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -15,6 +15,8 @@ from breos.emissions import EmissionsParams
 from breos.pv_modules import MODULES, PVModuleParams, get_module
 from breos.resources import load_config_json
 from breos.solar import (
+    BIFACIAL_MODELS,
+    DEFAULT_BIFACIAL_MODEL,
     DEFAULT_DIFFUSE_IAM,
     DEFAULT_PEREZ_MODEL,
     DEFAULT_SOLAR_POSITION,
@@ -53,6 +55,9 @@ DEFAULTS: dict[str, Any] = {
     "solar_position": DEFAULT_SOLAR_POSITION,
     "diffuse_iam": DEFAULT_DIFFUSE_IAM,
     "temperature_model": DEFAULT_TEMPERATURE_MODEL,
+    "bifacial_model": DEFAULT_BIFACIAL_MODEL,
+    "pvrow_height": None,
+    "pvrow_pitch": None,
     "resolution": "h",
     "projection_years": 20,
     "cost_preset": None,
@@ -153,6 +158,41 @@ def _validate_sky_settings(
         raise ValueError(f"'{prefix}model_perez' must be one of: {valid}")
 
 
+def _validate_bifacial_settings(
+    model: Any,
+    module: Any,
+    gcr: Any,
+    pvrow_height: Any,
+    pvrow_pitch: Any,
+    where: str = "",
+) -> None:
+    """Validate opt-in bifacial module metadata and row geometry."""
+    prefix = f"{where}." if where else ""
+    normalised = str(model).strip().lower()
+    if normalised not in BIFACIAL_MODELS:
+        valid = ", ".join(BIFACIAL_MODELS)
+        raise ValueError(f"'{prefix}bifacial_model' must be one of: {valid}")
+
+    for key, value in (("pvrow_height", pvrow_height), ("pvrow_pitch", pvrow_pitch)):
+        if value is not None and _finite_real(value, f"{prefix}{key}") <= 0:
+            raise ValueError(f"'{prefix}{key}' must be > 0 when configured")
+
+    if normalised == "none":
+        return
+
+    module_key = module or next(iter(MODULES))
+    if module_key in MODULES and MODULES[module_key].bifaciality is None:
+        raise ValueError(
+            f"'{prefix}bifacial_model=infinite_sheds' requires bifaciality metadata for PV module {module_key!r}"
+        )
+    if pvrow_height is None:
+        raise ValueError(f"'{prefix}pvrow_height' is required when bifacial_model='infinite_sheds'")
+    if pvrow_pitch is None:
+        raise ValueError(f"'{prefix}pvrow_pitch' is required when bifacial_model='infinite_sheds'")
+    if not 0 < _finite_real(gcr, f"{prefix}gcr") <= 1:
+        raise ValueError(f"'{prefix}gcr' must be between 0 (exclusive) and 1 (inclusive)")
+
+
 def validate_config(cfg: dict[str, Any]) -> None:
     """Validate user-facing App config before resolving derived values."""
     has_arrays = _validate_structure_and_location(cfg)
@@ -235,6 +275,14 @@ def _validate_pv_and_inverter(cfg: dict[str, Any], has_arrays: bool) -> None:
                 arr.get("model_perez"),
                 where=f"pv_arrays[{i}]",
             )
+            _validate_bifacial_settings(
+                arr.get("bifacial_model", cfg["bifacial_model"]),
+                module or next(iter(MODULES)),
+                arr.get("gcr", cfg["gcr"]),
+                arr.get("pvrow_height", cfg["pvrow_height"]),
+                arr.get("pvrow_pitch", cfg["pvrow_pitch"]),
+                where=f"pv_arrays[{i}]",
+            )
     if _finite_real(cfg["annual_consumption_kwh"], "annual_consumption_kwh") <= 0:
         raise ValueError("'annual_consumption_kwh' must be > 0")
     if _finite_real(cfg["battery_kwh"], "battery_kwh") < 0:
@@ -248,6 +296,14 @@ def _validate_pv_and_inverter(cfg: dict[str, Any], has_arrays: bool) -> None:
     azimuth = cfg.get("azimuth")
     if azimuth is not None and not 0 <= _finite_real(azimuth, "azimuth") <= 360:
         raise ValueError("'azimuth' must be between 0 and 360")
+    if not has_arrays:
+        _validate_bifacial_settings(
+            cfg["bifacial_model"],
+            cfg.get("pv_module") or next(iter(MODULES)),
+            cfg["gcr"],
+            cfg["pvrow_height"],
+            cfg["pvrow_pitch"],
+        )
     if not 0 < _finite_real(cfg["inverter_efficiency"], "inverter_efficiency") <= 1:
         raise ValueError("'inverter_efficiency' must be between 0 (exclusive) and 1 (inclusive)")
     if _finite_real(cfg["inverter_loading_ratio"], "inverter_loading_ratio") <= 0:
@@ -272,6 +328,7 @@ def _validate_time_and_weather(cfg: dict[str, Any]) -> None:
     if str(cfg["temperature_model"]).strip().lower() not in TEMPERATURE_MODELS:
         valid = ", ".join(TEMPERATURE_MODELS)
         raise ValueError(f"'temperature_model' must be one of: {valid}")
+    cfg["bifacial_model"] = str(cfg["bifacial_model"]).strip().lower()
     overrides = cfg.get("pv_loss_overrides")
     if overrides is not None:
         if not isinstance(overrides, dict):
@@ -399,6 +456,9 @@ def normalise_pv_arrays(arrays: list[dict[str, Any]] | None, cfg: dict[str, Any]
         "albedo",
         "surface_type",
         "model_perez",
+        "bifacial_model",
+        "pvrow_height",
+        "pvrow_pitch",
     )
 
     normalized: list[dict[str, Any]] = []

--- a/breos/app_inputs.py
+++ b/breos/app_inputs.py
@@ -125,6 +125,9 @@ def build_pv_production_breakdown(
         "solar_position": cfg["solar_position"],
         "diffuse_iam": cfg["diffuse_iam"],
         "temperature_model": cfg["temperature_model"],
+        "bifacial_model": cfg["bifacial_model"],
+        "pvrow_height": cfg["pvrow_height"],
+        "pvrow_pitch": cfg["pvrow_pitch"],
     }
 
     if resolved.pv_arrays:
@@ -134,6 +137,7 @@ def build_pv_production_breakdown(
             arrays=resolved.pv_arrays,
             freq=freq,
             loss_overrides=loss_overrides,
+            gcr=cfg["gcr"],
             **sky_kwargs,
         )
 
@@ -147,6 +151,7 @@ def build_pv_production_breakdown(
             pv_params=resolved.pv_params,
             freq=freq,
             loss_overrides=loss_overrides,
+            gcr=cfg["gcr"],
             **sky_kwargs,
         )
     else:

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -19,6 +19,7 @@ from breos.load_profiles import PROFILE_ALIASES, PROFILE_NAMES
 from breos.pv_modules import MODULES
 from breos.resources import load_config_json
 from breos.solar import (
+    BIFACIAL_MODELS,
     DIFFUSE_IAM_METHODS,
     PEREZ_MODELS,
     SOLAR_POSITION_METHODS,
@@ -83,6 +84,10 @@ def _build_config(args: argparse.Namespace) -> dict[str, Any]:
     _add_override(overrides, "solar_position", args.solar_position)
     _add_override(overrides, "diffuse_iam", args.diffuse_iam)
     _add_override(overrides, "temperature_model", args.temperature_model)
+    _add_override(overrides, "bifacial_model", args.bifacial_model)
+    _add_override(overrides, "pvrow_height", args.pvrow_height)
+    _add_override(overrides, "pvrow_pitch", args.pvrow_pitch)
+    _add_override(overrides, "gcr", args.gcr)
     _add_override(overrides, "resolution", args.resolution)
     _add_override(overrides, "projection_years", args.projection_years)
     _add_override(overrides, "inflation_rate", args.inflation_rate)
@@ -153,6 +158,10 @@ def _resolved_config_summary(config: dict[str, Any]) -> dict[str, Any]:
             "solar_position": cfg["solar_position"],
             "diffuse_iam": cfg["diffuse_iam"],
             "temperature_model": cfg["temperature_model"],
+            "bifacial_model": cfg["bifacial_model"],
+            "gcr": cfg["gcr"],
+            "pvrow_height": cfg["pvrow_height"],
+            "pvrow_pitch": cfg["pvrow_pitch"],
             "pv_loss_overrides": cfg["pv_loss_overrides"],
             "losses": resolve_pvwatts_losses(cfg["pv_loss_overrides"]),
         },
@@ -563,6 +572,22 @@ def build_parser() -> argparse.ArgumentParser:
             "(default: faiman, open rack)."
         ),
     )
+    run.add_argument(
+        "--bifacial-model",
+        choices=BIFACIAL_MODELS,
+        help="Rear-irradiance model (default: none; infinite_sheds requires bifacial module metadata and row geometry).",
+    )
+    run.add_argument(
+        "--pvrow-height",
+        type=float,
+        help="PV row center height above ground; use the same unit as --pvrow-pitch.",
+    )
+    run.add_argument(
+        "--pvrow-pitch",
+        type=float,
+        help="Distance between PV rows; use the same unit as --pvrow-height.",
+    )
+    run.add_argument("--gcr", type=float, help="PV row ground coverage ratio (default: 0.35).")
     run.add_argument("--resolution", choices=("h", "15min"), help="Simulation time resolution.")
     run.add_argument("--projection-years", type=int, help="Economic projection horizon.")
     run.add_argument("--inflation-rate", type=float, help="Annual electricity price inflation.")

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -133,6 +133,15 @@ DEFAULT_DIFFUSE_IAM = "none"
 _MARION_DIFFUSE_GRID_STEP_DEG = 0.5
 _marion_diffuse_grid_cache: Dict[tuple[float, float, float], tuple[np.ndarray, Dict[str, np.ndarray]]] = {}
 
+# Rear-side irradiance is opt-in. ``none`` preserves the historical front-only
+# model exactly; ``infinite_sheds`` uses pvlib's row-geometry model for the back
+# surface while leaving BREOS's existing front-side transposition unchanged.
+BIFACIAL_MODELS = (
+    "none",
+    "infinite_sheds",
+)
+DEFAULT_BIFACIAL_MODEL = "none"
+
 # Cell-temperature model and mounting presets. ``faiman`` is pvlib's Faiman
 # (2008) model with its open-rack default coefficients (u0=25, u1=6.84) —
 # the default and the only prior behaviour. The ``pvsyst-*`` presets use
@@ -230,6 +239,48 @@ def _resolve_temperature_model(model: str) -> str:
         valid = ", ".join(TEMPERATURE_MODELS)
         raise ValueError(f"Unknown temperature model {model!r}. Valid models: {valid}")
     return normalised
+
+
+def _resolve_bifacial_model(model: str) -> str:
+    """Normalise and validate a rear-irradiance model name."""
+    normalised = str(model).strip().lower()
+    if normalised not in BIFACIAL_MODELS:
+        valid = ", ".join(BIFACIAL_MODELS)
+        raise ValueError(f"Unknown bifacial model {model!r}. Valid models: {valid}")
+    return normalised
+
+
+def _validate_bifacial_inputs(
+    model: str,
+    bifaciality: Optional[float],
+    gcr: float,
+    pvrow_height: Optional[float],
+    pvrow_pitch: Optional[float],
+) -> str:
+    """Validate opt-in bifacial metadata and row geometry."""
+    model = _resolve_bifacial_model(model)
+    if model == "none":
+        return model
+    if bifaciality is None:
+        raise ValueError("bifacial_model='infinite_sheds' requires PV module bifaciality metadata")
+
+    geometry = {
+        "gcr": gcr,
+        "pvrow_height": pvrow_height,
+        "pvrow_pitch": pvrow_pitch,
+    }
+    for name, value in geometry.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+            raise TypeError(f"{name} must be a finite number for bifacial modeling")
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{name} must be a finite number for bifacial modeling")
+    if not 0.0 < float(gcr) <= 1.0:
+        raise ValueError("gcr must be between 0 (exclusive) and 1 (inclusive) for bifacial modeling")
+    if float(pvrow_height) <= 0.0:
+        raise ValueError("pvrow_height must be > 0 for bifacial modeling")
+    if float(pvrow_pitch) <= 0.0:
+        raise ValueError("pvrow_pitch must be > 0 for bifacial modeling")
+    return model
 
 
 def _resolve_perez_model(model_perez: str) -> str:
@@ -335,6 +386,8 @@ class _IrradianceModelResult:
 
     ghi: np.ndarray
     poa_global: np.ndarray
+    front_effective_irradiance: np.ndarray
+    rear_effective_irradiance: np.ndarray
     effective_irradiance: np.ndarray
     temp_cell: np.ndarray
 
@@ -378,6 +431,11 @@ def _compute_irradiance_and_cell_temp_detail(
     model_perez: str = DEFAULT_PEREZ_MODEL,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    bifaciality: Optional[float] = None,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> _IrradianceModelResult:
     """Compute GHI, POA, effective irradiance, and cell temperature.
 
@@ -403,6 +461,13 @@ def _compute_irradiance_and_cell_temp_detail(
     model_perez = _resolve_perez_model(model_perez)
     diffuse_iam = _resolve_diffuse_iam_method(diffuse_iam)
     temperature_model = _resolve_temperature_model(temperature_model)
+    bifacial_model = _validate_bifacial_inputs(
+        bifacial_model,
+        bifaciality,
+        gcr,
+        pvrow_height,
+        pvrow_pitch,
+    )
     dni, ghi, dhi = _extract_irradiance(weather_aligned)
     temp_air, wind_speed = _extract_met_data(weather_aligned)
 
@@ -457,9 +522,39 @@ def _compute_irradiance_and_cell_temp_detail(
         multipliers = _marion_diffuse_ashrae(surface_tilt)
         sky_mult = np.nan_to_num(np.asarray(multipliers["sky"], dtype=float), nan=0.0)
         ground_mult = np.nan_to_num(np.asarray(multipliers["ground"], dtype=float), nan=0.0)
-        effective_irradiance = poa_direct * iam_clean + poa_sky * sky_mult + poa_ground * ground_mult
+        front_effective_irradiance = poa_direct * iam_clean + poa_sky * sky_mult + poa_ground * ground_mult
     else:
-        effective_irradiance = poa_direct * iam_clean + poa_diffuse
+        front_effective_irradiance = poa_direct * iam_clean + poa_diffuse
+
+    if bifacial_model == "infinite_sheds":
+        tilt = np.asarray(surface_tilt, dtype=float)
+        azimuth = np.asarray(surface_azimuth, dtype=float)
+        back_tilt = 180.0 - tilt
+        back_azimuth = np.mod(azimuth + 180.0, 360.0)
+        rear_transposition = "haydavies" if model == "haydavies" else "isotropic"
+        rear_albedo = float(albedo) if albedo is not None else float(SURFACE_ALBEDOS.get(surface_type, 0.25))
+        rear = pvlib.bifacial.infinite_sheds.get_irradiance_poa(
+            surface_tilt=back_tilt,
+            surface_azimuth=back_azimuth,
+            solar_zenith=np.asarray(solarpos.apparent_zenith, dtype=float),
+            solar_azimuth=np.asarray(solarpos.azimuth, dtype=float),
+            gcr=float(gcr),
+            height=float(pvrow_height),
+            pitch=float(pvrow_pitch),
+            ghi=np.asarray(ghi, dtype=float),
+            dhi=np.asarray(dhi, dtype=float),
+            dni=np.asarray(dni, dtype=float),
+            albedo=rear_albedo,
+            model=rear_transposition,
+            dni_extra=np.asarray(dni_extra, dtype=float),
+            vectorize=tilt.ndim > 0 and tilt.size > 1,
+        )
+        rear_poa = np.clip(np.nan_to_num(np.asarray(rear["poa_global"], dtype=float), nan=0.0), 0.0, None)
+        rear_effective_irradiance = float(bifaciality) * rear_poa
+        effective_irradiance = front_effective_irradiance + rear_effective_irradiance
+    else:
+        rear_effective_irradiance = np.zeros_like(front_effective_irradiance)
+        effective_irradiance = front_effective_irradiance
 
     if temperature_model == "faiman":
         temp_cell = pvlib.temperature.faiman(poa_global, temp_air, wind_speed)
@@ -469,6 +564,8 @@ def _compute_irradiance_and_cell_temp_detail(
     return _IrradianceModelResult(
         ghi=np.nan_to_num(np.asarray(ghi, dtype=float), nan=0.0),
         poa_global=poa_global,
+        front_effective_irradiance=front_effective_irradiance,
+        rear_effective_irradiance=rear_effective_irradiance,
         effective_irradiance=effective_irradiance,
         temp_cell=np.nan_to_num(np.asarray(temp_cell, dtype=float), nan=25.0),
     )
@@ -485,6 +582,11 @@ def _compute_effective_irradiance_and_cell_temp(
     model_perez: str = DEFAULT_PEREZ_MODEL,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    bifaciality: Optional[float] = None,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ):
     """Compute effective POA irradiance (with IAM) and cell temperature."""
     detail = _compute_irradiance_and_cell_temp_detail(
@@ -498,6 +600,11 @@ def _compute_effective_irradiance_and_cell_temp(
         model_perez=model_perez,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        bifaciality=bifaciality,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     )
     return detail.effective_irradiance, detail.temp_cell
 
@@ -634,6 +741,10 @@ def _build_pv_production_breakdown(
     model_perez: str = DEFAULT_PEREZ_MODEL,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> PVProductionBreakdown:
     """Build the full fixed/tracking PV production breakdown."""
     detail = _compute_irradiance_and_cell_temp_detail(
@@ -647,6 +758,11 @@ def _build_pv_production_breakdown(
         model_perez=model_perez,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        bifaciality=pv_params.bifaciality,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     )
     module_dc = _module_dc_before_losses(
         detail.effective_irradiance,
@@ -762,6 +878,10 @@ def calculate_pv_production_breakdown(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> PVProductionBreakdown:
     """Calculate fixed-tilt PV production with intermediate loss stages."""
     if pv_params is None:
@@ -790,6 +910,10 @@ def calculate_pv_production_breakdown(
         model_perez=model_perez,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     )
 
     if verbose:
@@ -819,6 +943,10 @@ def calculate_pv_production_dc(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> pd.Series:
     """
     Calculate PV DC production from weather data (fixed-tilt array).
@@ -872,6 +1000,10 @@ def calculate_pv_production_dc(
             PVsyst cell model with its documented mounting coefficients;
             the default ``"faiman"`` (open rack) reproduces prior behaviour
             bit-for-bit.
+        bifacial_model: Rear-irradiance model (one of ``BIFACIAL_MODELS``).
+            ``"none"`` preserves front-only production; ``"infinite_sheds"``
+            requires module bifaciality plus ``gcr``, ``pvrow_height``, and
+            ``pvrow_pitch``.
 
     Returns:
         pd.Series with DC power production in Watts (before inverter)
@@ -896,6 +1028,10 @@ def calculate_pv_production_dc(
         solar_position=solar_position,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     ).dc_after_losses
 
 
@@ -925,6 +1061,9 @@ def calculate_pv_production_tracking_breakdown(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> PVProductionBreakdown:
     """Calculate tracking-array PV production with intermediate loss stages.
 
@@ -987,6 +1126,10 @@ def calculate_pv_production_tracking_breakdown(
         model_perez=model_perez,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     )
 
     if verbose:
@@ -1022,6 +1165,9 @@ def calculate_pv_production_dc_tracking(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> pd.Series:
     """
     Calculate PV DC production for a tracking array (single- or dual-axis).
@@ -1069,6 +1215,8 @@ def calculate_pv_production_dc_tracking(
         temperature_model: Cell-temperature model / mounting preset (one of
             ``TEMPERATURE_MODELS``); the default ``"faiman"`` (open rack)
             reproduces prior behaviour bit-for-bit.
+        bifacial_model: Rear-irradiance model (one of ``BIFACIAL_MODELS``).
+            ``"infinite_sheds"`` requires module bifaciality and row height/pitch.
 
     Returns:
         pd.Series with DC power production in Watts (before inverter).
@@ -1099,6 +1247,9 @@ def calculate_pv_production_dc_tracking(
         solar_position=solar_position,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     ).dc_after_losses
 
 
@@ -1146,6 +1297,10 @@ def calculate_pv_production_tmy(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> pd.Series:
     """
     Calculate PV DC production from TMY data.
@@ -1182,6 +1337,10 @@ def calculate_pv_production_tmy(
         solar_position=solar_position,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     )
 
 
@@ -1206,6 +1365,10 @@ def calculate_pv_production_ac(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> pd.Series:
     """
     Calculate PV AC production from weather data.
@@ -1255,6 +1418,10 @@ def calculate_pv_production_ac(
         solar_position=solar_position,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     )
 
     pv_peak_power_w = n_modules * pv_params.Mpp
@@ -1437,6 +1604,10 @@ def calculate_multi_array_production_breakdown(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> PVProductionBreakdown:
     """Calculate combined DC production breakdown from multiple PV arrays.
 
@@ -1462,6 +1633,10 @@ def calculate_multi_array_production_breakdown(
         arr_albedo = arr.get("albedo", albedo)
         arr_surface_type = arr.get("surface_type", surface_type)
         arr_model_perez = arr.get("model_perez", model_perez)
+        arr_bifacial_model = arr.get("bifacial_model", bifacial_model)
+        arr_gcr = arr.get("gcr", gcr)
+        arr_pvrow_height = arr.get("pvrow_height", pvrow_height)
+        arr_pvrow_pitch = arr.get("pvrow_pitch", pvrow_pitch)
 
         if tracking == "fixed":
             tilt = arr.get("tilt", 35)
@@ -1490,6 +1665,10 @@ def calculate_multi_array_production_breakdown(
                 solar_position=solar_position,
                 diffuse_iam=diffuse_iam,
                 temperature_model=temperature_model,
+                bifacial_model=arr_bifacial_model,
+                gcr=arr_gcr,
+                pvrow_height=arr_pvrow_height,
+                pvrow_pitch=arr_pvrow_pitch,
             )
         elif tracking in ("single_axis", "dual_axis"):
             if verbose:
@@ -1511,7 +1690,7 @@ def calculate_multi_array_production_breakdown(
                 axis_azimuth=arr.get("axis_azimuth", default_azimuth(location.latitude)),
                 max_angle=arr.get("max_angle", 60.0),
                 backtrack=arr.get("backtrack", True),
-                gcr=arr.get("gcr", 0.35),
+                gcr=arr_gcr,
                 cross_axis_tilt=arr.get("cross_axis_tilt", 0.0),
                 dual_axis_max_tilt=arr.get("dual_axis_max_tilt", 90.0),
                 pv_params=pv_params,
@@ -1528,6 +1707,9 @@ def calculate_multi_array_production_breakdown(
                 solar_position=solar_position,
                 diffuse_iam=diffuse_iam,
                 temperature_model=temperature_model,
+                bifacial_model=arr_bifacial_model,
+                pvrow_height=arr_pvrow_height,
+                pvrow_pitch=arr_pvrow_pitch,
             )
         else:
             raise ValueError(
@@ -1582,6 +1764,10 @@ def calculate_multi_array_production(
     solar_position: str = DEFAULT_SOLAR_POSITION,
     diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
     temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    gcr: float = 0.35,
+    pvrow_height: Optional[float] = None,
+    pvrow_pitch: Optional[float] = None,
 ) -> pd.Series:
     """
     Calculate combined DC production from multiple PV arrays.
@@ -1618,6 +1804,9 @@ def calculate_multi_array_production(
         temperature_model: Cell-temperature model / mounting preset (one of
             ``TEMPERATURE_MODELS``); function-level for all arrays, like
             ``solar_position``.
+        bifacial_model: Default rear-irradiance model for arrays that do not
+            override it. ``"infinite_sheds"`` requires bifacial module metadata
+            plus GCR, row height, and row pitch.
 
     Returns:
         pd.Series with total DC power (watts)
@@ -1639,4 +1828,8 @@ def calculate_multi_array_production(
         solar_position=solar_position,
         diffuse_iam=diffuse_iam,
         temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
     ).dc_after_losses

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -454,7 +454,10 @@ def _compute_irradiance_and_cell_temp_detail(
     selects the cell-temperature model / mounting preset (see
     ``TEMPERATURE_MODELS``); the default ``"faiman"`` reproduces prior
     behaviour bit-for-bit, and the pvsyst presets use pvlib's default
-    ``module_efficiency``/``alpha_absorption``.
+    ``module_efficiency``/``alpha_absorption``. The cell-temperature model is
+    driven by front-side ``poa_global`` plus the bifaciality-weighted rear
+    irradiance, so rear gain contributes heat as well as power; with
+    ``bifacial_model="none"`` the rear term is zero and the result is unchanged.
     """
     model = _resolve_transposition_model(transposition_model)
     albedo, surface_type = _resolve_ground_reflectance(albedo, surface_type)
@@ -556,11 +559,20 @@ def _compute_irradiance_and_cell_temp_detail(
         rear_effective_irradiance = np.zeros_like(front_effective_irradiance)
         effective_irradiance = front_effective_irradiance
 
+    # Rear irradiance heats the module as well as powering it, so it belongs in
+    # the thermal balance too. This matches pvlib's bifacial convention, where
+    # infinite_sheds returns poa_global = poa_front + poa_back * bifaciality and
+    # that composed series is what feeds the temperature model. Driving the
+    # temperature model from the front side alone credits the rear gain with
+    # power but no heat and overstates net bifacial gain. On the non-bifacial
+    # path rear_effective_irradiance is all zeros, so bifacial_model="none"
+    # stays bit-for-bit identical.
+    thermal_irradiance = poa_global + rear_effective_irradiance
     if temperature_model == "faiman":
-        temp_cell = pvlib.temperature.faiman(poa_global, temp_air, wind_speed)
+        temp_cell = pvlib.temperature.faiman(thermal_irradiance, temp_air, wind_speed)
     else:
         params = pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS["pvsyst"][_PVSYST_MOUNTING[temperature_model]]
-        temp_cell = pvlib.temperature.pvsyst_cell(poa_global, temp_air, wind_speed, **params)
+        temp_cell = pvlib.temperature.pvsyst_cell(thermal_irradiance, temp_air, wind_speed, **params)
     return _IrradianceModelResult(
         ghi=np.nan_to_num(np.asarray(ghi, dtype=float), nan=0.0),
         poa_global=poa_global,

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -1688,7 +1688,7 @@ def calculate_multi_array_production_breakdown(
                     print(
                         f"   Array {i + 1}: {n_mod}x {mod_name}, single-axis "
                         f"axis_azimuth={arr.get('axis_azimuth', 180.0)}, "
-                        f"gcr={arr.get('gcr', 0.35)}, max_angle=±{arr.get('max_angle', 60.0)}"
+                        f"gcr={arr_gcr}, max_angle=±{arr.get('max_angle', 60.0)}"
                     )
                 else:
                     print(f"   Array {i + 1}: {n_mod}x {mod_name}, dual-axis")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -737,6 +737,83 @@ class TestAppSimulateMultiArray:
         assert self.result["pv_production_kwh"] > 0
 
 
+class TestAppBifacialConfig:
+    def _config(self, **overrides):
+        return {
+            "location": "porto",
+            "n_modules": 6,
+            "annual_consumption_kwh": 3000,
+            "pv_module": "Generic_600W_Bifacial",
+            **overrides,
+        }
+
+    def test_front_only_default_needs_no_row_geometry(self):
+        app = App(self._config())
+
+        assert app._cfg["bifacial_model"] == "none"
+        assert app._cfg["pvrow_height"] is None
+        assert app._cfg["pvrow_pitch"] is None
+
+    def test_infinite_sheds_requires_bifacial_module(self):
+        with pytest.raises(ValueError, match="requires bifaciality metadata"):
+            App(
+                self._config(
+                    pv_module="Generic_400W",
+                    bifacial_model="infinite_sheds",
+                    pvrow_height=1.5,
+                    pvrow_pitch=6.0,
+                )
+            )
+
+    @pytest.mark.parametrize("missing", ["pvrow_height", "pvrow_pitch"])
+    def test_infinite_sheds_requires_complete_geometry(self, missing):
+        geometry = {"pvrow_height": 1.5, "pvrow_pitch": 6.0}
+        geometry.pop(missing)
+
+        with pytest.raises(ValueError, match=missing):
+            App(self._config(bifacial_model="infinite_sheds", **geometry))
+
+    def test_per_array_bifacial_override_is_normalized(self):
+        app = App(
+            {
+                "location": "porto",
+                "annual_consumption_kwh": 3000,
+                "pv_arrays": [
+                    {
+                        "modules": 6,
+                        "module": "Generic_600W_Bifacial",
+                        "tilt": 25,
+                        "azimuth": 180,
+                        "bifacial_model": "infinite_sheds",
+                        "gcr": 0.35,
+                        "pvrow_height": 1.5,
+                        "pvrow_pitch": 6.0,
+                    }
+                ],
+            }
+        )
+
+        assert app._cfg["pv_arrays"][0]["bifacial_model"] == "infinite_sheds"
+        assert app._cfg["pv_arrays"][0]["pvrow_height"] == 1.5
+
+    def test_infinite_sheds_runs_through_app_and_adds_generation(self, _patch_weather):
+        common = self._config(projection_years=1, albedo=0.3)
+        front_only = App(common)
+        front_only.simulate()
+        bifacial = App(
+            {
+                **common,
+                "bifacial_model": "infinite_sheds",
+                "gcr": 0.35,
+                "pvrow_height": 1.5,
+                "pvrow_pitch": 6.0,
+            }
+        )
+        bifacial.simulate()
+
+        assert bifacial.result()["pv_dc_generation_kwh"] > front_only.result()["pv_dc_generation_kwh"]
+
+
 class TestAppSimulateTracking:
     def test_invalid_tracking(self, _patch_weather):
         with pytest.raises(ValueError, match="tracking must be"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,38 @@ def test_run_flag_sell_price_inflation_reaches_config(monkeypatch, capsys):
     assert FakeApp.seen_config["sell_price_inflation"] == 0.03
 
 
+def test_run_bifacial_flags_reach_config(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "App", FakeApp)
+
+    exit_code = cli.main(
+        [
+            "run",
+            "--location",
+            "porto",
+            "--n-modules",
+            "10",
+            "--annual-consumption-kwh",
+            "4000",
+            "--pv-module",
+            "Generic_600W_Bifacial",
+            "--bifacial-model",
+            "infinite_sheds",
+            "--gcr",
+            "0.35",
+            "--pvrow-height",
+            "1.5",
+            "--pvrow-pitch",
+            "6.0",
+        ]
+    )
+
+    assert exit_code == 0
+    assert FakeApp.seen_config["bifacial_model"] == "infinite_sheds"
+    assert FakeApp.seen_config["gcr"] == 0.35
+    assert FakeApp.seen_config["pvrow_height"] == 1.5
+    assert FakeApp.seen_config["pvrow_pitch"] == 6.0
+
+
 def test_run_from_toml_config_with_cli_override(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "App", FakeApp)
     config_path = tmp_path / "experiment.toml"
@@ -237,6 +269,41 @@ battery_kwh = 5.0
     assert 14.0 < output["pv"]["losses"]["combined_pct"] < 15.0
     assert output["battery"]["degradation_engine"] == "native"
     assert output["battery"]["blast_model"] is None
+
+
+def test_run_dry_run_reports_bifacial_geometry(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "App", FakeApp)
+    output_path = tmp_path / "resolved.json"
+
+    exit_code = cli.main(
+        [
+            "run",
+            "--location",
+            "porto",
+            "--n-modules",
+            "10",
+            "--annual-consumption-kwh",
+            "4000",
+            "--pv-module",
+            "Generic_600W_Bifacial",
+            "--bifacial-model",
+            "infinite_sheds",
+            "--pvrow-height",
+            "1.5",
+            "--pvrow-pitch",
+            "6.0",
+            "--dry-run",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert exit_code == 0
+    pv = json.loads(output_path.read_text(encoding="utf-8"))["pv"]
+    assert pv["bifacial_model"] == "infinite_sheds"
+    assert pv["gcr"] == 0.35
+    assert pv["pvrow_height"] == 1.5
+    assert pv["pvrow_pitch"] == 6.0
 
 
 def test_sweep_expands_grid_and_writes_combined_csv(monkeypatch, tmp_path, capsys):

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -1,6 +1,8 @@
 """Tests for the solar module."""
 
+import numpy as np
 import pandas as pd
+import pvlib
 import pytest
 
 import breos.solar as solar
@@ -18,6 +20,19 @@ from breos.solar import (
     default_azimuth,
     estimate_optimal_tilt,
 )
+
+
+def _spy_on_faiman(monkeypatch):
+    """Record the irradiance array every ``faiman`` call is driven with."""
+    calls = []
+    real_faiman = pvlib.temperature.faiman
+
+    def spy(poa_global, *args, **kwargs):
+        calls.append(np.asarray(poa_global, dtype=float).copy())
+        return real_faiman(poa_global, *args, **kwargs)
+
+    monkeypatch.setattr(pvlib.temperature, "faiman", spy)
+    return calls
 
 
 def _module_params(**overrides):
@@ -191,6 +206,60 @@ class TestPVProduction:
                 **kwargs,
                 pv_params=get_module("Generic_600W_Bifacial"),
             )
+
+    def _detail_inputs(self, weather, location):
+        _, solarpos, weather_aligned = solar._prepare_solarpos_and_weather(weather, location, "h")
+        return weather_aligned, solarpos
+
+    def test_cell_temperature_excludes_rear_when_bifacial_disabled(
+        self, synthetic_weather, porto_location, monkeypatch
+    ):
+        # bifacial_model="none" must stay bit-for-bit identical to driving the
+        # temperature model with front-side poa_global alone.
+        thermal_inputs = _spy_on_faiman(monkeypatch)
+        weather_aligned, solarpos = self._detail_inputs(synthetic_weather.iloc[: 24 * 7], porto_location)
+
+        detail = solar._compute_irradiance_and_cell_temp_detail(
+            weather_aligned,
+            solarpos,
+            surface_tilt=35,
+            surface_azimuth=180,
+        )
+
+        assert not detail.rear_effective_irradiance.any()
+        np.testing.assert_array_equal(thermal_inputs[-1], detail.poa_global)
+
+    def test_rear_irradiance_heats_the_module(self, synthetic_weather, porto_location, monkeypatch):
+        # Rear gain must contribute heat as well as power; pvlib's bifacial
+        # convention feeds poa_front + poa_back * bifaciality to the
+        # temperature model.
+        thermal_inputs = _spy_on_faiman(monkeypatch)
+        weather_aligned, solarpos = self._detail_inputs(synthetic_weather.iloc[: 24 * 7], porto_location)
+        kwargs = dict(surface_tilt=35, surface_azimuth=180, albedo=0.25)
+
+        front_only = solar._compute_irradiance_and_cell_temp_detail(weather_aligned, solarpos, **kwargs)
+        bifacial = solar._compute_irradiance_and_cell_temp_detail(
+            weather_aligned,
+            solarpos,
+            bifacial_model="infinite_sheds",
+            bifaciality=0.8,
+            gcr=0.35,
+            pvrow_height=1.5,
+            pvrow_pitch=6.0,
+            **kwargs,
+        )
+
+        np.testing.assert_array_equal(
+            thermal_inputs[-1],
+            bifacial.poa_global + bifacial.rear_effective_irradiance,
+        )
+        np.testing.assert_array_equal(bifacial.poa_global, front_only.poa_global)
+        assert (bifacial.temp_cell >= front_only.temp_cell).all()
+        # Rear irradiance below ~1 W/m2 is lost in float rounding of the
+        # temperature model, so only require a strict rise where it is real.
+        lit = bifacial.rear_effective_irradiance > 1.0
+        assert lit.any()
+        assert (bifacial.temp_cell[lit] > front_only.temp_cell[lit]).all()
 
     def test_output_shape(self, synthetic_weather, porto_location, pv_params):
         dc = calculate_pv_production_dc(

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import breos.solar as solar
+from breos.pv_modules import get_module
 from breos.solar import (
     PEREZ_MODELS,
     SURFACE_TYPES,
@@ -122,6 +123,74 @@ class TestPVProduction:
         bifacial_metadata = calculate_pv_production_dc(**kwargs, pv_params=_module_params(bifaciality=0.8))
 
         pd.testing.assert_series_equal(front_only, bifacial_metadata)
+
+    def test_infinite_sheds_adds_rear_gain(self, synthetic_weather, porto_location):
+        kwargs = dict(
+            weather_data=synthetic_weather.iloc[: 24 * 30],
+            location=porto_location,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=get_module("Generic_600W_Bifacial"),
+            freq="h",
+            albedo=0.25,
+        )
+
+        front_only = calculate_pv_production_dc(**kwargs)
+        bifacial = calculate_pv_production_dc(
+            **kwargs,
+            bifacial_model="infinite_sheds",
+            gcr=0.35,
+            pvrow_height=1.5,
+            pvrow_pitch=6.0,
+        )
+
+        assert bifacial.sum() > front_only.sum()
+
+    def test_rear_gain_increases_with_albedo(self, synthetic_weather, porto_location):
+        kwargs = dict(
+            weather_data=synthetic_weather.iloc[: 24 * 30],
+            location=porto_location,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            pv_params=get_module("Generic_600W_Bifacial"),
+            freq="h",
+            bifacial_model="infinite_sheds",
+            gcr=0.35,
+            pvrow_height=1.5,
+            pvrow_pitch=6.0,
+        )
+
+        low_albedo = calculate_pv_production_dc(**kwargs, albedo=0.15)
+        high_albedo = calculate_pv_production_dc(**kwargs, albedo=0.65)
+
+        assert high_albedo.sum() > low_albedo.sum()
+
+    def test_infinite_sheds_requires_bifacial_metadata_and_geometry(self, synthetic_weather, porto_location):
+        kwargs = dict(
+            weather_data=synthetic_weather.iloc[:48],
+            location=porto_location,
+            tilt=35,
+            surface_azimuth=180,
+            n_modules=1,
+            freq="h",
+            bifacial_model="infinite_sheds",
+            gcr=0.35,
+        )
+
+        with pytest.raises(ValueError, match="requires PV module bifaciality"):
+            calculate_pv_production_dc(
+                **kwargs,
+                pv_params=_module_params(),
+                pvrow_height=1.5,
+                pvrow_pitch=6.0,
+            )
+        with pytest.raises(TypeError, match="pvrow_height must be a finite number"):
+            calculate_pv_production_dc(
+                **kwargs,
+                pv_params=get_module("Generic_600W_Bifacial"),
+            )
 
     def test_output_shape(self, synthetic_weather, porto_location, pv_params):
         dc = calculate_pv_production_dc(
@@ -350,6 +419,23 @@ class TestTracking:
             )
             assert dc.fillna(0).sum() == pytest.approx(0.0, abs=1.0)
 
+    def test_single_axis_supports_infinite_sheds_rear_gain(self, synthetic_weather, porto_location):
+        module = get_module("Generic_600W_Bifacial")
+        weather = synthetic_weather.iloc[: 24 * 30]
+
+        front_only = self._single(weather, porto_location, module, gcr=0.35)
+        bifacial = self._single(
+            weather,
+            porto_location,
+            module,
+            gcr=0.35,
+            bifacial_model="infinite_sheds",
+            pvrow_height=1.5,
+            pvrow_pitch=6.0,
+        )
+
+        assert bifacial.sum() > front_only.sum()
+
 
 class TestMultiArrayTracking:
     def test_mixed_arrays(self, synthetic_weather, porto_location):
@@ -377,6 +463,32 @@ class TestMultiArrayTracking:
                 arrays=arrays,
                 freq="h",
             )
+
+    def test_per_array_bifacial_model_is_independent(self, synthetic_weather, porto_location):
+        weather = synthetic_weather.iloc[: 24 * 30]
+        front_array = {
+            "modules": 1,
+            "module": "Generic_600W_Bifacial",
+            "tilt": 30,
+            "azimuth": 180,
+        }
+        bifacial_array = {
+            **front_array,
+            "bifacial_model": "infinite_sheds",
+            "gcr": 0.35,
+            "pvrow_height": 1.5,
+            "pvrow_pitch": 6.0,
+        }
+
+        front_only = calculate_multi_array_production(weather, porto_location, [front_array], freq="h")
+        mixed = calculate_multi_array_production(
+            weather,
+            porto_location,
+            [front_array, bifacial_array],
+            freq="h",
+        )
+
+        assert mixed.sum() > 2 * front_only.sum()
 
 
 class TestTranspositionModel:


### PR DESCRIPTION
Bifacial modules gain power from light hitting their back side. This PR makes BREOS model that, but only when you explicitly ask for it: set `bifacial_model = "infinite_sheds"` and supply the row geometry, and the model adds the rear-side irradiance to production. Leave it alone and nothing about your results changes.

Rear irradiance is fed to the cell-temperature model as well as to the power calculation. That matters because a module that absorbs more light also runs hotter, and a hotter module is slightly less efficient. Crediting the rear gain with power but no heat would overstate the net benefit of going bifacial by roughly 7% of the gain.

This PR also changes how `gcr` reaches multi-array systems. Previously a top-level `gcr` never reached per-array tracking, which silently fell back to `0.35`; now it does. If you run a multi-array tracking system with a non-default top-level `gcr` and no per-array override, your rows will backtrack with different geometry and your production numbers will move slightly. Set `gcr` on each entry in `pv_arrays` to keep the old behaviour.

## Summary

Adds opt-in bifacial rear-gain modeling to the PV configuration, solar model, and CLI, with focused coverage for solar, App, and CLI behavior.

## Stack position

This is PR 2 of the ordered 0.5.0 PV stack. It is intentionally based on draft PR #92 (`feature/0.5.0-bifacial-metadata`) and should be reviewed after that PR.

## What changed

- Add opt-in `bifacial_model="infinite_sheds"` rear-gain modeling for fixed, tracking, and mixed multi-array systems, requiring explicit row height and pitch plus sourced module bifaciality.
- Drive the cell-temperature model with `poa_global + rear_effective_irradiance` rather than front-side `poa_global` alone, matching pvlib's `poa_front + poa_back * bifaciality` convention. At 800 W/m2 front and 64 W/m2 rear (faiman, 25 °C, 2 m/s) that is about +1.65 °C and -0.58% DC.
- Add a function-level `gcr` to `calculate_multi_array_production_breakdown` and forward the configured `gcr` from `app_inputs`, replacing the hardcoded per-array `0.35` fallback.
- Report the effective per-array `gcr` in verbose tracking output, which previously printed the old `0.35` default rather than the value the model used.
- Document the `gcr` behaviour change under `### Changed`, and scope the existing bifacial bullet's preservation claim to the rear-gain model.

## Behaviour guarantees

- `bifacial_model="none"` is bit-for-bit unchanged: `rear_effective_irradiance` is `zeros_like(...)` on that path, so front-side irradiance, cell temperature, and DC production are identical. Asserted directly by `test_cell_temperature_excludes_rear_when_bifacial_disabled`, which checks the array handed to the temperature model.
- `test_rear_irradiance_heats_the_module` asserts the composed thermal input and a strictly higher cell temperature wherever rear irradiance is meaningfully non-zero.
- The `gcr` forwarding change is a real behaviour change for multi-array tracking configurations and is called out as such in the changelog.

## Validation

- `.venv/bin/python -m pytest -q` (598 passed, 7 skipped)
- `.venv/bin/ruff check breos tests tools`
- `.venv/bin/ruff format --check breos tests tools`
- `.venv/bin/sphinx-build -W -b html docs docs/_build/html`
