### PR TITLE
Refactor PV model core and validate reachable configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   different production. Set `gcr` explicitly on each entry in `pv_arrays` to
   keep the previous geometry. Single-array systems and per-array `gcr`
   overrides are unaffected.
+- Refactored PV model-option resolution and the IAM and temperature kernels
+  into focused internal modules while preserving the `breos.App` facade,
+  public solar-function signatures, defaults, validation, and numerical paths.
 
 ## [0.4.2] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,20 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   different production. Set `gcr` explicitly on each entry in `pv_arrays` to
   keep the previous geometry. Single-array systems and per-array `gcr`
   overrides are unaffected.
+- `App` and CLI configuration now reject a `gcr` outside `(0, 1]`, including
+  non-finite and null values and every explicit `pv_arrays[i].gcr` override,
+  instead of passing it to pvlib. pvlib does not reject a nonsensical ratio on
+  the tracking path; it quietly derives a different backtracking rotation, so a
+  mistyped `3.5` previously returned roughly half the annual energy with no
+  error. Configurations that were already invalid for another reason keep
+  reporting that error. Tracking configurations with an out-of-range `gcr` that
+  used to run and produce wrong numbers now fail at `App()` construction. This
+  guards the config path only; callers going directly to `breos.solar` tracking
+  functions are still responsible for their own `gcr`.
 - Refactored PV model-option resolution and the IAM and temperature kernels
   into focused internal modules while preserving the `breos.App` facade,
-  public solar-function signatures, defaults, validation, and numerical paths.
+  public solar-function signatures, defaults, and numerical paths. Config
+  validation is preserved except for the `gcr` tightening noted above.
 
 ## [0.4.2] - 2026-07-27
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,11 +15,14 @@ intentions, not commitments; reassess after each release.
   troubleshooting, dependency hygiene, coverage automation, cross-platform
   smoke tests, reproducible BLAST parity tooling, and an internal degradation
   lifecycle protocol. No scientific-model, dispatch, or public result changes.
-- **0.5.0** — bifacial rear-gain is the firm scope (activation key, explicit
-  rear-gain loss-waterfall stage, benchmark rows). Independently complete
-  PV-fidelity items (the pvsyst real-efficiency fix, additional IAM and
-  cell-temperature models) may ride along if each lands with its own
-  compatibility and benchmark tests.
+- **0.5.0** — a focused PV-fidelity release delivered as independently
+  reviewable slices: bifacial rear gain (activation key, explicit waterfall
+  stage, and benchmark rows); a behavior-preserving internal PV-model-core
+  refactor; selectable pvlib IAM models; sourced cell-temperature fidelity;
+  and a recommended-configuration example that includes an equal-nameplate
+  2×600 W bifacial versus 3×400 W monofacial comparison. Existing defaults
+  remain bit-for-bit compatible unless a documented correctness fix is
+  explicitly selected.
 - **0.5.x** — the declarative config schema (behavior-preserving, and
   deliberately before TOU adds another cluster of config keys);
   horizon-profile input; and further internal maintainability work if needed.
@@ -33,6 +36,37 @@ without the 3D scene modeling. That standard is earned two ways: closing
 known systematic modeling gaps, and publishing reproducible evidence that
 the numbers are right. This work takes priority over architectural
 refactoring (see the deferred adapter layer at the bottom of this document).
+
+### 0.5.0 PV-fidelity delivery plan
+
+Keep the public `breos.App` facade and `breos.solar` function signatures
+stable while landing the release as a local/PR stack in this order:
+
+1. **PV model core refactor:** introduce one internal resolved-options object
+   for transposition, ground reflectance, IAM, temperature, and bifacial
+   choices; extract narrow IAM and temperature kernels; and leave all public
+   defaults, errors, and numerical results unchanged. This is deliberately a
+   targeted seam for the next two features, not the deferred project-wide
+   third-party-adapter rewrite.
+2. **IAM selection:** expose pvlib's `ashrae`, `physical`, and `martin_ruiz`
+   beam models, with `ashrae` retaining the historical default. When diffuse
+   IAM is enabled, use pvlib's Marion solid-angle integration with the same
+   selected IAM model so beam and diffuse optics cannot silently disagree.
+3. **Temperature fidelity:** pass sourced module efficiency into the existing
+   PVsyst heat-balance path, add named SAPM construction/mounting presets, and
+   add SAM NOCT only for modules with sourced NOCT and efficiency metadata.
+   Never invent missing module thermal inputs. Record any intentional change
+   to an already opt-in model in the changelog and validation report.
+4. **Guidance and evidence:** publish a recommended PV configuration without
+   changing defaults, add IAM/temperature rows to the seven-site validation
+   report, and add a practical equal-nameplate comparison of 2×600 W
+   bifacial against 3×400 W monofacial modules. State the albedo, GCR, row
+   height/pitch, inverter loading, and the front-shading limitation beside the
+   result.
+
+Each slice gets its own compatibility tests and benchmark evidence. Horizon
+profiles, string-aware electrical validation, currency, and time-of-use
+tariffs remain outside 0.5.0.
 
 ### Standing validation and benchmark suite
 
@@ -225,14 +259,16 @@ Capabilities still to bring online (transposition is already selectable via
 end-to-end through `build_dc_system_base` and the multi-array path):
 
 - **Bifacial rear-gain** — see the dedicated item below.
-- **Cell-temperature model choice** — expose `sapm` and `noct_sam` alongside
-  the existing Faiman and PVsyst mounting presets, with their parameter sets,
-  and let the PVsyst path take the module's real efficiency instead of
-  pvlib's 0.1 default — a natural 0.5.0 ride-along, since
-  `PVModuleParams.Module_Efficiency` already exists as explicitly unused
-  metadata.
-- **IAM model choice** — expose `martin_ruiz`, `physical`, and the SAPM IAM
-  for the beam term, extending the existing diffuse-IAM option.
+- **Cell-temperature model choice (0.5.0):** expose named SAPM presets and,
+  where the module catalog has complete sourced inputs, `noct_sam` alongside
+  the existing Faiman and PVsyst presets. Let the PVsyst path consume real
+  module efficiency instead of pvlib's 0.1 fallback. `noct_sam` must require
+  NOCT plus efficiency rather than assuming either value.
+- **IAM model choice (0.5.0):** expose pvlib's `martin_ruiz` and `physical`
+  beam models alongside the existing `ashrae` path, and extend Marion diffuse
+  IAM with the same selection. SAPM IAM remains later work because its
+  module-specific polynomial coefficients are not in BREOS's CEC-style
+  catalog.
 - **DC-side loss refinements** — optional time-series ohmic/soiling/snow models in
   place of (parts of) the flat PVWatts loss stack, where inputs allow.
 - Non-goal: replacing the CEC single-diode core or the PVWatts loss model as the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -313,7 +313,7 @@ modeling" above.
   limit — BREOS's primary audience — and front-optimistic for dense
   ground-mount rows. Document it, and consider a warning for tight pitch.
 - **Integration:** compute rear POA inside
-  `_compute_effective_irradiance_and_cell_temp` and blend
+  `_compute_irradiance_and_cell_temp_detail` and blend
   `effective_irradiance += bifaciality * poa_rear` before the CEC DC model. The
   stage's output contract (DC-watts series) is unchanged, so nothing downstream
   moves — the whole point of the self-contained PV stage above.

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from breos.degradation.profiles import ENABLED_BLAST_MODEL_KEYS, apply_battery_profile_defaults
 from breos.economics import CostParams, calculate_costs
 from breos.emissions import EmissionsParams
