### PR TITLE
Verify releases with uv instead of pip in the checklist

### DIFF
--- a/maintainers/release-checklist.md
+++ b/maintainers/release-checklist.md
@@ -135,14 +135,19 @@ Release flow:
    dependencies still come from PyPI:
 
    ```
-   uv venv /tmp/breos-testpypi
+   uv venv --clear /tmp/breos-testpypi
    VIRTUAL_ENV=/tmp/breos-testpypi uv pip install \
-     --index-url https://test.pypi.org/simple/ \
-     --extra-index-url https://pypi.org/simple/ breos
+     --index https://test.pypi.org/simple/ \
+     breos==X.Y.Z
+   VIRTUAL_ENV=/tmp/breos-testpypi uv pip show breos
+   VIRTUAL_ENV=/tmp/breos-testpypi uv pip check
    ```
 
-   If uv resolves a dependency to an unexpected TestPyPI upload rather than
-   the real PyPI release, add `--index-strategy unsafe-best-match`.
+   `--index` gives TestPyPI priority while leaving PyPI as uv's default,
+   lower-priority index for dependencies that are absent from TestPyPI. Keep
+   uv's default `first-index` strategy: if an unexpected TestPyPI package
+   shadows a dependency, investigate it rather than enabling an `unsafe-*`
+   index strategy.
 3. Tag the release commit on `main` (`git tag vX.Y.Z && git push origin vX.Y.Z`).
    The workflow refuses tags whose commit is not on `main`, then publishes to
    PyPI.
@@ -150,8 +155,10 @@ Release flow:
    installs from a clean environment:
 
    ```
-   uv venv /tmp/breos-pypi
+   uv venv --clear /tmp/breos-pypi
    VIRTUAL_ENV=/tmp/breos-pypi uv pip install breos==X.Y.Z
+   VIRTUAL_ENV=/tmp/breos-pypi uv pip show breos
+   VIRTUAL_ENV=/tmp/breos-pypi uv pip check
    ```
 
 ## Data And Docs

--- a/maintainers/release-checklist.md
+++ b/maintainers/release-checklist.md
@@ -130,13 +130,29 @@ Release flow:
 
 1. Merge the release PR into `main` after all gates pass.
 2. Optionally trigger the `Publish` workflow manually (`workflow_dispatch`)
-   to dry-run the upload against TestPyPI, then verify with
-   `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ breos`.
+   to dry-run the upload against TestPyPI, then verify the release installs
+   into a throwaway environment. TestPyPI serves `breos` itself; the runtime
+   dependencies still come from PyPI:
+
+   ```
+   uv venv /tmp/breos-testpypi
+   VIRTUAL_ENV=/tmp/breos-testpypi uv pip install \
+     --index-url https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ breos
+   ```
+
+   If uv resolves a dependency to an unexpected TestPyPI upload rather than
+   the real PyPI release, add `--index-strategy unsafe-best-match`.
 3. Tag the release commit on `main` (`git tag vX.Y.Z && git push origin vX.Y.Z`).
    The workflow refuses tags whose commit is not on `main`, then publishes to
    PyPI.
-4. Create the GitHub Release from the tag and confirm
-   `pip install breos==X.Y.Z` works from a clean environment.
+4. Create the GitHub Release from the tag and confirm the published release
+   installs from a clean environment:
+
+   ```
+   uv venv /tmp/breos-pypi
+   VIRTUAL_ENV=/tmp/breos-pypi uv pip install breos==X.Y.Z
+   ```
 
 ## Data And Docs
 


### PR DESCRIPTION
The release checklist used `pip` commands that are not available in a normal uv-managed checkout. This replaces them with copy-pasteable uv commands for isolated TestPyPI and PyPI verification.

## What changed

- Recreate the fixed temporary environments with `uv venv --clear`, so a previous release cannot contaminate the check.
- Pin `breos==X.Y.Z` in both checks.
- Give TestPyPI explicit higher priority with `--index https://test.pypi.org/simple/`; PyPI remains uv's lower-priority default for dependencies absent from TestPyPI.
- Run `uv pip show breos` and `uv pip check` after installation to verify the selected version and dependency consistency.

## Index safety

The checklist keeps uv's default `first-index` strategy. It no longer recommends `unsafe-best-match`: if an unexpected TestPyPI project shadows a dependency, maintainers should investigate the conflicting upload rather than broaden resolution across indexes.

## Verification

`uv run pytest -q tests/test_docs_content.py` → 3 passed, and the documented flags match the current uv CLI (`--index`; the legacy `--index-url` / `--extra-index-url` pair is deprecated).
