### PR TITLE
Accept the documented [sweep] config section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Fixed
+- Accept the optional `[sweep]` config section in `ALLOWED_CONFIG_KEYS`, so
+  `breos validate-config configs/examples/sweep.toml` no longer rejects a
+  shipped example that `breos sweep` runs successfully. The documented
+  behaviour was already that `[sweep]` and `[montecarlo]` are recognised; only
+  `[montecarlo]` actually was. Every `configs/examples/*.toml` is now covered
+  by a `validate-config` regression test.
+
 ## [0.5.0] - 2026-08-05
 
 ### Added

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -89,16 +89,18 @@ DEFAULTS: dict[str, Any] = {
     "start_date": "2023-01-01",
 }
 
-# Required inputs are not in DEFAULTS (they have no default); ``montecarlo`` is
-# an optional config-file section consumed by the Monte Carlo runner/CLI, which
-# validates the same dict through resolve_app_config. Everything else at the top
-# level must be a known key so typos (e.g. ``batery_kwh``) fail loudly instead
-# of being silently dropped by merge_defaults.
+# Required inputs are not in DEFAULTS (they have no default); ``montecarlo`` and
+# ``sweep`` are optional config-file sections consumed by their dedicated
+# runners/CLI commands, which validate the same dict through resolve_app_config.
+# Everything else at the top level must be a known key so typos (e.g.
+# ``batery_kwh``) fail loudly instead of being silently dropped by
+# merge_defaults.
 ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(DEFAULTS) | {
     "location",
     "annual_consumption_kwh",
     "n_modules",
     "montecarlo",
+    "sweep",
     "battery_type",
 }
 

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -339,6 +339,8 @@ def _list_options_command(args: argparse.Namespace) -> int:
 
 def _validate_config(args: argparse.Namespace) -> int:
     config = _load_config(args.config)
+    if "sweep" in config:
+        _normalise_sweep_grid(config["sweep"])
     payload = _resolved_config_summary(config)
     if args.json:
         print(json.dumps(payload, indent=2))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,6 +318,25 @@ def test_shipped_example_configs_validate(config_path, capsys):
     assert "Config OK" in capsys.readouterr().out
 
 
+def test_validate_config_rejects_malformed_sweep(tmp_path, capsys):
+    config_path = tmp_path / "invalid-sweep.toml"
+    config_path.write_text(
+        """
+location = "porto"
+n_modules = 10
+annual_consumption_kwh = 4000
+
+[sweep]
+battery_kwh = []
+""".strip()
+    )
+
+    exit_code = cli.main(["validate-config", str(config_path)])
+
+    assert exit_code == 1
+    assert "sweep.battery_kwh must be a non-empty array" in capsys.readouterr().err
+
+
 def test_run_dry_run_outputs_resolved_config_without_simulating(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "App", FakeApp)
     FakeApp.simulated = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,11 @@ import csv
 import json
 from pathlib import Path
 
+import pytest
+
 from breos import cli
+
+EXAMPLE_CONFIGS = sorted((Path(__file__).resolve().parents[1] / "configs" / "examples").glob("*.toml"))
 
 
 class FakeApp:
@@ -298,6 +302,20 @@ def test_recommended_pv_example_validates(capsys):
     output = capsys.readouterr().out
     assert "Config OK" in output
     assert "PV: 8 modules, 4.400 kWp" in output
+
+
+def test_example_configs_are_discovered():
+    # A moved or renamed directory would otherwise turn the parametrised test
+    # below into zero silent cases.
+    assert len(EXAMPLE_CONFIGS) >= 10
+
+
+@pytest.mark.parametrize("config_path", EXAMPLE_CONFIGS, ids=lambda path: path.name)
+def test_shipped_example_configs_validate(config_path, capsys):
+    exit_code = cli.main(["validate-config", str(config_path)])
+
+    assert exit_code == 0
+    assert "Config OK" in capsys.readouterr().out
 
 
 def test_run_dry_run_outputs_resolved_config_without_simulating(monkeypatch, tmp_path):


### PR DESCRIPTION
One shipped example config never worked with `validate-config`: `configs/examples/sweep.toml` was rejected because `ALLOWED_CONFIG_KEYS` listed `montecarlo` but not `sweep`, despite the documentation promising both optional sections are recognised. This is a pre-existing gap, not a 0.5.0 regression.

## What changed

- Allow the documented `[sweep]` section through App-key validation.
- Make `validate-config` run the sweep table's structural validation too, so an empty or incorrectly typed grid cannot print `Config OK` and fail only when `breos sweep` starts.
- Run every `configs/examples/*.toml` file through `validate-config`, with a discovery guard so moving the directory cannot silently produce zero cases.

`breos sweep` itself was not broken: it removes `[sweep]` before constructing each `App`. The new validation only closes the config-checking gap.

## Verification

- `uv run pytest -q tests/test_cli.py` → 29 passed
- `uv run ruff check breos/cli.py tests/test_cli.py`
- `uv run ruff format --check breos/cli.py tests/test_cli.py`
- `git diff --check`