+from breos.pv.model_options import is_known_model, is_valid_albedo, is_valid_gcr, normalise_model_name
 from breos.pv_modules import MODULES, PVModuleParams, get_module
 from breos.resources import load_config_json
 from breos.solar import (
@@ -141,14 +142,17 @@ def _validate_sky_settings(
     ``where`` prefixes the key name in error messages (e.g. ``pv_arrays[0]``);
     ``None`` values are treated as "not set" and skipped, so per-array overrides
     only validate the keys they actually provide.
+
+    The rules come from :mod:`breos.pv.model_options`; only the config-key
+    phrasing and the None-means-unset handling are this layer's own.
     """
     prefix = f"{where}." if where else ""
-    if transposition_model is not None and str(transposition_model).strip().lower() not in TRANSPOSITION_MODELS:
+    if transposition_model is not None and not is_known_model(transposition_model, TRANSPOSITION_MODELS):
         valid = ", ".join(TRANSPOSITION_MODELS)
         raise ValueError(f"'{prefix}transposition_model' must be one of: {valid}")
     if albedo is not None and surface_type is not None:
         raise ValueError(f"Set either '{prefix}albedo' or '{prefix}surface_type', not both.")
-    if albedo is not None and (not isinstance(albedo, (int, float)) or not 0 <= albedo <= 1):
+    if albedo is not None and (not isinstance(albedo, (int, float)) or not is_valid_albedo(albedo)):
         raise ValueError(f"'{prefix}albedo' must be a number between 0 and 1")
     if surface_type is not None and surface_type not in SURFACE_TYPES:
         valid = ", ".join(SURFACE_TYPES)
@@ -156,6 +160,22 @@ def _validate_sky_settings(
     if model_perez is not None and model_perez not in PEREZ_MODELS:
         valid = ", ".join(PEREZ_MODELS)
         raise ValueError(f"'{prefix}model_perez' must be one of: {valid}")
+
+
+def _validate_gcr(gcr: Any, prefix: str = "") -> None:
+    """Validate a ground coverage ratio, whichever model consumes it.
+
+    ``gcr`` has two consumers and neither is a shading calculation: the
+    ``infinite_sheds`` rear-side view factors, and — on the tracking path —
+    the backtracking rotation schedule that pvlib's ``singleaxis`` derives
+    from it. The second is why this is checked even with no rear-side model
+    active. pvlib does not reject a nonsensical ratio; it quietly computes a
+    different rotation, so a mistyped ``3.5`` returns roughly half the annual
+    energy with no error anywhere. ``prefix`` already carries its trailing
+    dot, matching the other config-key messages.
+    """
+    if not is_valid_gcr(_finite_real(gcr, f"{prefix}gcr")):
+        raise ValueError(f"'{prefix}gcr' must be between 0 (exclusive) and 1 (inclusive)")
 
 
 def _validate_bifacial_settings(
@@ -168,8 +188,8 @@ def _validate_bifacial_settings(
 ) -> None:
     """Validate opt-in bifacial module metadata and row geometry."""
     prefix = f"{where}." if where else ""
-    normalised = str(model).strip().lower()
-    if normalised not in BIFACIAL_MODELS:
+    normalised = normalise_model_name(model)
+    if not is_known_model(model, BIFACIAL_MODELS):
         valid = ", ".join(BIFACIAL_MODELS)
         raise ValueError(f"'{prefix}bifacial_model' must be one of: {valid}")
 
@@ -189,8 +209,9 @@ def _validate_bifacial_settings(
         raise ValueError(f"'{prefix}pvrow_height' is required when bifacial_model='infinite_sheds'")
     if pvrow_pitch is None:
         raise ValueError(f"'{prefix}pvrow_pitch' is required when bifacial_model='infinite_sheds'")
-    if not 0 < _finite_real(gcr, f"{prefix}gcr") <= 1:
-        raise ValueError(f"'{prefix}gcr' must be between 0 (exclusive) and 1 (inclusive)")
+    # Deliberately last, so an active rear-side model still reports its
+    # missing metadata and geometry before quibbling about the ratio.
+    _validate_gcr(gcr, prefix)
 
 
 def validate_config(cfg: dict[str, Any]) -> None:
@@ -319,16 +340,16 @@ def _validate_time_and_weather(cfg: dict[str, Any]) -> None:
     if cfg["resolution"] not in ("h", "15min"):
         raise ValueError("'resolution' must be 'h' or '15min'")
     _validate_sky_settings(cfg["transposition_model"], cfg["albedo"], cfg["surface_type"], cfg["model_perez"])
-    if str(cfg["solar_position"]).strip().lower() not in SOLAR_POSITION_METHODS:
+    if not is_known_model(cfg["solar_position"], SOLAR_POSITION_METHODS):
         valid = ", ".join(SOLAR_POSITION_METHODS)
         raise ValueError(f"'solar_position' must be one of: {valid}")
-    if str(cfg["diffuse_iam"]).strip().lower() not in DIFFUSE_IAM_METHODS:
+    if not is_known_model(cfg["diffuse_iam"], DIFFUSE_IAM_METHODS):
         valid = ", ".join(DIFFUSE_IAM_METHODS)
         raise ValueError(f"'diffuse_iam' must be one of: {valid}")
-    if str(cfg["temperature_model"]).strip().lower() not in TEMPERATURE_MODELS:
+    if not is_known_model(cfg["temperature_model"], TEMPERATURE_MODELS):
         valid = ", ".join(TEMPERATURE_MODELS)
         raise ValueError(f"'temperature_model' must be one of: {valid}")
-    cfg["bifacial_model"] = str(cfg["bifacial_model"]).strip().lower()
+    cfg["bifacial_model"] = normalise_model_name(cfg["bifacial_model"])
     overrides = cfg.get("pv_loss_overrides")
     if overrides is not None:
         if not isinstance(overrides, dict):

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -186,7 +186,13 @@ def _validate_bifacial_settings(
     pvrow_pitch: Any,
     where: str = "",
 ) -> None:
-    """Validate opt-in bifacial module metadata and row geometry."""
+    """Validate opt-in bifacial module metadata and row geometry.
+
+    Shares its predicates with :mod:`breos.pv.model_options` but reports them
+    against config keys. ``pvrow_*`` geometry is required only for an active
+    rear-side model; ``gcr`` is also checked independently after the existing
+    validators because tracking can consume it without bifacial modeling.
+    """
     prefix = f"{where}." if where else ""
     normalised = normalise_model_name(model)
     if not is_known_model(model, BIFACIAL_MODELS):
@@ -221,6 +227,31 @@ def validate_config(cfg: dict[str, Any]) -> None:
     _validate_time_and_weather(cfg)
     _validate_economics(cfg)
     _validate_battery_and_degradation(cfg)
+    _validate_reachable_gcr(cfg, has_arrays)
+
+
+def _validate_reachable_gcr(cfg: dict[str, Any], has_arrays: bool) -> None:
+    """Check every ``gcr`` that can reach the model, once everything else passes.
+
+    Runs last, and deliberately so: an out-of-range ``gcr`` used to be caught
+    only under an active bifacial model, so checking it earlier would change
+    which error an already-broken config reports. Running it here makes the
+    check purely additive — a config failing on some other key keeps failing
+    on that key, and ``gcr`` is only ever the *new* reason a config is
+    rejected.
+
+    Arrays that set no ``gcr`` inherit the top-level value, which is also the
+    function-level default handed to the multi-array entry point, so the
+    top-level value is checked even when every array overrides it. Bifacial
+    arrays have already had their effective ``gcr`` checked in the loop above;
+    re-checking an explicit override here is harmless and covers the
+    non-bifacial tracking path that nothing else reaches.
+    """
+    _validate_gcr(cfg["gcr"])
+    if has_arrays:
+        for index, array in enumerate(cfg["pv_arrays"]):
+            if "gcr" in array:
+                _validate_gcr(array["gcr"], f"pv_arrays[{index}].")
 
 
 def _validate_structure_and_location(cfg: dict[str, Any]) -> bool:

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -130,6 +130,17 @@ def merge_defaults(config: dict[str, Any]) -> dict[str, Any]:
     return apply_battery_profile_defaults(DEFAULTS, config)
 
 
+def default_module_key() -> str:
+    """Return the catalog key used when a config names no PV module.
+
+    ``DEFAULTS["pv_module"]`` is ``None`` rather than a key, so the real
+    default is the catalog's insertion order. Resolving it here keeps the
+    validation, resolution, and results layers from each re-deriving it and
+    silently disagreeing if the catalog is reordered.
+    """
+    return next(iter(MODULES))
+
+
 def _validate_sky_settings(
     transposition_model: Any,
     albedo: Any,
@@ -206,7 +217,7 @@ def _validate_bifacial_settings(
     if normalised == "none":
         return
 
-    module_key = module or next(iter(MODULES))
+    module_key = module or default_module_key()
     if module_key in MODULES and MODULES[module_key].bifaciality is None:
         raise ValueError(
             f"'{prefix}bifacial_model=infinite_sheds' requires bifaciality metadata for PV module {module_key!r}"
@@ -329,7 +340,7 @@ def _validate_pv_and_inverter(cfg: dict[str, Any], has_arrays: bool) -> None:
             )
             _validate_bifacial_settings(
                 arr.get("bifacial_model", cfg["bifacial_model"]),
-                module or next(iter(MODULES)),
+                module or default_module_key(),
                 arr.get("gcr", cfg["gcr"]),
                 arr.get("pvrow_height", cfg["pvrow_height"]),
                 arr.get("pvrow_pitch", cfg["pvrow_pitch"]),
@@ -351,7 +362,7 @@ def _validate_pv_and_inverter(cfg: dict[str, Any], has_arrays: bool) -> None:
     if not has_arrays:
         _validate_bifacial_settings(
             cfg["bifacial_model"],
-            cfg.get("pv_module") or next(iter(MODULES)),
+            cfg.get("pv_module") or default_module_key(),
             cfg["gcr"],
             cfg["pvrow_height"],
             cfg["pvrow_pitch"],
@@ -491,7 +502,7 @@ def normalise_pv_arrays(arrays: list[dict[str, Any]] | None, cfg: dict[str, Any]
     if not arrays:
         return []
 
-    default_module = cfg.get("pv_module") or next(iter(MODULES))
+    default_module = cfg.get("pv_module") or default_module_key()
     default_tilt = cfg.get("tilt") if cfg.get("tilt") is not None else estimate_optimal_tilt(lat)
     default_azimuth = cfg.get("azimuth") if cfg.get("azimuth") is not None else default_azimuth_fn(lat)
 
@@ -549,7 +560,7 @@ def resolve_pv_system(
         module_name = cfg["pv_module"]
 
     if module_name is None:
-        module_name = next(iter(MODULES))
+        module_name = default_module_key()
     pv_params = get_module(module_name)
 
     if not pv_arrays:

--- a/breos/pv/__init__.py
+++ b/breos/pv/__init__.py
@@ -1,0 +1,6 @@
+"""Internal PV-model building blocks.
+
+The stable public surface remains :mod:`breos.solar`. Modules in this package
+hold resolved model options and focused numerical kernels so new pvlib-backed
+models do not enlarge the public facade or the central production pipeline.
+"""

--- a/breos/pv/iam.py
+++ b/breos/pv/iam.py
@@ -1,0 +1,62 @@
+"""Focused incidence-angle modifier kernels used by :mod:`breos.solar`."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pvlib
+
+_MARION_DIFFUSE_GRID_STEP_DEG = 0.5
+_marion_diffuse_grid_cache: dict[tuple[float, float, float], tuple[np.ndarray, dict[str, np.ndarray]]] = {}
+
+
+def _marion_diffuse_ashrae(surface_tilt):
+    """Return Marion diffuse IAM for Ashrae, interpolating large tilt arrays."""
+    tilt_array = np.asarray(surface_tilt, dtype=float)
+    if tilt_array.ndim == 0 or tilt_array.size <= 16:
+        return pvlib.iam.marion_diffuse("ashrae", surface_tilt)
+
+    finite = tilt_array[np.isfinite(tilt_array)]
+    if finite.size == 0:
+        zeros = np.zeros_like(tilt_array, dtype=float)
+        return {"sky": zeros, "ground": zeros}
+
+    step = _MARION_DIFFUSE_GRID_STEP_DEG
+    lo = math.floor(float(finite.min()) / step) * step
+    hi = math.ceil(float(finite.max()) / step) * step
+    key = (lo, hi, step)
+
+    if key not in _marion_diffuse_grid_cache:
+        grid = np.arange(lo, hi + step / 2.0, step)
+        values = {"sky": [], "ground": []}
+        for tilt in grid:
+            exact = pvlib.iam.marion_diffuse("ashrae", float(tilt))
+            values["sky"].append(float(exact["sky"]))
+            values["ground"].append(float(exact["ground"]))
+        _marion_diffuse_grid_cache[key] = (
+            grid,
+            {region: np.asarray(region_values) for region, region_values in values.items()},
+        )
+
+    grid, values = _marion_diffuse_grid_cache[key]
+    interp_tilt = np.nan_to_num(tilt_array, nan=lo)
+    return {region: np.interp(interp_tilt, grid, region_values) for region, region_values in values.items()}
+
+
+def calculate_front_effective_irradiance(poa, aoi, surface_tilt, diffuse_iam: str) -> np.ndarray:
+    """Apply BREOS's historical Ashrae beam and optional Marion diffuse IAM."""
+    iam = pvlib.iam.ashrae(aoi)
+    poa_direct = np.nan_to_num(poa["poa_direct"].values, nan=0.0)
+    poa_diffuse = np.nan_to_num(poa["poa_diffuse"].values, nan=0.0)
+    iam_clean = np.nan_to_num(np.asarray(iam, dtype=float), nan=0.0)
+
+    if diffuse_iam == "marion":
+        poa_sky = np.nan_to_num(poa["poa_sky_diffuse"].values, nan=0.0)
+        poa_ground = np.nan_to_num(poa["poa_ground_diffuse"].values, nan=0.0)
+        multipliers = _marion_diffuse_ashrae(surface_tilt)
+        sky_mult = np.nan_to_num(np.asarray(multipliers["sky"], dtype=float), nan=0.0)
+        ground_mult = np.nan_to_num(np.asarray(multipliers["ground"], dtype=float), nan=0.0)
+        return poa_direct * iam_clean + poa_sky * sky_mult + poa_ground * ground_mult
+
+    return poa_direct * iam_clean + poa_diffuse

--- a/breos/pv/iam.py
+++ b/breos/pv/iam.py
@@ -1,4 +1,10 @@
-"""Focused incidence-angle modifier kernels used by :mod:`breos.solar`."""
+"""Focused incidence-angle modifier kernels used by :mod:`breos.solar`.
+
+The beam IAM is always pvlib's ``ashrae``, which is BREOS's historical
+behaviour; the diffuse components are only weighted when the caller opted in
+via ``diffuse_iam="marion"``. Inputs are assumed already validated by
+:mod:`breos.pv.model_options`.
+"""
 
 from __future__ import annotations
 
@@ -7,13 +13,29 @@ import math
 import numpy as np
 import pvlib
 
+# Tilt resolution of the cached Marion multiplier grid. The integrated sky and
+# ground multipliers vary smoothly and slowly over tilt, so 0.5 degrees is far
+# finer than the ~0.5-1% effect the diffuse IAM itself corrects for.
 _MARION_DIFFUSE_GRID_STEP_DEG = 0.5
+
+# (lo, hi, step) -> (tilt grid, {"sky"/"ground": multipliers}). Keyed by the
+# rounded-out tilt span so repeated years or Monte Carlo runs over the same
+# tracker geometry reuse one grid. Unbounded, but each entry is a few thousand
+# floats and the number of distinct spans in a session is tiny.
 _marion_diffuse_grid_cache: dict[tuple[float, float, float], tuple[np.ndarray, dict[str, np.ndarray]]] = {}
 
 
 def _marion_diffuse_ashrae(surface_tilt):
-    """Return Marion diffuse IAM for Ashrae, interpolating large tilt arrays."""
+    """Return Marion diffuse IAM for ashrae, interpolating large tilt arrays.
+
+    pvlib's exact Marion integration is fast for fixed tilt but expensive for
+    tracker arrays with thousands of distinct angles. The integrated
+    sky/ground multipliers are smooth over tilt, so a cached 0.5 degree grid
+    keeps tracker runs tractable without changing the scalar fixed-tilt path.
+    """
     tilt_array = np.asarray(surface_tilt, dtype=float)
+    # Small inputs (scalar fixed tilt, or a handful of angles) go straight to
+    # pvlib so the common case stays bit-for-bit exact.
     if tilt_array.ndim == 0 or tilt_array.size <= 16:
         return pvlib.iam.marion_diffuse("ashrae", surface_tilt)
 
@@ -40,18 +62,30 @@ def _marion_diffuse_ashrae(surface_tilt):
         )
 
     grid, values = _marion_diffuse_grid_cache[key]
+    # NaN tilts (below-horizon tracker steps) are pinned to the grid floor;
+    # their POA components are zeroed by the caller, so the value is unused.
     interp_tilt = np.nan_to_num(tilt_array, nan=lo)
     return {region: np.interp(interp_tilt, grid, region_values) for region, region_values in values.items()}
 
 
 def calculate_front_effective_irradiance(poa, aoi, surface_tilt, diffuse_iam: str) -> np.ndarray:
-    """Apply BREOS's historical Ashrae beam and optional Marion diffuse IAM."""
+    """Apply the ashrae beam IAM and, optionally, the Marion diffuse IAM.
+
+    ``poa`` is the frame returned by ``pvlib.irradiance.get_total_irradiance``
+    and ``diffuse_iam`` must already be one of ``DIFFUSE_IAM_METHODS``. Returns
+    front-side effective irradiance in W/m2, with NaNs zeroed so downstream
+    single-diode and thermal calls never see them.
+    """
     iam = pvlib.iam.ashrae(aoi)
     poa_direct = np.nan_to_num(poa["poa_direct"].values, nan=0.0)
     poa_diffuse = np.nan_to_num(poa["poa_diffuse"].values, nan=0.0)
     iam_clean = np.nan_to_num(np.asarray(iam, dtype=float), nan=0.0)
 
     if diffuse_iam == "marion":
+        # Marion (2017) view-factor-integrated IAM on the diffuse components,
+        # using the same ashrae model as the beam IAM above. Transposition
+        # folds any horizon-brightening term into poa_sky_diffuse, so the sky
+        # multiplier covers it too.
         poa_sky = np.nan_to_num(poa["poa_sky_diffuse"].values, nan=0.0)
         poa_ground = np.nan_to_num(poa["poa_ground_diffuse"].values, nan=0.0)
         multipliers = _marion_diffuse_ashrae(surface_tilt)

--- a/breos/pv/model_options.py
+++ b/breos/pv/model_options.py
@@ -1,4 +1,11 @@
-"""Resolved options for BREOS's internal PV model stage."""
+"""Resolved options for BREOS's internal PV model stage.
+
+Every name a user can pass for an irradiance, optics, thermal, or bifacial
+choice is enumerated, documented, and validated here, so ``breos.solar`` and
+``breos.app_config`` share one definition of what is selectable and what each
+selection means. The kernels in this package assume they are handed an
+already-resolved :class:`PVModelOptions` and do no validation of their own.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +15,11 @@ from dataclasses import dataclass
 import numpy as np
 from pvlib.albedo import SURFACE_ALBEDOS
 
+# Sky-diffusion (transposition) models for projecting GHI/DHI/DNI onto the
+# plane of array, as supported by pvlib.irradiance.get_total_irradiance.
+# ``isotropic`` is the simple, robust baseline (and the default); the
+# anisotropic models are more accurate on clear days but need extra inputs
+# (extraterrestrial DNI and, for the Perez variants, relative airmass).
 TRANSPOSITION_MODELS = (
     "isotropic",
     "klucher",
@@ -19,6 +31,8 @@ TRANSPOSITION_MODELS = (
 )
 DEFAULT_TRANSPOSITION_MODEL = "isotropic"
 
+# Perez sky-diffusion coefficient sets accepted by pvlib's perez model. Only
+# used when ``transposition_model == "perez"``; the default matches pvlib.
 PEREZ_MODELS = (
     "allsitescomposite1990",
     "allsitescomposite1988",
@@ -34,26 +48,56 @@ PEREZ_MODELS = (
 )
 DEFAULT_PEREZ_MODEL = "allsitescomposite1990"
 
+# Named ground-cover types pvlib maps to a ground reflectance (albedo); an
+# alternative to supplying a numeric ``albedo`` directly.
 SURFACE_TYPES = tuple(sorted(SURFACE_ALBEDOS))
 
+# Where within each timestep the solar position is evaluated.
+# ``interval-start`` evaluates at the timestamp itself (the default, and the
+# only prior behaviour). ``mid-interval`` evaluates half a step later, which
+# is the PVWatts/SAM convention for interval-averaged irradiance: an hourly
+# value labelled 07:00 that represents the 07:00-08:00 average pairs with the
+# 07:30 sun position. Use it when the weather source reports interval
+# averages (e.g. ERA5); keep the default for instantaneous samples.
+#
+# Applied in breos.solar._prepare_solarpos_and_weather, which shifts the
+# solar-position times before transposition, so it is resolved separately
+# from PVModelOptions rather than carried on it.
 SOLAR_POSITION_METHODS = (
     "interval-start",
     "mid-interval",
 )
 DEFAULT_SOLAR_POSITION = "interval-start"
 
+# Whether the incidence-angle modifier is applied to the diffuse POA
+# components. ``none`` applies IAM to beam only, with diffuse passing at 1.0
+# — the default and the only prior behaviour, a known ~0.5-1% systematic
+# overestimate. ``marion`` additionally weighs the sky- and ground-diffuse
+# components with the same ashrae IAM integrated over their view factors
+# (Marion 2017, via pvlib's ``iam.marion_diffuse``).
 DIFFUSE_IAM_METHODS = (
     "none",
     "marion",
 )
 DEFAULT_DIFFUSE_IAM = "none"
 
+# Rear-side irradiance is opt-in. ``none`` preserves the historical front-only
+# model exactly; ``infinite_sheds`` uses pvlib's row-geometry model for the back
+# surface while leaving BREOS's existing front-side transposition unchanged.
 BIFACIAL_MODELS = (
     "none",
     "infinite_sheds",
 )
 DEFAULT_BIFACIAL_MODEL = "none"
 
+# Cell-temperature model and mounting presets. ``faiman`` is pvlib's Faiman
+# (2008) model with its open-rack default coefficients (u0=25, u1=6.84) —
+# the default and the only prior behaviour. The ``pvsyst-*`` presets use
+# pvlib's PVsyst cell model with its documented mounting parameter sets:
+# free-standing coefficients run cool for roof-mounted systems, so rooftop
+# studies should pick the mounting-appropriate preset (``semi-integrated``
+# for close roof mounts with a rear air gap, ``insulated`` for fully
+# building-integrated modules with no rear ventilation).
 TEMPERATURE_MODELS = (
     "faiman",
     "pvsyst-freestanding",
@@ -63,9 +107,76 @@ TEMPERATURE_MODELS = (
 DEFAULT_TEMPERATURE_MODEL = "faiman"
 
 
+# --------------------------------------------------------------------------
+# Shared predicates
+#
+# These carry the *rules* only, never the phrasing. ``breos.app_config`` and
+# the resolvers below check the same conditions but must report them
+# differently: config validation speaks in config keys ("'pv_arrays[0].gcr'
+# must be ...") and treats ``None`` as "not set" for per-array overrides,
+# while the resolvers speak in argument names ("gcr must be ...") and treat
+# ``None`` as a value. Folding the messages together would flatten one of
+# those behaviours, so each caller formats its own error and only the
+# predicate is shared. Adding a selectable model in a later slice means
+# adding one tuple above and using ``is_known_model`` against it — not a
+# third copy of the membership rule.
+# --------------------------------------------------------------------------
+
+
+def normalise_model_name(value) -> str:
+    """Canonicalise a user-supplied model name for a membership check.
+
+    Model names are matched case- and whitespace-insensitively, so config
+    files and keyword arguments accept ``"Perez"`` and ``" perez "`` alike.
+    Non-strings are stringified rather than rejected, which is what makes
+    ``resolve_*`` report an unknown-name error (listing the valid names) for
+    e.g. an integer instead of a bare ``TypeError``.
+    """
+    return str(value).strip().lower()
+
+
+def is_known_model(value, valid: tuple[str, ...]) -> bool:
+    """Return whether *value* names one of *valid* after normalisation."""
+    return normalise_model_name(value) in valid
+
+
+def is_valid_albedo(value) -> bool:
+    """Return whether *value* is a ground reflectance in [0, 1].
+
+    Deliberately does not type-check: a non-numeric ``value`` raises
+    ``TypeError`` from the comparison, which is the long-standing behaviour of
+    the keyword-argument path. Callers that owe the user a friendlier message
+    (``breos.app_config``) check the type themselves first.
+    """
+    return 0.0 <= value <= 1.0
+
+
+def is_valid_gcr(value) -> bool:
+    """Return whether *value* is a ground coverage ratio in (0, 1].
+
+    Zero is excluded because a zero-coverage array has no rows to model, and
+    values above 1 would mean the modules cover more than the ground beneath
+    them. Callers pass an already-finite number.
+    """
+    return 0.0 < float(value) <= 1.0
+
+
 @dataclass(frozen=True)
 class PVModelOptions:
-    """Validated choices consumed by the internal irradiance/PV kernels."""
+    """Validated choices consumed by the internal irradiance/PV kernels.
+
+    Build one of these with :func:`resolve_pv_model_options` — never by hand.
+    Constructing it directly bypasses every check in this module, and the
+    kernels downstream trust their fields without re-validating. Frozen so a
+    resolved set cannot drift between the transposition, IAM, thermal, and
+    bifacial stages of a single production run.
+
+    ``albedo`` and ``surface_type`` are mutually exclusive and both may be
+    ``None``, in which case pvlib's own 0.25 default applies. ``bifaciality``
+    comes from the PV module's metadata rather than from user config, and the
+    ``gcr``/``pvrow_height``/``pvrow_pitch`` row geometry is only required
+    (and only validated) when ``bifacial_model`` is not ``"none"``.
+    """
 
     transposition_model: str
     albedo: float | None
@@ -82,47 +193,42 @@ class PVModelOptions:
 
 def resolve_transposition_model(model: str) -> str:
     """Normalise and validate a sky-diffusion transposition model name."""
-    normalised = str(model).strip().lower()
-    if normalised not in TRANSPOSITION_MODELS:
+    if not is_known_model(model, TRANSPOSITION_MODELS):
         valid = ", ".join(TRANSPOSITION_MODELS)
         raise ValueError(f"Unknown transposition model {model!r}. Valid models: {valid}")
-    return normalised
+    return normalise_model_name(model)
 
 
 def resolve_solar_position_method(method: str) -> str:
     """Normalise and validate a solar-position evaluation method name."""
-    normalised = str(method).strip().lower()
-    if normalised not in SOLAR_POSITION_METHODS:
+    if not is_known_model(method, SOLAR_POSITION_METHODS):
         valid = ", ".join(SOLAR_POSITION_METHODS)
         raise ValueError(f"Unknown solar position method {method!r}. Valid methods: {valid}")
-    return normalised
+    return normalise_model_name(method)
 
 
 def resolve_diffuse_iam_method(method: str) -> str:
     """Normalise and validate a diffuse-IAM method name."""
-    normalised = str(method).strip().lower()
-    if normalised not in DIFFUSE_IAM_METHODS:
+    if not is_known_model(method, DIFFUSE_IAM_METHODS):
         valid = ", ".join(DIFFUSE_IAM_METHODS)
         raise ValueError(f"Unknown diffuse IAM method {method!r}. Valid methods: {valid}")
-    return normalised
+    return normalise_model_name(method)
 
 
 def resolve_temperature_model(model: str) -> str:
     """Normalise and validate a cell-temperature model / mounting preset."""
-    normalised = str(model).strip().lower()
-    if normalised not in TEMPERATURE_MODELS:
+    if not is_known_model(model, TEMPERATURE_MODELS):
         valid = ", ".join(TEMPERATURE_MODELS)
         raise ValueError(f"Unknown temperature model {model!r}. Valid models: {valid}")
-    return normalised
+    return normalise_model_name(model)
 
 
 def resolve_bifacial_model(model: str) -> str:
     """Normalise and validate a rear-irradiance model name."""
-    normalised = str(model).strip().lower()
-    if normalised not in BIFACIAL_MODELS:
+    if not is_known_model(model, BIFACIAL_MODELS):
         valid = ", ".join(BIFACIAL_MODELS)
         raise ValueError(f"Unknown bifacial model {model!r}. Valid models: {valid}")
-    return normalised
+    return normalise_model_name(model)
 
 
 def validate_bifacial_inputs(
@@ -132,7 +238,16 @@ def validate_bifacial_inputs(
     pvrow_height: float | None,
     pvrow_pitch: float | None,
 ) -> str:
-    """Validate opt-in bifacial metadata and row geometry."""
+    """Validate opt-in bifacial metadata and row geometry, returning the model.
+
+    Row geometry is only meaningful once a rear-side model is selected, so the
+    ``none`` path returns early and leaves ``gcr``/``pvrow_*`` unchecked — the
+    fixed-tilt and tracking paths carry their own ``gcr`` default that has
+    nothing to do with bifacial modeling. ``bifaciality`` is module metadata,
+    not user config: a ``None`` here means the selected PV module was never
+    characterised for rear-side gain, which is a configuration error rather
+    than a reason to silently fall back to front-only production.
+    """
     model = resolve_bifacial_model(model)
     if model == "none":
         return model
@@ -149,7 +264,7 @@ def validate_bifacial_inputs(
             raise TypeError(f"{name} must be a finite number for bifacial modeling")
         if not math.isfinite(float(value)):
             raise ValueError(f"{name} must be a finite number for bifacial modeling")
-    if not 0.0 < float(gcr) <= 1.0:
+    if not is_valid_gcr(gcr):
         raise ValueError("gcr must be between 0 (exclusive) and 1 (inclusive) for bifacial modeling")
     if float(pvrow_height) <= 0.0:
         raise ValueError("pvrow_height must be > 0 for bifacial modeling")
@@ -167,13 +282,19 @@ def resolve_perez_model(model_perez: str) -> str:
 
 
 def resolve_ground_reflectance(albedo, surface_type):
-    """Validate ground-reflectance inputs and return their resolved pair."""
+    """Validate the ground-reflectance inputs and return ``(albedo, surface_type)``.
+
+    Accepts either a numeric ``albedo`` (0-1) or a named ``surface_type`` from
+    ``SURFACE_TYPES`` (which pvlib maps to an albedo), but not both. Both may
+    be ``None``; the pair is passed through unchanged for the transposition
+    call to turn into pvlib's ``albedo``/``surface_type`` keyword.
+    """
     if albedo is not None and surface_type is not None:
         raise ValueError("Set either 'albedo' or 'surface_type', not both.")
     if surface_type is not None and surface_type not in SURFACE_ALBEDOS:
         valid = ", ".join(SURFACE_TYPES)
         raise ValueError(f"Unknown surface_type {surface_type!r}. Valid types: {valid}")
-    if albedo is not None and not 0.0 <= albedo <= 1.0:
+    if albedo is not None and not is_valid_albedo(albedo):
         raise ValueError(f"albedo must be between 0 and 1, got {albedo!r}")
     return albedo, surface_type
 
@@ -192,7 +313,15 @@ def resolve_pv_model_options(
     pvrow_height: float | None = None,
     pvrow_pitch: float | None = None,
 ) -> PVModelOptions:
-    """Resolve and validate one complete set of PV-kernel choices."""
+    """Resolve and validate one complete set of PV-kernel choices.
+
+    The only supported way to build a :class:`PVModelOptions`. Call it once
+    per production run, before any irradiance work, so a bad model name fails
+    before the expensive transposition rather than midway through it.
+
+    Raises ``ValueError`` (or ``TypeError`` for non-numeric bifacial geometry)
+    naming the offending option and its valid values.
+    """
     transposition_model = resolve_transposition_model(transposition_model)
     albedo, surface_type = resolve_ground_reflectance(albedo, surface_type)
     model_perez = resolve_perez_model(model_perez)

--- a/breos/pv/model_options.py
+++ b/breos/pv/model_options.py
@@ -1,0 +1,220 @@
+"""Resolved options for BREOS's internal PV model stage."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from pvlib.albedo import SURFACE_ALBEDOS
+
+TRANSPOSITION_MODELS = (
+    "isotropic",
+    "klucher",
+    "haydavies",
+    "reindl",
+    "king",
+    "perez",
+    "perez-driesse",
+)
+DEFAULT_TRANSPOSITION_MODEL = "isotropic"
+
+PEREZ_MODELS = (
+    "allsitescomposite1990",
+    "allsitescomposite1988",
+    "sandiacomposite1988",
+    "usacomposite1988",
+    "france1988",
+    "phoenix1988",
+    "elmonte1988",
+    "osage1988",
+    "albuquerque1988",
+    "capecanaveral1988",
+    "albany1988",
+)
+DEFAULT_PEREZ_MODEL = "allsitescomposite1990"
+
+SURFACE_TYPES = tuple(sorted(SURFACE_ALBEDOS))
+
+SOLAR_POSITION_METHODS = (
+    "interval-start",
+    "mid-interval",
+)
+DEFAULT_SOLAR_POSITION = "interval-start"
+
+DIFFUSE_IAM_METHODS = (
+    "none",
+    "marion",
+)
+DEFAULT_DIFFUSE_IAM = "none"
+
+BIFACIAL_MODELS = (
+    "none",
+    "infinite_sheds",
+)
+DEFAULT_BIFACIAL_MODEL = "none"
+
+TEMPERATURE_MODELS = (
+    "faiman",
+    "pvsyst-freestanding",
+    "pvsyst-semi-integrated",
+    "pvsyst-insulated",
+)
+DEFAULT_TEMPERATURE_MODEL = "faiman"
+
+
+@dataclass(frozen=True)
+class PVModelOptions:
+    """Validated choices consumed by the internal irradiance/PV kernels."""
+
+    transposition_model: str
+    albedo: float | None
+    surface_type: str | None
+    model_perez: str
+    diffuse_iam: str
+    temperature_model: str
+    bifacial_model: str
+    bifaciality: float | None
+    gcr: float
+    pvrow_height: float | None
+    pvrow_pitch: float | None
+
+
+def resolve_transposition_model(model: str) -> str:
+    """Normalise and validate a sky-diffusion transposition model name."""
+    normalised = str(model).strip().lower()
+    if normalised not in TRANSPOSITION_MODELS:
+        valid = ", ".join(TRANSPOSITION_MODELS)
+        raise ValueError(f"Unknown transposition model {model!r}. Valid models: {valid}")
+    return normalised
+
+
+def resolve_solar_position_method(method: str) -> str:
+    """Normalise and validate a solar-position evaluation method name."""
+    normalised = str(method).strip().lower()
+    if normalised not in SOLAR_POSITION_METHODS:
+        valid = ", ".join(SOLAR_POSITION_METHODS)
+        raise ValueError(f"Unknown solar position method {method!r}. Valid methods: {valid}")
+    return normalised
+
+
+def resolve_diffuse_iam_method(method: str) -> str:
+    """Normalise and validate a diffuse-IAM method name."""
+    normalised = str(method).strip().lower()
+    if normalised not in DIFFUSE_IAM_METHODS:
+        valid = ", ".join(DIFFUSE_IAM_METHODS)
+        raise ValueError(f"Unknown diffuse IAM method {method!r}. Valid methods: {valid}")
+    return normalised
+
+
+def resolve_temperature_model(model: str) -> str:
+    """Normalise and validate a cell-temperature model / mounting preset."""
+    normalised = str(model).strip().lower()
+    if normalised not in TEMPERATURE_MODELS:
+        valid = ", ".join(TEMPERATURE_MODELS)
+        raise ValueError(f"Unknown temperature model {model!r}. Valid models: {valid}")
+    return normalised
+
+
+def resolve_bifacial_model(model: str) -> str:
+    """Normalise and validate a rear-irradiance model name."""
+    normalised = str(model).strip().lower()
+    if normalised not in BIFACIAL_MODELS:
+        valid = ", ".join(BIFACIAL_MODELS)
+        raise ValueError(f"Unknown bifacial model {model!r}. Valid models: {valid}")
+    return normalised
+
+
+def validate_bifacial_inputs(
+    model: str,
+    bifaciality: float | None,
+    gcr: float,
+    pvrow_height: float | None,
+    pvrow_pitch: float | None,
+) -> str:
+    """Validate opt-in bifacial metadata and row geometry."""
+    model = resolve_bifacial_model(model)
+    if model == "none":
+        return model
+    if bifaciality is None:
+        raise ValueError("bifacial_model='infinite_sheds' requires PV module bifaciality metadata")
+
+    geometry = {
+        "gcr": gcr,
+        "pvrow_height": pvrow_height,
+        "pvrow_pitch": pvrow_pitch,
+    }
+    for name, value in geometry.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+            raise TypeError(f"{name} must be a finite number for bifacial modeling")
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{name} must be a finite number for bifacial modeling")
+    if not 0.0 < float(gcr) <= 1.0:
+        raise ValueError("gcr must be between 0 (exclusive) and 1 (inclusive) for bifacial modeling")
+    if float(pvrow_height) <= 0.0:
+        raise ValueError("pvrow_height must be > 0 for bifacial modeling")
+    if float(pvrow_pitch) <= 0.0:
+        raise ValueError("pvrow_pitch must be > 0 for bifacial modeling")
+    return model
+
+
+def resolve_perez_model(model_perez: str) -> str:
+    """Validate the Perez coefficient set name."""
+    if model_perez not in PEREZ_MODELS:
+        valid = ", ".join(PEREZ_MODELS)
+        raise ValueError(f"Unknown Perez coefficient model {model_perez!r}. Valid models: {valid}")
+    return model_perez
+
+
+def resolve_ground_reflectance(albedo, surface_type):
+    """Validate ground-reflectance inputs and return their resolved pair."""
+    if albedo is not None and surface_type is not None:
+        raise ValueError("Set either 'albedo' or 'surface_type', not both.")
+    if surface_type is not None and surface_type not in SURFACE_ALBEDOS:
+        valid = ", ".join(SURFACE_TYPES)
+        raise ValueError(f"Unknown surface_type {surface_type!r}. Valid types: {valid}")
+    if albedo is not None and not 0.0 <= albedo <= 1.0:
+        raise ValueError(f"albedo must be between 0 and 1, got {albedo!r}")
+    return albedo, surface_type
+
+
+def resolve_pv_model_options(
+    *,
+    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
+    albedo: float | None = None,
+    surface_type: str | None = None,
+    model_perez: str = DEFAULT_PEREZ_MODEL,
+    diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
+    temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
+    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
+    bifaciality: float | None = None,
+    gcr: float = 0.35,
+    pvrow_height: float | None = None,
+    pvrow_pitch: float | None = None,
+) -> PVModelOptions:
+    """Resolve and validate one complete set of PV-kernel choices."""
+    transposition_model = resolve_transposition_model(transposition_model)
+    albedo, surface_type = resolve_ground_reflectance(albedo, surface_type)
+    model_perez = resolve_perez_model(model_perez)
+    diffuse_iam = resolve_diffuse_iam_method(diffuse_iam)
+    temperature_model = resolve_temperature_model(temperature_model)
+    bifacial_model = validate_bifacial_inputs(
+        bifacial_model,
+        bifaciality,
+        gcr,
+        pvrow_height,
+        pvrow_pitch,
+    )
+    return PVModelOptions(
+        transposition_model=transposition_model,
+        albedo=albedo,
+        surface_type=surface_type,
+        model_perez=model_perez,
+        diffuse_iam=diffuse_iam,
+        temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        bifaciality=bifaciality,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
+    )

--- a/breos/pv/temperature.py
+++ b/breos/pv/temperature.py
@@ -1,0 +1,21 @@
+"""Focused cell-temperature kernels used by :mod:`breos.solar`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pvlib
+
+_PVSYST_MOUNTING = {
+    "pvsyst-freestanding": "freestanding",
+    "pvsyst-semi-integrated": "semi_integrated",
+    "pvsyst-insulated": "insulated",
+}
+
+
+def calculate_cell_temperature(poa_global, temp_air, wind_speed, temperature_model: str) -> np.ndarray:
+    """Run one already-resolved BREOS cell-temperature model."""
+    if temperature_model == "faiman":
+        return pvlib.temperature.faiman(poa_global, temp_air, wind_speed)
+
+    params = pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS["pvsyst"][_PVSYST_MOUNTING[temperature_model]]
+    return pvlib.temperature.pvsyst_cell(poa_global, temp_air, wind_speed, **params)

--- a/breos/pv/temperature.py
+++ b/breos/pv/temperature.py
@@ -1,10 +1,19 @@
-"""Focused cell-temperature kernels used by :mod:`breos.solar`."""
+"""Focused cell-temperature kernels used by :mod:`breos.solar`.
+
+Both models are driven by plane-of-array irradiance (pre-IAM), which is what
+pvlib's thermal models expect: they describe the heat actually absorbed by the
+module, not the fraction of it that reaches the cell as usable photons. For a
+bifacial system the caller composes front-side ``poa_global`` with the
+bifaciality-weighted rear irradiance first, so rear gain contributes heat as
+well as power; a front-only system passes ``poa_global`` unchanged.
+"""
 
 from __future__ import annotations
 
 import numpy as np
 import pvlib
 
+# pvsyst-* preset -> key into pvlib's TEMPERATURE_MODEL_PARAMETERS["pvsyst"].
 _PVSYST_MOUNTING = {
     "pvsyst-freestanding": "freestanding",
     "pvsyst-semi-integrated": "semi_integrated",
@@ -13,8 +22,17 @@ _PVSYST_MOUNTING = {
 
 
 def calculate_cell_temperature(poa_global, temp_air, wind_speed, temperature_model: str) -> np.ndarray:
-    """Run one already-resolved BREOS cell-temperature model."""
+    """Run one already-resolved BREOS cell-temperature model.
+
+    ``temperature_model`` must already be one of ``TEMPERATURE_MODELS``; an
+    unrecognised name raises ``KeyError`` here rather than being validated,
+    because :func:`breos.pv.model_options.resolve_temperature_model` owns that
+    check. The pvsyst presets deliberately take pvlib's default
+    ``module_efficiency``/``alpha_absorption`` — feeding the catalog's real
+    module efficiency in is a separate, behaviour-changing 0.5.0 slice.
+    """
     if temperature_model == "faiman":
+        # pvlib's open-rack defaults (u0=25, u1=6.84); BREOS's historical path.
         return pvlib.temperature.faiman(poa_global, temp_air, wind_speed)
 
     params = pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS["pvsyst"][_PVSYST_MOUNTING[temperature_model]]

--- a/breos/runners/app.py
+++ b/breos/runners/app.py
@@ -8,12 +8,12 @@ from typing import Any
 
 import pandas as pd
 
-from breos.app_config import ResolvedAppConfig, build_costs_dict
+from breos.app_config import DEFAULTS, ResolvedAppConfig, build_costs_dict, default_module_key
 from breos.app_inputs import AppRuntimeDependencies, prepare_simulation_inputs
 from breos.battery import BatteryConfig, simulate_energy_balance
 from breos.degradation.results import build_degradation_summary_from_state
 from breos.economics import calculate_lcoe_from_projection, cost_analysis_projection, find_payback_year
-from breos.pv_modules import MODULES, get_module
+from breos.pv_modules import get_module
 from breos.solar import PVProductionBreakdown
 from breos.utils import get_hours_per_step
 
@@ -74,8 +74,8 @@ def _bifacial_summary(
     rear_gain_dc_kwh: float,
 ) -> dict[str, Any]:
     """Build JSON-safe bifacial configuration and year-1 gain provenance."""
-    default_model = cfg.get("bifacial_model", "none")
-    default_gcr = cfg.get("gcr", 0.35)
+    default_model = cfg.get("bifacial_model", DEFAULTS["bifacial_model"])
+    default_gcr = cfg.get("gcr", DEFAULTS["gcr"])
     default_height = cfg.get("pvrow_height")
     default_pitch = cfg.get("pvrow_pitch")
     resolved_arrays = getattr(resolved, "pv_arrays", None)
@@ -85,7 +85,7 @@ def _bifacial_summary(
         arrays = [
             {
                 "modules": cfg["n_modules"],
-                "module": cfg.get("pv_module") or next(iter(MODULES)),
+                "module": cfg.get("pv_module") or default_module_key(),
                 "bifacial_model": default_model,
                 "gcr": default_gcr,
                 "pvrow_height": default_height,
@@ -97,7 +97,7 @@ def _bifacial_summary(
     models: set[str] = set()
     for index, array in enumerate(arrays):
         model = str(array.get("bifacial_model", default_model)).strip().lower()
-        module_key = array.get("module") or cfg.get("pv_module") or next(iter(MODULES))
+        module_key = array.get("module") or cfg.get("pv_module") or default_module_key()
         module = get_module(module_key)
         models.add(model)
         row: dict[str, Any] = {

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -343,47 +343,6 @@ def _compute_irradiance_and_cell_temp_detail(
     )
 
 
-def _compute_effective_irradiance_and_cell_temp(
-    weather_aligned: pd.DataFrame,
-    solarpos: pd.DataFrame,
-    surface_tilt,
-    surface_azimuth,
-    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
-    albedo: Optional[float] = None,
-    surface_type: Optional[str] = None,
-    model_perez: str = DEFAULT_PEREZ_MODEL,
-    diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
-    temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
-    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
-    bifaciality: Optional[float] = None,
-    gcr: float = 0.35,
-    pvrow_height: Optional[float] = None,
-    pvrow_pitch: Optional[float] = None,
-):
-    """Compute effective POA irradiance (with IAM) and cell temperature."""
-    model_options = resolve_pv_model_options(
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        bifaciality=bifaciality,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
-    )
-    detail = _compute_irradiance_and_cell_temp_detail(
-        weather_aligned,
-        solarpos,
-        surface_tilt=surface_tilt,
-        surface_azimuth=surface_azimuth,
-        model_options=model_options,
-    )
-    return detail.effective_irradiance, detail.temp_cell
-
-
 def _get_cec_params(pv_params: "PVModuleParams"):
     """Fetch (and cache) CEC single-diode model params for a module."""
     key = (

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -58,6 +58,62 @@ DEFAULT_PVWATTS_LOSSES: Dict[str, float] = {
     "availability": 3.0,
 }
 
+# The PV model-option block every public ``calculate_pv_production_*`` entry
+# point accepts. Each of those functions still declares these explicitly —
+# the signature is the documentation, and ``**kwargs`` would silently swallow
+# a misspelled option — but the wrappers that only forward the block use this
+# tuple instead of re-listing it, so adding an option is one edit here plus
+# one per signature rather than one per call site too.
+_MODEL_OPTION_KEYS = (
+    "transposition_model",
+    "albedo",
+    "surface_type",
+    "model_perez",
+    "solar_position",
+    "diffuse_iam",
+    "temperature_model",
+    "bifacial_model",
+    "gcr",
+    "pvrow_height",
+    "pvrow_pitch",
+)
+
+# On the tracking entry points ``gcr`` is tracker row geometry with its own
+# argument slot next to ``backtrack`` and ``cross_axis_tilt``, so it is
+# forwarded there rather than as part of the model-option block.
+_TRACKING_MODEL_OPTION_KEYS = tuple(key for key in _MODEL_OPTION_KEYS if key != "gcr")
+
+# Model options a single array in ``calculate_multi_array_production_breakdown``
+# may override. ``diffuse_iam``, ``temperature_model`` and ``solar_position``
+# are deliberately absent: they are function-level for every array. That
+# asymmetry is intentional and documented on the public function — sky and
+# ground geometry genuinely differ between arrays on one building, whereas the
+# thermal model and the solar-position convention describe the simulation, not
+# the array.
+_PER_ARRAY_MODEL_OPTION_KEYS = (
+    "transposition_model",
+    "albedo",
+    "surface_type",
+    "model_perez",
+    "bifacial_model",
+    "gcr",
+    "pvrow_height",
+    "pvrow_pitch",
+)
+_FUNCTION_LEVEL_MODEL_OPTION_KEYS = tuple(key for key in _MODEL_OPTION_KEYS if key not in _PER_ARRAY_MODEL_OPTION_KEYS)
+
+
+def _model_option_kwargs(caller_locals: Dict[str, Any], keys: tuple = _MODEL_OPTION_KEYS) -> Dict[str, Any]:
+    """Pick the shared model-option block out of a caller's ``locals()``.
+
+    Call this from a wrapper that only forwards its options, passing
+    ``locals()`` before any of the named options is rebound, so the result is
+    the arguments as the caller received them rather than anything derived
+    later in the body. Missing a key is a ``KeyError`` at the call, which is
+    what keeps the tuple and the signatures from drifting apart silently.
+    """
+    return {key: caller_locals[key] for key in keys}
+
 
 def resolve_pvwatts_losses(
     loss_overrides: Optional[Dict[str, float]] = None,
@@ -216,33 +272,18 @@ def _compute_irradiance_and_cell_temp_detail(
     surface_tilt / surface_azimuth may be scalars (fixed) or per-timestep arrays/Series
     (tracking). Uses pvlib.irradiance.get_total_irradiance which is array-aware.
 
-    ``model_options.transposition_model`` selects the sky-diffusion model (see
-    ``TRANSPOSITION_MODELS``); the default ``"isotropic"`` reproduces prior
-    behaviour bit-for-bit. ``albedo`` (0-1) or ``surface_type`` (see
-    ``SURFACE_TYPES``) sets the ground reflectance for the ground-diffuse
-    component; when neither is given pvlib's 0.25 default applies.
-    ``model_perez`` selects the Perez coefficient set (only used by the
-    ``"perez"`` model). ``diffuse_iam`` selects whether IAM is also applied
-    to the diffuse components (see ``DIFFUSE_IAM_METHODS``); the default
-    ``"none"`` reproduces prior behaviour bit-for-bit. ``temperature_model``
-    selects the cell-temperature model / mounting preset (see
-    ``TEMPERATURE_MODELS``); the default ``"faiman"`` reproduces prior
-    behaviour bit-for-bit, and the pvsyst presets use pvlib's default
-    ``module_efficiency``/``alpha_absorption``. The cell-temperature model is
-    driven by front-side ``poa_global`` plus the bifaciality-weighted rear
-    irradiance, so rear gain contributes heat as well as power; with
-    ``bifacial_model="none"`` the rear term is zero and the result is unchanged.
+    ``model_options`` must come from
+    :func:`breos.pv.model_options.resolve_pv_model_options`; every model name
+    and geometry value it carries is taken as already validated. Its BREOS
+    defaults (isotropic transposition, beam-only IAM, faiman cell temperature,
+    no rear-side model, pvlib's own 0.25 albedo) reproduce pre-0.4 behaviour
+    bit-for-bit — see ``breos.pv.model_options`` for what each choice means.
+
+    The cell-temperature model is driven by front-side ``poa_global`` plus the
+    bifaciality-weighted rear irradiance, so rear gain contributes heat as well
+    as power; with ``bifacial_model="none"`` the rear term is zero and the
+    result is unchanged.
     """
-    model = model_options.transposition_model
-    albedo = model_options.albedo
-    surface_type = model_options.surface_type
-    model_perez = model_options.model_perez
-    diffuse_iam = model_options.diffuse_iam
-    bifacial_model = model_options.bifacial_model
-    bifaciality = model_options.bifaciality
-    gcr = model_options.gcr
-    pvrow_height = model_options.pvrow_height
-    pvrow_pitch = model_options.pvrow_pitch
     dni, ghi, dhi = _extract_irradiance(weather_aligned)
     temp_air, wind_speed = _extract_met_data(weather_aligned)
 
@@ -257,10 +298,10 @@ def _compute_irradiance_and_cell_temp_detail(
     # Only forward ground-reflectance overrides when set, so the default path
     # keeps pvlib's built-in albedo and stays bit-for-bit identical.
     ground_kwargs: Dict[str, Any] = {}
-    if albedo is not None:
-        ground_kwargs["albedo"] = albedo
-    if surface_type is not None:
-        ground_kwargs["surface_type"] = surface_type
+    if model_options.albedo is not None:
+        ground_kwargs["albedo"] = model_options.albedo
+    if model_options.surface_type is not None:
+        ground_kwargs["surface_type"] = model_options.surface_type
 
     # apparent_zenith (refraction-corrected) everywhere, matching pvlib's
     # ModelChain; aoi above uses it too. Mixing true and apparent zenith in
@@ -275,8 +316,8 @@ def _compute_irradiance_and_cell_temp_detail(
         dhi=dhi,
         dni_extra=dni_extra,
         airmass=airmass,
-        model=model,
-        model_perez=model_perez,
+        model=model_options.transposition_model,
+        model_perez=model_options.model_perez,
         **ground_kwargs,
     )
 
@@ -285,24 +326,33 @@ def _compute_irradiance_and_cell_temp_detail(
         poa,
         aoi,
         surface_tilt,
-        diffuse_iam,
+        model_options.diffuse_iam,
     )
 
-    if bifacial_model == "infinite_sheds":
+    if model_options.bifacial_model == "infinite_sheds":
         tilt = np.asarray(surface_tilt, dtype=float)
         azimuth = np.asarray(surface_azimuth, dtype=float)
         back_tilt = 180.0 - tilt
         back_azimuth = np.mod(azimuth + 180.0, 360.0)
-        rear_transposition = "haydavies" if model == "haydavies" else "isotropic"
-        rear_albedo = float(albedo) if albedo is not None else float(SURFACE_ALBEDOS.get(surface_type, 0.25))
+        # infinite_sheds only accepts 'isotropic' or 'haydavies', so the rear
+        # side matches the front only when the front is one of those; every
+        # other front model falls back to isotropic rather than failing.
+        rear_transposition = "haydavies" if model_options.transposition_model == "haydavies" else "isotropic"
+        # Rear ground reflectance must be a number here (infinite_sheds takes
+        # no surface_type), so resolve the named type to pvlib's albedo value.
+        rear_albedo = (
+            float(model_options.albedo)
+            if model_options.albedo is not None
+            else float(SURFACE_ALBEDOS.get(model_options.surface_type, 0.25))
+        )
         rear = pvlib.bifacial.infinite_sheds.get_irradiance_poa(
             surface_tilt=back_tilt,
             surface_azimuth=back_azimuth,
             solar_zenith=np.asarray(solarpos.apparent_zenith, dtype=float),
             solar_azimuth=np.asarray(solarpos.azimuth, dtype=float),
-            gcr=float(gcr),
-            height=float(pvrow_height),
-            pitch=float(pvrow_pitch),
+            gcr=float(model_options.gcr),
+            height=float(model_options.pvrow_height),
+            pitch=float(model_options.pvrow_pitch),
             ghi=np.asarray(ghi, dtype=float),
             dhi=np.asarray(dhi, dtype=float),
             dni=np.asarray(dni, dtype=float),
@@ -312,7 +362,7 @@ def _compute_irradiance_and_cell_temp_detail(
             vectorize=tilt.ndim > 0 and tilt.size > 1,
         )
         rear_poa = np.clip(np.nan_to_num(np.asarray(rear["poa_global"], dtype=float), nan=0.0), 0.0, None)
-        rear_effective_irradiance = float(bifaciality) * rear_poa
+        rear_effective_irradiance = float(model_options.bifaciality) * rear_poa
         effective_irradiance = front_effective_irradiance + rear_effective_irradiance
     else:
         rear_effective_irradiance = np.zeros_like(front_effective_irradiance)
@@ -749,17 +799,7 @@ def calculate_pv_production_dc(
         start_year=start_year,
         verbose=verbose,
         loss_overrides=loss_overrides,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        solar_position=solar_position,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        **_model_option_kwargs(locals()),
     ).dc_after_losses
 
 
@@ -972,16 +1012,7 @@ def calculate_pv_production_dc_tracking(
         start_year=start_year,
         verbose=verbose,
         loss_overrides=loss_overrides,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        solar_position=solar_position,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        **_model_option_kwargs(locals(), _TRACKING_MODEL_OPTION_KEYS),
     ).dc_after_losses
 
 
@@ -1062,17 +1093,7 @@ def calculate_pv_production_tmy(
         freq=freq,
         degradation_rate=0.0,  # TMY doesn't include degradation
         verbose=verbose,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        solar_position=solar_position,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        **_model_option_kwargs(locals()),
     )
 
 
@@ -1126,6 +1147,8 @@ def calculate_pv_production_ac(
     Returns:
         pd.Series with AC power production in Watts
     """
+    model_kwargs = _model_option_kwargs(locals())
+
     if pv_params is None:
         from breos.pv_modules import get_module
 
@@ -1143,17 +1166,7 @@ def calculate_pv_production_ac(
         current_year=current_year,
         start_year=start_year,
         verbose=False,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        solar_position=solar_position,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        **model_kwargs,
     )
 
     pv_peak_power_w = n_modules * pv_params.Mpp
@@ -1347,6 +1360,8 @@ def calculate_multi_array_production_breakdown(
 
     Each array is either fixed-tilt or tracking. Mixed configurations are supported.
     """
+    defaults = _model_option_kwargs(locals())
+
     # Import locally to avoid circular dependencies (if solar imported by pv_modules)
     try:
         from breos.pv_modules import get_module
@@ -1363,14 +1378,11 @@ def calculate_multi_array_production_breakdown(
         mod_name = arr.get("module", "Generic_400W")
         pv_params = get_module(mod_name)
         tracking = arr.get("tracking", "fixed")
-        arr_transposition = arr.get("transposition_model", transposition_model)
-        arr_albedo = arr.get("albedo", albedo)
-        arr_surface_type = arr.get("surface_type", surface_type)
-        arr_model_perez = arr.get("model_perez", model_perez)
-        arr_bifacial_model = arr.get("bifacial_model", bifacial_model)
-        arr_gcr = arr.get("gcr", gcr)
-        arr_pvrow_height = arr.get("pvrow_height", pvrow_height)
-        arr_pvrow_pitch = arr.get("pvrow_pitch", pvrow_pitch)
+        # Sky/ground geometry is per-array overridable; the thermal model and
+        # solar-position convention stay function-level for every array.
+        arr_options = {key: arr.get(key, defaults[key]) for key in _PER_ARRAY_MODEL_OPTION_KEYS}
+        arr_options.update({key: defaults[key] for key in _FUNCTION_LEVEL_MODEL_OPTION_KEYS})
+        arr_gcr = arr_options["gcr"]
 
         if tracking == "fixed":
             tilt = arr.get("tilt", 35)
@@ -1392,17 +1404,7 @@ def calculate_multi_array_production_breakdown(
                 start_year=start_year,
                 verbose=False,
                 loss_overrides=loss_overrides,
-                transposition_model=arr_transposition,
-                albedo=arr_albedo,
-                surface_type=arr_surface_type,
-                model_perez=arr_model_perez,
-                solar_position=solar_position,
-                diffuse_iam=diffuse_iam,
-                temperature_model=temperature_model,
-                bifacial_model=arr_bifacial_model,
-                gcr=arr_gcr,
-                pvrow_height=arr_pvrow_height,
-                pvrow_pitch=arr_pvrow_pitch,
+                **arr_options,
             )
         elif tracking in ("single_axis", "dual_axis"):
             if verbose:
@@ -1434,16 +1436,8 @@ def calculate_multi_array_production_breakdown(
                 start_year=start_year,
                 verbose=False,
                 loss_overrides=loss_overrides,
-                transposition_model=arr_transposition,
-                albedo=arr_albedo,
-                surface_type=arr_surface_type,
-                model_perez=arr_model_perez,
-                solar_position=solar_position,
-                diffuse_iam=diffuse_iam,
-                temperature_model=temperature_model,
-                bifacial_model=arr_bifacial_model,
-                pvrow_height=arr_pvrow_height,
-                pvrow_pitch=arr_pvrow_pitch,
+                # gcr goes in the tracker geometry block above, not here.
+                **{key: value for key, value in arr_options.items() if key != "gcr"},
             )
         else:
             raise ValueError(
@@ -1557,15 +1551,5 @@ def calculate_multi_array_production(
         start_year=start_year,
         verbose=verbose,
         loss_overrides=loss_overrides,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        solar_position=solar_position,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        **_model_option_kwargs(locals()),
     ).dc_after_losses

--- a/breos/solar.py
+++ b/breos/solar.py
@@ -18,6 +18,26 @@ from pvlib.location import Location
 
 from breos.cec_fit import fit_cec_params
 from breos.inverter import calculate_dc_ac_power
+from breos.pv.iam import calculate_front_effective_irradiance
+from breos.pv.model_options import (
+    BIFACIAL_MODELS,
+    DEFAULT_BIFACIAL_MODEL,
+    DEFAULT_DIFFUSE_IAM,
+    DEFAULT_PEREZ_MODEL,
+    DEFAULT_SOLAR_POSITION,
+    DEFAULT_TEMPERATURE_MODEL,
+    DEFAULT_TRANSPOSITION_MODEL,
+    DIFFUSE_IAM_METHODS,
+    PEREZ_MODELS,
+    SOLAR_POSITION_METHODS,
+    SURFACE_TYPES,
+    TEMPERATURE_MODELS,
+    TRANSPOSITION_MODELS,
+    PVModelOptions,
+    resolve_pv_model_options,
+    resolve_solar_position_method,
+)
+from breos.pv.temperature import calculate_cell_temperature
 from breos.utils import get_hours_per_step
 
 # Module-level cache for CEC model parameters (depends only on module specs, not weather)
@@ -67,244 +87,6 @@ def resolve_pvwatts_losses(
         "age_degradation_pct": float(age_degradation_percent),
         "combined_pct": float(combined_percent),
     }
-
-
-# Sky-diffusion (transposition) models for projecting GHI/DHI/DNI onto the
-# plane of array, as supported by pvlib.irradiance.get_total_irradiance.
-# ``isotropic`` is the simple, robust baseline (and the default); the
-# anisotropic models are more accurate on clear days but need extra inputs
-# (extraterrestrial DNI and, for the Perez variants, relative airmass).
-TRANSPOSITION_MODELS = (
-    "isotropic",
-    "klucher",
-    "haydavies",
-    "reindl",
-    "king",
-    "perez",
-    "perez-driesse",
-)
-DEFAULT_TRANSPOSITION_MODEL = "isotropic"
-
-# Perez sky-diffusion coefficient sets accepted by pvlib's perez model. Only
-# used when ``transposition_model == "perez"``; the default matches pvlib.
-PEREZ_MODELS = (
-    "allsitescomposite1990",
-    "allsitescomposite1988",
-    "sandiacomposite1988",
-    "usacomposite1988",
-    "france1988",
-    "phoenix1988",
-    "elmonte1988",
-    "osage1988",
-    "albuquerque1988",
-    "capecanaveral1988",
-    "albany1988",
-)
-DEFAULT_PEREZ_MODEL = "allsitescomposite1990"
-
-# Named ground-cover types pvlib maps to a ground reflectance (albedo); an
-# alternative to supplying a numeric ``albedo`` directly.
-SURFACE_TYPES = tuple(sorted(SURFACE_ALBEDOS))
-
-# Where within each timestep the solar position is evaluated.
-# ``interval-start`` evaluates at the timestamp itself (the default, and the
-# only prior behaviour). ``mid-interval`` evaluates half a step later, which
-# is the PVWatts/SAM convention for interval-averaged irradiance: an hourly
-# value labelled 07:00 that represents the 07:00-08:00 average pairs with the
-# 07:30 sun position. Use it when the weather source reports interval
-# averages (e.g. ERA5); keep the default for instantaneous samples.
-SOLAR_POSITION_METHODS = (
-    "interval-start",
-    "mid-interval",
-)
-DEFAULT_SOLAR_POSITION = "interval-start"
-
-# Whether the incidence-angle modifier is applied to the diffuse POA
-# components. ``none`` applies IAM to beam only, with diffuse passing at 1.0
-# — the default and the only prior behaviour, a known ~0.5-1% systematic
-# overestimate. ``marion`` additionally weighs the sky- and ground-diffuse
-# components with the same ashrae IAM integrated over their view factors
-# (Marion 2017, via pvlib's ``iam.marion_diffuse``).
-DIFFUSE_IAM_METHODS = (
-    "none",
-    "marion",
-)
-DEFAULT_DIFFUSE_IAM = "none"
-_MARION_DIFFUSE_GRID_STEP_DEG = 0.5
-_marion_diffuse_grid_cache: Dict[tuple[float, float, float], tuple[np.ndarray, Dict[str, np.ndarray]]] = {}
-
-# Rear-side irradiance is opt-in. ``none`` preserves the historical front-only
-# model exactly; ``infinite_sheds`` uses pvlib's row-geometry model for the back
-# surface while leaving BREOS's existing front-side transposition unchanged.
-BIFACIAL_MODELS = (
-    "none",
-    "infinite_sheds",
-)
-DEFAULT_BIFACIAL_MODEL = "none"
-
-# Cell-temperature model and mounting presets. ``faiman`` is pvlib's Faiman
-# (2008) model with its open-rack default coefficients (u0=25, u1=6.84) —
-# the default and the only prior behaviour. The ``pvsyst-*`` presets use
-# pvlib's PVsyst cell model with its documented mounting parameter sets:
-# free-standing coefficients run cool for roof-mounted systems, so rooftop
-# studies should pick the mounting-appropriate preset (``semi-integrated``
-# for close roof mounts with a rear air gap, ``insulated`` for fully
-# building-integrated modules with no rear ventilation).
-TEMPERATURE_MODELS = (
-    "faiman",
-    "pvsyst-freestanding",
-    "pvsyst-semi-integrated",
-    "pvsyst-insulated",
-)
-DEFAULT_TEMPERATURE_MODEL = "faiman"
-
-# pvsyst-* preset -> key into pvlib's TEMPERATURE_MODEL_PARAMETERS["pvsyst"].
-_PVSYST_MOUNTING = {
-    "pvsyst-freestanding": "freestanding",
-    "pvsyst-semi-integrated": "semi_integrated",
-    "pvsyst-insulated": "insulated",
-}
-
-
-def _resolve_transposition_model(model: str) -> str:
-    """Normalise and validate a sky-diffusion transposition model name."""
-    normalised = str(model).strip().lower()
-    if normalised not in TRANSPOSITION_MODELS:
-        valid = ", ".join(TRANSPOSITION_MODELS)
-        raise ValueError(f"Unknown transposition model {model!r}. Valid models: {valid}")
-    return normalised
-
-
-def _resolve_solar_position_method(method: str) -> str:
-    """Normalise and validate a solar-position evaluation method name."""
-    normalised = str(method).strip().lower()
-    if normalised not in SOLAR_POSITION_METHODS:
-        valid = ", ".join(SOLAR_POSITION_METHODS)
-        raise ValueError(f"Unknown solar position method {method!r}. Valid methods: {valid}")
-    return normalised
-
-
-def _resolve_diffuse_iam_method(method: str) -> str:
-    """Normalise and validate a diffuse-IAM method name."""
-    normalised = str(method).strip().lower()
-    if normalised not in DIFFUSE_IAM_METHODS:
-        valid = ", ".join(DIFFUSE_IAM_METHODS)
-        raise ValueError(f"Unknown diffuse IAM method {method!r}. Valid methods: {valid}")
-    return normalised
-
-
-def _marion_diffuse_ashrae(surface_tilt):
-    """Return Marion diffuse IAM for ashrae, interpolating large tilt arrays.
-
-    pvlib's exact Marion integration is fast for fixed tilt but expensive for
-    tracker arrays with thousands of distinct angles. The integrated
-    sky/ground multipliers are smooth over tilt, so a cached 0.5 degree grid
-    keeps tracker runs tractable without changing the scalar fixed-tilt path.
-    """
-    tilt_array = np.asarray(surface_tilt, dtype=float)
-    if tilt_array.ndim == 0 or tilt_array.size <= 16:
-        return pvlib.iam.marion_diffuse("ashrae", surface_tilt)
-
-    finite = tilt_array[np.isfinite(tilt_array)]
-    if finite.size == 0:
-        zeros = np.zeros_like(tilt_array, dtype=float)
-        return {"sky": zeros, "ground": zeros}
-
-    step = _MARION_DIFFUSE_GRID_STEP_DEG
-    lo = math.floor(float(finite.min()) / step) * step
-    hi = math.ceil(float(finite.max()) / step) * step
-    key = (lo, hi, step)
-
-    if key not in _marion_diffuse_grid_cache:
-        grid = np.arange(lo, hi + step / 2.0, step)
-        values = {"sky": [], "ground": []}
-        for tilt in grid:
-            exact = pvlib.iam.marion_diffuse("ashrae", float(tilt))
-            values["sky"].append(float(exact["sky"]))
-            values["ground"].append(float(exact["ground"]))
-        _marion_diffuse_grid_cache[key] = (
-            grid,
-            {region: np.asarray(region_values) for region, region_values in values.items()},
-        )
-
-    grid, values = _marion_diffuse_grid_cache[key]
-    interp_tilt = np.nan_to_num(tilt_array, nan=lo)
-    return {region: np.interp(interp_tilt, grid, region_values) for region, region_values in values.items()}
-
-
-def _resolve_temperature_model(model: str) -> str:
-    """Normalise and validate a cell-temperature model / mounting preset name."""
-    normalised = str(model).strip().lower()
-    if normalised not in TEMPERATURE_MODELS:
-        valid = ", ".join(TEMPERATURE_MODELS)
-        raise ValueError(f"Unknown temperature model {model!r}. Valid models: {valid}")
-    return normalised
-
-
-def _resolve_bifacial_model(model: str) -> str:
-    """Normalise and validate a rear-irradiance model name."""
-    normalised = str(model).strip().lower()
-    if normalised not in BIFACIAL_MODELS:
-        valid = ", ".join(BIFACIAL_MODELS)
-        raise ValueError(f"Unknown bifacial model {model!r}. Valid models: {valid}")
-    return normalised
-
-
-def _validate_bifacial_inputs(
-    model: str,
-    bifaciality: Optional[float],
-    gcr: float,
-    pvrow_height: Optional[float],
-    pvrow_pitch: Optional[float],
-) -> str:
-    """Validate opt-in bifacial metadata and row geometry."""
-    model = _resolve_bifacial_model(model)
-    if model == "none":
-        return model
-    if bifaciality is None:
-        raise ValueError("bifacial_model='infinite_sheds' requires PV module bifaciality metadata")
-
-    geometry = {
-        "gcr": gcr,
-        "pvrow_height": pvrow_height,
-        "pvrow_pitch": pvrow_pitch,
-    }
-    for name, value in geometry.items():
-        if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
-            raise TypeError(f"{name} must be a finite number for bifacial modeling")
-        if not math.isfinite(float(value)):
-            raise ValueError(f"{name} must be a finite number for bifacial modeling")
-    if not 0.0 < float(gcr) <= 1.0:
-        raise ValueError("gcr must be between 0 (exclusive) and 1 (inclusive) for bifacial modeling")
-    if float(pvrow_height) <= 0.0:
-        raise ValueError("pvrow_height must be > 0 for bifacial modeling")
-    if float(pvrow_pitch) <= 0.0:
-        raise ValueError("pvrow_pitch must be > 0 for bifacial modeling")
-    return model
-
-
-def _resolve_perez_model(model_perez: str) -> str:
-    """Validate the Perez coefficient set name."""
-    if model_perez not in PEREZ_MODELS:
-        valid = ", ".join(PEREZ_MODELS)
-        raise ValueError(f"Unknown Perez coefficient model {model_perez!r}. Valid models: {valid}")
-    return model_perez
-
-
-def _resolve_ground_reflectance(albedo, surface_type):
-    """Validate the ground-reflectance inputs and return ``(albedo, surface_type)``.
-
-    Accepts either a numeric ``albedo`` (0-1) or a named ``surface_type`` from
-    ``SURFACE_TYPES`` (which pvlib maps to an albedo), but not both.
-    """
-    if albedo is not None and surface_type is not None:
-        raise ValueError("Set either 'albedo' or 'surface_type', not both.")
-    if surface_type is not None and surface_type not in SURFACE_ALBEDOS:
-        valid = ", ".join(SURFACE_TYPES)
-        raise ValueError(f"Unknown surface_type {surface_type!r}. Valid types: {valid}")
-    if albedo is not None and not 0.0 <= albedo <= 1.0:
-        raise ValueError(f"albedo must be between 0 and 1, got {albedo!r}")
-    return albedo, surface_type
 
 
 @dataclass
@@ -409,7 +191,7 @@ def _prepare_solarpos_and_weather(
     """
     if not isinstance(weather_data.index, pd.DatetimeIndex):
         raise ValueError("weather_data must have a DatetimeIndex")
-    method = _resolve_solar_position_method(solar_position)
+    method = resolve_solar_position_method(solar_position)
 
     times = pd.date_range(start=weather_data.index[0], end=weather_data.index[-1], freq=freq)
     if method == "mid-interval":
@@ -427,24 +209,14 @@ def _compute_irradiance_and_cell_temp_detail(
     solarpos: pd.DataFrame,
     surface_tilt,
     surface_azimuth,
-    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
-    albedo: Optional[float] = None,
-    surface_type: Optional[str] = None,
-    model_perez: str = DEFAULT_PEREZ_MODEL,
-    diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
-    temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
-    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
-    bifaciality: Optional[float] = None,
-    gcr: float = 0.35,
-    pvrow_height: Optional[float] = None,
-    pvrow_pitch: Optional[float] = None,
+    model_options: PVModelOptions,
 ) -> _IrradianceModelResult:
     """Compute GHI, POA, effective irradiance, and cell temperature.
 
     surface_tilt / surface_azimuth may be scalars (fixed) or per-timestep arrays/Series
     (tracking). Uses pvlib.irradiance.get_total_irradiance which is array-aware.
 
-    ``transposition_model`` selects the sky-diffusion model (see
+    ``model_options.transposition_model`` selects the sky-diffusion model (see
     ``TRANSPOSITION_MODELS``); the default ``"isotropic"`` reproduces prior
     behaviour bit-for-bit. ``albedo`` (0-1) or ``surface_type`` (see
     ``SURFACE_TYPES``) sets the ground reflectance for the ground-diffuse
@@ -461,24 +233,20 @@ def _compute_irradiance_and_cell_temp_detail(
     irradiance, so rear gain contributes heat as well as power; with
     ``bifacial_model="none"`` the rear term is zero and the result is unchanged.
     """
-    model = _resolve_transposition_model(transposition_model)
-    albedo, surface_type = _resolve_ground_reflectance(albedo, surface_type)
-    model_perez = _resolve_perez_model(model_perez)
-    diffuse_iam = _resolve_diffuse_iam_method(diffuse_iam)
-    temperature_model = _resolve_temperature_model(temperature_model)
-    bifacial_model = _validate_bifacial_inputs(
-        bifacial_model,
-        bifaciality,
-        gcr,
-        pvrow_height,
-        pvrow_pitch,
-    )
+    model = model_options.transposition_model
+    albedo = model_options.albedo
+    surface_type = model_options.surface_type
+    model_perez = model_options.model_perez
+    diffuse_iam = model_options.diffuse_iam
+    bifacial_model = model_options.bifacial_model
+    bifaciality = model_options.bifaciality
+    gcr = model_options.gcr
+    pvrow_height = model_options.pvrow_height
+    pvrow_pitch = model_options.pvrow_pitch
     dni, ghi, dhi = _extract_irradiance(weather_aligned)
     temp_air, wind_speed = _extract_met_data(weather_aligned)
 
     aoi = pvlib.irradiance.aoi(surface_tilt, surface_azimuth, solarpos.apparent_zenith, solarpos.azimuth)
-    iam = pvlib.iam.ashrae(aoi)
-
     # Hay-Davies, Reindl, and the Perez variants need extraterrestrial DNI; the
     # Perez variants additionally need relative airmass. Isotropic, Klucher, and
     # King ignore both, and passing them does not change the isotropic result,
@@ -512,24 +280,13 @@ def _compute_irradiance_and_cell_temp_detail(
         **ground_kwargs,
     )
 
-    poa_direct = np.nan_to_num(poa["poa_direct"].values, nan=0.0)
-    poa_diffuse = np.nan_to_num(poa["poa_diffuse"].values, nan=0.0)
     poa_global = np.nan_to_num(poa["poa_global"].values, nan=0.0)
-    iam_clean = np.nan_to_num(np.asarray(iam, dtype=float), nan=0.0)
-
-    if diffuse_iam == "marion":
-        # Marion (2017) view-factor-integrated IAM on the diffuse components,
-        # using the same ashrae model as the beam IAM above. Transposition
-        # folds any horizon-brightening term into poa_sky_diffuse, so the sky
-        # multiplier covers it too.
-        poa_sky = np.nan_to_num(poa["poa_sky_diffuse"].values, nan=0.0)
-        poa_ground = np.nan_to_num(poa["poa_ground_diffuse"].values, nan=0.0)
-        multipliers = _marion_diffuse_ashrae(surface_tilt)
-        sky_mult = np.nan_to_num(np.asarray(multipliers["sky"], dtype=float), nan=0.0)
-        ground_mult = np.nan_to_num(np.asarray(multipliers["ground"], dtype=float), nan=0.0)
-        front_effective_irradiance = poa_direct * iam_clean + poa_sky * sky_mult + poa_ground * ground_mult
-    else:
-        front_effective_irradiance = poa_direct * iam_clean + poa_diffuse
+    front_effective_irradiance = calculate_front_effective_irradiance(
+        poa,
+        aoi,
+        surface_tilt,
+        diffuse_iam,
+    )
 
     if bifacial_model == "infinite_sheds":
         tilt = np.asarray(surface_tilt, dtype=float)
@@ -570,11 +327,12 @@ def _compute_irradiance_and_cell_temp_detail(
     # path rear_effective_irradiance is all zeros, so bifacial_model="none"
     # stays bit-for-bit identical.
     thermal_irradiance = poa_global + rear_effective_irradiance
-    if temperature_model == "faiman":
-        temp_cell = pvlib.temperature.faiman(thermal_irradiance, temp_air, wind_speed)
-    else:
-        params = pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS["pvsyst"][_PVSYST_MOUNTING[temperature_model]]
-        temp_cell = pvlib.temperature.pvsyst_cell(thermal_irradiance, temp_air, wind_speed, **params)
+    temp_cell = calculate_cell_temperature(
+        thermal_irradiance,
+        temp_air,
+        wind_speed,
+        model_options.temperature_model,
+    )
     return _IrradianceModelResult(
         ghi=np.nan_to_num(np.asarray(ghi, dtype=float), nan=0.0),
         poa_global=poa_global,
@@ -603,11 +361,7 @@ def _compute_effective_irradiance_and_cell_temp(
     pvrow_pitch: Optional[float] = None,
 ):
     """Compute effective POA irradiance (with IAM) and cell temperature."""
-    detail = _compute_irradiance_and_cell_temp_detail(
-        weather_aligned,
-        solarpos,
-        surface_tilt=surface_tilt,
-        surface_azimuth=surface_azimuth,
+    model_options = resolve_pv_model_options(
         transposition_model=transposition_model,
         albedo=albedo,
         surface_type=surface_type,
@@ -619,6 +373,13 @@ def _compute_effective_irradiance_and_cell_temp(
         gcr=gcr,
         pvrow_height=pvrow_height,
         pvrow_pitch=pvrow_pitch,
+    )
+    detail = _compute_irradiance_and_cell_temp_detail(
+        weather_aligned,
+        solarpos,
+        surface_tilt=surface_tilt,
+        surface_azimuth=surface_azimuth,
+        model_options=model_options,
     )
     return detail.effective_irradiance, detail.temp_cell
 
@@ -745,20 +506,11 @@ def _build_pv_production_breakdown(
     pv_params: "PVModuleParams",
     n_modules: int,
     times: pd.DatetimeIndex,
+    model_options: PVModelOptions,
     degradation_rate: float = 0.0,
     current_year: Optional[int] = None,
     start_year: Optional[int] = None,
     loss_overrides: Optional[Dict[str, float]] = None,
-    transposition_model: str = DEFAULT_TRANSPOSITION_MODEL,
-    albedo: Optional[float] = None,
-    surface_type: Optional[str] = None,
-    model_perez: str = DEFAULT_PEREZ_MODEL,
-    diffuse_iam: str = DEFAULT_DIFFUSE_IAM,
-    temperature_model: str = DEFAULT_TEMPERATURE_MODEL,
-    bifacial_model: str = DEFAULT_BIFACIAL_MODEL,
-    gcr: float = 0.35,
-    pvrow_height: Optional[float] = None,
-    pvrow_pitch: Optional[float] = None,
 ) -> PVProductionBreakdown:
     """Build the full fixed/tracking PV production breakdown."""
     detail = _compute_irradiance_and_cell_temp_detail(
@@ -766,17 +518,7 @@ def _build_pv_production_breakdown(
         solarpos,
         surface_tilt=surface_tilt,
         surface_azimuth=surface_azimuth,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        bifaciality=pv_params.bifaciality,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        model_options=model_options,
     )
     module_dc = _module_dc_before_losses(
         detail.effective_irradiance,
@@ -915,6 +657,19 @@ def calculate_pv_production_breakdown(
     times, solarpos, weather_aligned = _prepare_solarpos_and_weather(
         weather_data, location, freq, solar_position=solar_position
     )
+    model_options = resolve_pv_model_options(
+        transposition_model=transposition_model,
+        albedo=albedo,
+        surface_type=surface_type,
+        model_perez=model_perez,
+        diffuse_iam=diffuse_iam,
+        temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        bifaciality=pv_params.bifaciality,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
+    )
     breakdown = _build_pv_production_breakdown(
         weather_aligned,
         solarpos,
@@ -927,16 +682,7 @@ def calculate_pv_production_breakdown(
         current_year=current_year,
         start_year=start_year,
         loss_overrides=loss_overrides,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        model_options=model_options,
     )
 
     if verbose:
@@ -1131,6 +877,19 @@ def calculate_pv_production_tracking_breakdown(
         surface_tilt = np.where(below_horizon, 0.0, surface_tilt)
         surface_azimuth = np.where(below_horizon, axis_azimuth, surface_azimuth)
 
+    model_options = resolve_pv_model_options(
+        transposition_model=transposition_model,
+        albedo=albedo,
+        surface_type=surface_type,
+        model_perez=model_perez,
+        diffuse_iam=diffuse_iam,
+        temperature_model=temperature_model,
+        bifacial_model=bifacial_model,
+        bifaciality=pv_params.bifaciality,
+        gcr=gcr,
+        pvrow_height=pvrow_height,
+        pvrow_pitch=pvrow_pitch,
+    )
     breakdown = _build_pv_production_breakdown(
         weather_aligned,
         solarpos,
@@ -1143,16 +902,7 @@ def calculate_pv_production_tracking_breakdown(
         current_year=current_year,
         start_year=start_year,
         loss_overrides=loss_overrides,
-        transposition_model=transposition_model,
-        albedo=albedo,
-        surface_type=surface_type,
-        model_perez=model_perez,
-        diffuse_iam=diffuse_iam,
-        temperature_model=temperature_model,
-        bifacial_model=bifacial_model,
-        gcr=gcr,
-        pvrow_height=pvrow_height,
-        pvrow_pitch=pvrow_pitch,
+        model_options=model_options,
     )
 
     if verbose:

--- a/docs/release.md
+++ b/docs/release.md
@@ -41,6 +41,12 @@ BREOS from the installed wheel instead of the source checkout. It also imports
 all 14 vendored BLAST models and verifies the installed BLAST license, DOE
 notice, and pinned upstream provenance.
 
+Regenerate `validation/baselines/breos_baseline.json` *after* bumping the
+package version, not before. The baseline records `breos.__version__` as read
+at generation time, so a baseline generated on the previous version stamps
+itself with that version while encoding the new release's behavior, which
+misleads anyone later diffing it against the release it names.
+
 ## Release Validation Matrix
 
 The `Tests` workflow runs the complete matrix on Python 3.11, 3.12, 3.13, and

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -560,6 +560,74 @@ class TestAppValidation:
         assert seen["timezone"] == "Europe/Lisbon"
 
 
+class TestGcrValidation:
+    """``gcr`` is checked on every path, not only under a bifacial model.
+
+    It drives pvlib's backtracking rotation as well as ``infinite_sheds`` rear
+    view factors, and pvlib silently computes a different rotation rather than
+    rejecting a nonsensical ratio — a mistyped ``3.5`` used to return roughly
+    half the annual energy with no error anywhere.
+    """
+
+    BASE = {"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000}
+
+    @pytest.mark.parametrize("gcr", [0, 0.0, -0.5, 1.2, 3.5, 5.0])
+    @pytest.mark.parametrize("tracking", ["fixed", "single_axis", "dual_axis"])
+    def test_out_of_range_gcr_rejected_without_a_bifacial_model(self, gcr, tracking):
+        with pytest.raises(ValueError, match="'gcr' must be between 0 .exclusive. and 1 .inclusive."):
+            App({**self.BASE, "gcr": gcr, "tracking": tracking})
+
+    @pytest.mark.parametrize("gcr", ["x", None, float("nan"), float("inf")])
+    def test_non_finite_gcr_rejected(self, gcr):
+        with pytest.raises((ValueError, TypeError), match="'gcr' must be a finite number"):
+            App({**self.BASE, "gcr": gcr})
+
+    @pytest.mark.parametrize("gcr", [0.01, 0.35, 1, 1.0])
+    def test_valid_gcr_accepted(self, gcr):
+        App({**self.BASE, "gcr": gcr})
+
+    def test_per_array_gcr_override_is_reported_against_its_own_key(self):
+        with pytest.raises(ValueError, match=r"'pv_arrays\[1\].gcr' must be between"):
+            App(
+                {
+                    "location": "porto",
+                    "annual_consumption_kwh": 4000,
+                    "pv_arrays": [{"modules": 4}, {"modules": 3, "gcr": 2.0}],
+                }
+            )
+
+    def test_top_level_gcr_checked_even_when_every_array_overrides_it(self):
+        """It is still the function-level default handed to the multi-array path."""
+        with pytest.raises(ValueError, match="'gcr' must be between"):
+            App(
+                {
+                    "location": "porto",
+                    "annual_consumption_kwh": 4000,
+                    "gcr": 4.0,
+                    "pv_arrays": [{"modules": 4, "gcr": 0.4}],
+                }
+            )
+
+    @pytest.mark.parametrize(
+        ("extra", "expected"),
+        [
+            ({"resolution": "weekly"}, "resolution"),
+            ({"inverter_efficiency": 2.0}, "inverter_efficiency"),
+            ({"transposition_model": "nope"}, "transposition_model"),
+            ({"tilt": 120}, "tilt"),
+            ({"bifacial_model": "nope"}, "bifacial_model"),
+        ],
+    )
+    def test_gcr_check_never_steals_a_pre_existing_error(self, extra, expected):
+        """The check runs last, so it is purely additive.
+
+        A config that was already rejected for some other key must keep
+        reporting that key rather than switching to gcr.
+        """
+        with pytest.raises((ValueError, TypeError), match=expected):
+            App({**self.BASE, **extra, "gcr": 3.5})
+
+
 # ---------------------------------------------------------------------------
 # Simulation (with monkeypatched weather)
 # ---------------------------------------------------------------------------

--- a/tests/test_pv_model_core.py
+++ b/tests/test_pv_model_core.py
@@ -1,0 +1,79 @@
+"""Focused tests for the internal PV-model option and kernel modules."""
+
+from dataclasses import FrozenInstanceError
+
+import numpy as np
+import pandas as pd
+import pvlib
+import pytest
+
+from breos.pv.iam import calculate_front_effective_irradiance
+from breos.pv.model_options import PVModelOptions, resolve_pv_model_options
+from breos.pv.temperature import calculate_cell_temperature
+
+
+def test_model_options_are_normalised_validated_and_immutable():
+    options = resolve_pv_model_options(
+        transposition_model=" PEREZ ",
+        diffuse_iam="MARION",
+        temperature_model="PVsyst-Insulated",
+        surface_type="urban",
+    )
+
+    assert options == PVModelOptions(
+        transposition_model="perez",
+        albedo=None,
+        surface_type="urban",
+        model_perez="allsitescomposite1990",
+        diffuse_iam="marion",
+        temperature_model="pvsyst-insulated",
+        bifacial_model="none",
+        bifaciality=None,
+        gcr=0.35,
+        pvrow_height=None,
+        pvrow_pitch=None,
+    )
+    with pytest.raises(FrozenInstanceError):
+        options.temperature_model = "faiman"
+
+
+def test_front_irradiance_kernel_preserves_beam_only_ashrae_path():
+    poa = pd.DataFrame(
+        {
+            "poa_direct": [800.0, 200.0, np.nan],
+            "poa_diffuse": [100.0, 80.0, 20.0],
+            "poa_sky_diffuse": [75.0, 60.0, 15.0],
+            "poa_ground_diffuse": [25.0, 20.0, 5.0],
+        }
+    )
+    aoi = np.array([10.0, 70.0, 95.0])
+    expected = (
+        np.nan_to_num(poa["poa_direct"].to_numpy(), nan=0.0) * np.nan_to_num(pvlib.iam.ashrae(aoi), nan=0.0)
+        + poa["poa_diffuse"].to_numpy()
+    )
+
+    actual = calculate_front_effective_irradiance(poa, aoi, 30.0, "none")
+
+    np.testing.assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("model", "pvlib_function", "parameters"),
+    [
+        ("faiman", pvlib.temperature.faiman, {}),
+        (
+            "pvsyst-semi-integrated",
+            pvlib.temperature.pvsyst_cell,
+            pvlib.temperature.TEMPERATURE_MODEL_PARAMETERS["pvsyst"]["semi_integrated"],
+        ),
+    ],
+)
+def test_temperature_kernel_preserves_pvlib_dispatch(model, pvlib_function, parameters):
+    poa_global = np.array([0.0, 400.0, 900.0])
+    temp_air = np.array([15.0, 20.0, 28.0])
+    wind_speed = np.array([1.0, 2.0, 4.0])
+    expected = pvlib_function(poa_global, temp_air, wind_speed, **parameters)
+
+    actual = calculate_cell_temperature(poa_global, temp_air, wind_speed, model)
+
+    np.testing.assert_allclose(actual, expected)

--- a/tests/test_pv_model_core.py
+++ b/tests/test_pv_model_core.py
@@ -1,5 +1,6 @@
 """Focused tests for the internal PV-model option and kernel modules."""
 
+import inspect
 from dataclasses import FrozenInstanceError
 
 import numpy as np
@@ -7,9 +8,22 @@ import pandas as pd
 import pvlib
 import pytest
 
+from breos import solar
 from breos.pv.iam import calculate_front_effective_irradiance
 from breos.pv.model_options import PVModelOptions, resolve_pv_model_options
 from breos.pv.temperature import calculate_cell_temperature
+
+# Every public entry point that accepts the shared PV model-option block.
+MODEL_OPTION_ENTRY_POINTS = (
+    solar.calculate_pv_production_breakdown,
+    solar.calculate_pv_production_dc,
+    solar.calculate_pv_production_tracking_breakdown,
+    solar.calculate_pv_production_dc_tracking,
+    solar.calculate_pv_production_tmy,
+    solar.calculate_pv_production_ac,
+    solar.calculate_multi_array_production_breakdown,
+    solar.calculate_multi_array_production,
+)
 
 
 def test_model_options_are_normalised_validated_and_immutable():
@@ -77,3 +91,48 @@ def test_temperature_kernel_preserves_pvlib_dispatch(model, pvlib_function, para
     actual = calculate_cell_temperature(poa_global, temp_air, wind_speed, model)
 
     np.testing.assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("function", MODEL_OPTION_ENTRY_POINTS, ids=lambda f: f.__name__)
+def test_every_entry_point_declares_the_whole_model_option_block(function):
+    """Each public entry point must accept every shared model option by keyword.
+
+    ``solar._MODEL_OPTION_KEYS`` drives the wrappers' dict forwarding, so a new
+    option added to the tuple without being added to a signature would raise a
+    ``TypeError`` only when that path happened to run. Assert it up front, and
+    keep the options keyword-addressable — ``breos.App``, ``cli.py`` and
+    ``validation/`` all pass them by name.
+    """
+    parameters = inspect.signature(function).parameters
+    missing = [key for key in solar._MODEL_OPTION_KEYS if key not in parameters]
+    assert not missing, f"{function.__name__} is missing model options: {missing}"
+
+    positional_only = [
+        key for key in solar._MODEL_OPTION_KEYS if parameters[key].kind is inspect.Parameter.POSITIONAL_ONLY
+    ]
+    assert not positional_only, f"{function.__name__} made model options positional-only: {positional_only}"
+
+
+def test_model_option_keys_partition_into_per_array_and_function_level():
+    """The multi-array override asymmetry is intentional — pin it exactly.
+
+    ``diffuse_iam``/``temperature_model``/``solar_position`` are function-level
+    for every array while the sky and ground geometry is per-array
+    overridable. A new option must land in exactly one of the two tuples, so
+    the partition (not just the union) is what gets asserted.
+    """
+    per_array = set(solar._PER_ARRAY_MODEL_OPTION_KEYS)
+    function_level = set(solar._FUNCTION_LEVEL_MODEL_OPTION_KEYS)
+
+    assert per_array | function_level == set(solar._MODEL_OPTION_KEYS)
+    assert per_array & function_level == set()
+    assert function_level == {"solar_position", "diffuse_iam", "temperature_model"}
+    # gcr is model geometry here but tracker geometry on the tracking path.
+    assert set(solar._TRACKING_MODEL_OPTION_KEYS) == set(solar._MODEL_OPTION_KEYS) - {"gcr"}
+
+
+def test_no_public_entry_point_accepts_var_keywords():
+    """``**kwargs`` on these would silently swallow a misspelled option."""
+    for function in MODEL_OPTION_ENTRY_POINTS:
+        kinds = [p.kind for p in inspect.signature(function).parameters.values()]
+        assert inspect.Parameter.VAR_KEYWORD not in kinds, f"{function.__name__} accepts **kwargs"

--- a/tests/test_solar.py
+++ b/tests/test_solar.py
@@ -6,6 +6,7 @@ import pvlib
 import pytest
 
 import breos.solar as solar
+from breos.pv.model_options import resolve_pv_model_options
 from breos.pv_modules import get_module
 from breos.solar import (
     PEREZ_MODELS,
@@ -231,6 +232,7 @@ class TestPVProduction:
             solarpos,
             surface_tilt=35,
             surface_azimuth=180,
+            model_options=resolve_pv_model_options(),
         )
 
         assert not detail.rear_effective_irradiance.any()
@@ -242,18 +244,26 @@ class TestPVProduction:
         # temperature model.
         thermal_inputs = _spy_on_faiman(monkeypatch)
         weather_aligned, solarpos = self._detail_inputs(synthetic_weather.iloc[: 24 * 7], porto_location)
-        kwargs = dict(surface_tilt=35, surface_azimuth=180, albedo=0.25)
+        geometry = dict(surface_tilt=35, surface_azimuth=180)
 
-        front_only = solar._compute_irradiance_and_cell_temp_detail(weather_aligned, solarpos, **kwargs)
+        front_only = solar._compute_irradiance_and_cell_temp_detail(
+            weather_aligned,
+            solarpos,
+            model_options=resolve_pv_model_options(albedo=0.25),
+            **geometry,
+        )
         bifacial = solar._compute_irradiance_and_cell_temp_detail(
             weather_aligned,
             solarpos,
-            bifacial_model="infinite_sheds",
-            bifaciality=0.8,
-            gcr=0.35,
-            pvrow_height=1.5,
-            pvrow_pitch=6.0,
-            **kwargs,
+            model_options=resolve_pv_model_options(
+                albedo=0.25,
+                bifacial_model="infinite_sheds",
+                bifaciality=0.8,
+                gcr=0.35,
+                pvrow_height=1.5,
+                pvrow_pitch=6.0,
+            ),
+            **geometry,
         )
 
         np.testing.assert_array_equal(


### PR DESCRIPTION
The PV model's configuration handling had grown scattered: option validation, forwarding, and the IAM and temperature calculations were spread through `breos/solar.py` with no single place that said what a valid set of choices looks like. This PR pulls that apart into a `breos/pv/` package — one resolver that validates and freezes a complete set of model options, and dedicated kernels for the IAM and cell-temperature maths — so later PV work has one consistent layer to build on.

Nothing about the numbers changes. This is a structural refactor: the public function signatures, the defaults, the per-array override rules, and the computed results are all the same. The one genuine behaviour change is that an unusable ground-coverage ratio now fails fast with a clear BREOS error instead of surfacing as a confusing failure from inside pvlib.

## Summary

This core stack slice refactors the internal PV-model path around resolved model options and dedicated IAM and temperature helpers.

- Removes the obsolete irradiance wrapper and consolidates explicit option forwarding through the public PV wrappers.
- Centralizes PV model-name, albedo, and ground-coverage-ratio validation while retaining existing validation boundaries and messages where inputs were already invalid.
- Validates reachable top-level and per-array GCR values before they reach pvlib, including non-finite values, `None`, and ratios outside `(0, 1]`.

## Why

PV configuration checks and forwarding were distributed across the solar path. This makes the core rules explicit, prevents invalid tracking and multi-array GCR values from failing later in pvlib, and gives subsequent PV work one consistent option layer to build on.

## User impact

Existing public PV signatures and their per-array/function-level override behavior remain explicit and covered by tests. Invalid reachable GCR configuration now fails at BREOS validation with a precise error instead of reaching pvlib.

## Carried through from the stack below

The rear-side thermal coupling added in #93 moves to the new `breos.pv.temperature.calculate_cell_temperature` call site here: the composed `poa_global + rear_effective_irradiance` is what the kernel is driven with. The bifacial thermal tests are updated to the resolved-options signature, and `breos/pv/temperature.py`'s module docstring describes the composed input rather than front-side POA only. Every commit on this branch passes `tests/test_solar.py` individually.

## Stack

This is the core slice of the PV-model stack. It follows the bifacial diagnostics PR (#95) and is intended to be reviewed as the next ordered layer.

## Validation

- `.venv/bin/python -m pytest -q` (660 passed, 7 skipped, 2 deselected)
- `.venv/bin/ruff check breos tests tools`
- `.venv/bin/ruff format --check breos tests tools`
- `.venv/bin/sphinx-build -W -b html docs docs/_build/html`
