### PR TITLE
docs: describe coverage as a separate report, not a per-PR check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 - Removed residential-only framing from the README description and feature
   list. The packaged presets remain residential-scale, but the engine itself
   carries no building assumption.
+- Moved core-package coverage instrumentation out of the per-pull-request test
+  matrix and into a separate `coverage-report` job on the nightly, manual, and
+  release triggers. All four Python versions now run the suite uninstrumented,
+  which takes a pull request from roughly 45 minutes to a few minutes. Coverage
+  is unchanged in scope — still branch-aware, still excluding vendored
+  BLAST-Lite — and remains a report rather than a gate, as it was before: no
+  threshold is configured. CI also no longer filters the `pull_request` trigger
+  by base branch, so pull requests stacked on other feature branches are built.
 
 ### Fixed
 - Corrected the `fast` extra documentation: the current Numba kernels are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,10 +102,11 @@ uv run pytest tests/test_app.py -v
 
 - PRs should target `develop`, not `main`
 - Include a brief description of what changed and why
-- Make sure CI passes. It runs lint, format checks, tests and core-package
-  coverage, release artifact verification, the Sphinx docs build, and
+- Make sure CI passes. It runs lint, format checks, tests on Python 3.11
+  through 3.14, release artifact verification, the Sphinx docs build, and
   lightweight macOS/Windows public-entrypoint checks on every PR to `develop`
-  or `main`.
+  or `main`. Core-package coverage is not part of that — it is published by a
+  separate `coverage-report` job that runs nightly, on demand, and at release.
 - Keep PRs focused — one feature or fix per PR
 
 ## Reporting Issues

--- a/maintainers/release-checklist.md
+++ b/maintainers/release-checklist.md
@@ -50,10 +50,14 @@ misleads anyone later diffing it against the release it names.
 ## Release Validation Matrix
 
 The `Tests` workflow runs the complete matrix on Python 3.11, 3.12, 3.13, and
-3.14. Python 3.12 also reports branch-aware core-package coverage, excluding
-the vendored BLAST-Lite implementation, while macOS and Windows run a focused
-public-entrypoint smoke suite. The following release claims must remain tied to
-executable checks:
+3.14, while macOS and Windows run a focused public-entrypoint smoke suite. A
+separate `coverage-report` job publishes branch-aware core-package coverage on
+Python 3.12, excluding the vendored BLAST-Lite implementation; it runs nightly,
+on demand, and on `release/**`, so a release build produces a coverage snapshot
+without every pull request paying for one. That job is a report, not a gate — no
+threshold is configured, and a failure there means the instrumented run broke
+rather than that coverage is insufficient. The following release claims must
+remain tied to executable checks:
 
 | Gate | Executable coverage |
 | --- | --- |


### PR DESCRIPTION
Two places in the docs still tell contributors that core-package coverage runs on every pull request. Since #106 that is no longer true — coverage moved to a separate `coverage-report` job on the nightly, manual and release triggers, and the per-PR matrix runs the suite uninstrumented. This corrects both, and says explicitly what the previous wording left ambiguous: the coverage job is a report, not a gate. No threshold is configured, so a red X there means the instrumented run broke, not that coverage fell short.

Documentation and changelog only — no workflow or code changes. The wording fixes were deliberately held back from #106 because both files were being edited or moved by #102 at the time.

## What changed

- `maintainers/release-checklist.md` — the Release Validation Matrix preamble no longer claims Python 3.12 reports coverage as part of the per-PR matrix. It describes the `coverage-report` job, its triggers, and its status as a report. The claims table below it is untouched.
- `CONTRIBUTING.md` — the PR guidelines list of what CI runs drops core-package coverage and names the Python range explicitly, with a sentence pointing at the separate job.
- `CHANGELOG.md` — an Unreleased entry for the CI change itself, which #106 did not add.

## Notes

`CONTRIBUTING.md` still documents `uv run pytest tests/ -v --cov=breos --cov-report=term-missing` as a local command. That is unaffected and left as is — running coverage locally was never tied to what CI does.
