### PR TITLE
chore: move core coverage off the per-PR test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,8 @@ on:
   # all until it was retargeted at develop, which is the point where a failure
   # is most expensive to discover.
   pull_request:
-  # Slow endurance/multi-year tests run nightly, on demand, and as a release gate.
+  # Slow endurance/multi-year tests run nightly, on demand, and as a release
+  # gate; the coverage report is published on the same triggers.
   schedule:
     - cron: "0 4 * * *"  # 04:00 UTC every day
   workflow_dispatch:
@@ -47,22 +48,8 @@ jobs:
         run: uv run ruff format --check breos/ tests/ tools/
 
       - name: Run tests
-        if: matrix.python-version != '3.12'
         # Slow tests are deselected by default (pyproject addopts: -m "not slow").
         run: uv run pytest tests/ -v
-
-      - name: Run tests with core coverage
-        if: matrix.python-version == '3.12'
-        # Vendored BLAST-Lite is excluded by the coverage configuration.
-        run: uv run pytest tests/ -v --cov=breos --cov-report=term-missing --cov-report=xml
-
-      - name: Upload core coverage report
-        if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v7
-        with:
-          name: core-coverage-python-3.12
-          path: coverage.xml
-          if-no-files-found: error
 
       - name: Verify release artifacts
         run: uv run python tools/verify_release_artifacts.py
@@ -131,3 +118,43 @@ jobs:
 
       - name: Run slow tests
         run: uv run pytest tests/ -m slow -v
+
+  coverage-report:
+    # Publishes a branch-aware core-coverage snapshot; it is a report, not a
+    # gate. No threshold is configured, so a failure here means the instrumented
+    # run itself broke, never that coverage is too low. Instrumenting the whole
+    # suite costs 25-45 minutes against ~2 minutes uninstrumented, which is why
+    # it stays off the per-PR path. If diff coverage matters later, add a check
+    # scoped to the changed lines rather than restoring this to the matrix.
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.ref, 'refs/heads/release/') ||
+      startsWith(github.base_ref, 'release/')
+    runs-on: ubuntu-latest
+
+    env:
+      UV_PYTHON: "3.12"
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests with core coverage
+        # Vendored BLAST-Lite is excluded by the coverage configuration.
+        run: uv run pytest tests/ -v --cov=breos --cov-report=term-missing --cov-report=xml
+
+      - name: Upload core coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: core-coverage-python-3.12
+          path: coverage.xml
+          if-no-files-found: error

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,11 @@ name: Tests
 on:
   push:
     branches: [main, develop, "release/**"]
+  # Deliberately unfiltered: a `branches` filter here matches the *base* of the
+  # pull request, so a PR stacked on another feature branch would get no run at
+  # all until it was retargeted at develop, which is the point where a failure
+  # is most expensive to discover.
   pull_request:
-    branches: [main, develop, "release/**"]
   # Slow endurance/multi-year tests run nightly, on demand, and as a release gate.
   schedule:
     - cron: "0 4 * * *"  # 04:00 UTC every day


### PR DESCRIPTION
Every pull request in this repo has been waiting on a coverage run that nobody reads. The Python 3.12 leg of the test matrix ran the full suite under `coverage` instrumentation, and across the five PRs currently open it took between 25 and 46 minutes, while the 3.11, 3.13 and 3.14 legs finished in about two minutes each. Nothing consumed the result: `fail_under` is not configured and there is no diff-coverage reporter, so `coverage.xml` was uploaded as an artifact and never looked at. That wait bought nothing, and it was the critical path on every PR.

The instrumented run moves to a separate `coverage-report` job on the nightly, manual and release triggers, so a typical PR should now finish in a few minutes instead of the better part of an hour. Coverage itself is unchanged — still branch-aware, still excluding vendored BLAST-Lite — and you can get a report on demand from the Actions tab with a `workflow_dispatch` run. Nothing about the tests that actually gate a merge changes: all four Python versions still run the same suite, on the same events, and still have to pass.

## Summary

- All four matrix legs run plain `pytest`; the 3.12 special case is gone.
- Coverage instrumentation moves to a new `coverage-report` job on `schedule`, `workflow_dispatch`, and `release/**`.
- Removes the `branches` filter on the `pull_request` trigger so PRs stacked on feature branches are covered.

## What changed

**`test` job.** The `if: matrix.python-version != '3.12'` / `== '3.12'` split on the test steps is removed, along with the coverage artifact upload. Every leg now runs `uv run pytest tests/ -v`.

**New `coverage-report` job.** Same triggers as `slow-tests` — nightly cron, manual dispatch, and pushes or PRs on `release/**`. It runs the suite with `--cov=breos --cov-report=term-missing --cov-report=xml` on 3.12 and uploads `coverage.xml` under the same artifact name as before, `core-coverage-python-3.12`.

It is deliberately named and commented as a *report*, not a gate. With no threshold configured, a red X on that job means the instrumented run broke, not that coverage is insufficient — and the comment in the workflow says so, to stop a future reader misreading it.

**`pull_request` trigger.** A `branches` filter on `pull_request` matches the *base* of the PR, not the head, so a PR opened against another feature branch falls outside `[main, develop, release/**]` and can be skipped entirely — with the failure surfacing later, at retarget time, when it is most expensive. The filter is dropped and the reasoning recorded in a comment. This is the previously unmerged `chore/ci-run-on-stacked-prs` work, folded in here rather than landed separately, since both commits touch the same file.

## Why

Branch coverage stays on. Turning it off would have shaved time off a report whose value depends on it, which is the wrong trade — the fix for a slow report on the critical path is to take it off the critical path, not to make it worse.

Moving coverage off PRs does mean a coverage regression on an arbitrary PR diff is not caught at review time. It wasn't caught before either: with no threshold and no reporter, the per-PR job could not fail on low coverage and nothing surfaced the delta. If diff coverage becomes important, the right answer is a check scoped to the changed lines, not full-suite instrumentation restored to the matrix.

## Validation

- `tests.yml` parses; jobs resolve to `test`, `platform-smoke`, `slow-tests`, `coverage-report`, and the `pull_request` trigger is unfiltered.
- CI on this PR exercises the changed matrix directly — the check to look for is four `test (3.x)` legs of comparable duration and no `coverage-report` run.
- The `coverage-report` job cannot run on this PR by construction. Confirm it with a `workflow_dispatch` run on this branch, or on the next nightly, before relying on it.

## Follow-up

Two docs claims go stale the moment this merges, and both are left alone here on purpose:

- `docs/release.md:45` — "Python 3.12 also reports branch-aware core-package coverage" as part of the per-PR matrix.
- `CONTRIBUTING.md:88` — lists core-package coverage among the checks that run "on every PR".

Both files are edited or moved by #102 (`docs/release.md` is renamed to `docs/maintainers/release-checklist.md`), so correcting them here would guarantee a conflict. They follow in a separate PR once #101 and #102 land.
