### PR TITLE
Record the 0.5.x dead code and bloat cleanup plan

### DIFF
--- a/design/architecture/0.5x-cleanup-plan.md
+++ b/design/architecture/0.5x-cleanup-plan.md
@@ -1,0 +1,534 @@
+# BREOS 0.5.x Dead Code and Bloat Cleanup Plan
+
+## Purpose
+
+This plan inventories unreachable, duplicated, and unverified code carried into
+the 0.5.x tree, and proposes an ordered set of small PRs to remove or repair it
+during 0.5.x.
+
+The tree is not bloated by test volume: 7 840 test lines against 20 937 source
+lines is a healthy ratio. The bloat is concentrated in **public API surface that
+nothing calls, nothing tests, and in two cases nothing documents** — roughly
+2 000 lines of source, plus a second copy of the dispatch physics.
+
+Several items are load-bearing for planned work rather than dead weight. Those
+are called out in "Deliberately retained" so a future sweep does not remove
+them by mistake.
+
+Line references were re-verified against the post-0.5.0 tree. The 0.5.0
+PV-model-core refactor and battery dispatch-seam extraction moved code within
+`breos/battery.py`, `breos/solar.py`, and `breos/constants.py`; `plotting.py`,
+`io.py`, `weather.py`, `optimization.py`, and `utils.py` are unchanged.
+
+## Invariants for every PR
+
+- Public removals are announced in `CHANGELOG.md` under a `Removed` heading and
+  land in a minor bump, never a patch.
+- Native Naumann/Lam remains the default degradation engine; BLAST stays
+  explicit opt-in.
+- The 0.3.4 energy ledger, cross-year stored-energy/PV-origin continuity, and
+  BLAST parity fixtures are unchanged by any cleanup PR.
+- No cleanup PR also changes scientific behaviour, dispatch, or release
+  defaults.
+- `breos.__all__` and the `_LAZY_PLOTTING_EXPORTS` set are updated in the same
+  PR as the symbol they name, so the two never drift.
+
+Before handoff:
+
+```bash
+uv run pytest -q
+uv run ruff check breos tests tools
+uv run ruff format --check breos tests tools
+uv run python tools/verify_release_artifacts.py
+uv run --extra docs sphinx-build -W -b html docs docs/_build/html
+```
+
+## Inventory
+
+Counted by AST span. "Reachable" means a call site somewhere in `breos/`,
+`tests/`, `tools/`, or `validation/` — a re-export in `breos/__init__.py` or a
+name in `docs/api/*.md` does not count.
+
+| Item | Lines | Reachable | Tested | Documented |
+|---|---:|---|---|---|
+| `breos/numba_kernels.py` (whole module) | 770 | no | partial | no |
+| `breos/polysun_degradation.py` + 2 plots + constants | ~550 | no | no | appendix only |
+| Uncalled `plotting.py` functions (excl. retained) | ~478 | no | no | no |
+| `io.py` report/summary exporters | 146 | no | no | no |
+| `weather.py` resample/CSV converters | 114 | no | no | partial |
+| `solar.py` `calculate_pv_production_tmy`, `zeb_sizer` | 91 | no | no | no |
+| `optimization.py` `optimize_tilt_brent`, `size_for_zeb` | 97 | no | no | yes |
+| `battery.py` orphaned helpers | 61 | no | no | partial |
+| `utils.py` `count_leap_years`, `number_of_cores` | 22 | no | no | no |
+| `tools/analyze_results.py`, `tools/compare_two_results.py` | 167 | n/a | no | no |
+
+A further ~25 `plotting.py` functions are referenced only by
+`docs/api/plotting.md`. Those are a documented plotting surface and are not
+proposed for removal, but they are wholly unverified — see Phase C7.
+
+---
+
+## Phase C1 — Replace `numba_kernels.py` with a day-kernel seam
+
+### Objective
+
+`breos/numba_kernels.py` is 770 lines and is unreachable from the package. The
+only reference is `breos/__init__.py:299`:
+
+```python
+def _get_numba():
+    """Lazy import of Numba-accelerated kernels."""
+    from breos import numba_kernels
+    return numba_kernels
+```
+
+`_get_numba` is private and is itself never called. `battery.py` does not import
+the module. `pyproject.toml:60` advertises `fast = ["numba>=0.63.1"]` for a path
+that does nothing.
+
+Worse than unused: the module re-implements the *whole* multi-year loop,
+including `_daily_degradation_step` (lines 236-374) and
+`energy_balance_kernel_with_degradation` (376-537). That is a second copy of the
+degradation science which must track `battery.py` but is never exercised
+against it. Three of its functions —
+`batch_energy_balance_kernel_with_degradation` (147 lines),
+`simulate_energy_balance_numba` (83), `batch_energy_balance_kernel` (78) — are
+not even imported by `tests/test_numba_kernels.py`.
+
+### Reference design for the seam
+
+If the fast path is rebuilt, the shape that works is a **day kernel**, not a
+whole-loop kernel:
+
+- **A `canonical_battery_dispatch_day_kernel`** compiles one day of timestep
+  dispatch and nothing else. Rainflow counting, degradation, resistance
+  updates, and replacement stay in the Python orchestrator at the positional
+  day boundary, and no fast-math transformations are enabled.
+- **The orchestrator lives in `battery.py`** beside the reference
+  implementation, not in a parallel module, and is called from all three public
+  entry points (`simulate_energy_balance`, the projection loop, and
+  `simulate_energy_balance_summary`). That is what makes the accelerated full
+  and summary APIs use exactly the same scientific state transitions — the
+  property the current parallel-module design cannot offer.
+- **The kernel import is lazy, at the call site inside the orchestrator**, so
+  importing `battery` never pulls in numba.
+- The kernel takes ~20 scalar/array positionals and returns flat arrays; the
+  `BatteryConfig` object is unpacked by the orchestrator, never passed in.
+- Chemistry is passed as a compact integer code via a
+  `_battery_chemistry_code()` mapping rather than a string.
+- Parity is enforced by a test asserting the JIT path matches the pure-Python
+  reference across chemistries.
+
+### Proposed shape for BREOS
+
+1. Delete `breos/numba_kernels.py` and `_get_numba`. This is a clean removal:
+   nothing depends on it.
+2. If the fast path is wanted in 0.5.x, re-add it as a day kernel only —
+   dispatch compiled, degradation and replacement in Python — with the
+   orchestrator in `breos/battery.py`, following the reference design above.
+   BREOS is LFP-only and `BatteryConfig` already rejects non-LFP, so the
+   chemistry-code mapping collapses to a single entry.
+3. Decide whether numba stays an optional extra. Keeping it optional means the
+   orchestrator needs a documented pure-Python fallback and both paths need
+   parity coverage — that is the more expensive option, and it should be a
+   deliberate choice rather than the current accident.
+4. If the fast path is *not* wanted in 0.5.x, drop the `fast` extra in the same
+   PR so `pyproject.toml` stops advertising it. Note that PR #101 corrected the
+   *description* of this extra; the extra itself still points at dead code.
+
+A TOU variant of the same day-kernel seam is the natural follow-on when
+time-of-use tariffs land — see Deliberately retained.
+
+### Acceptance criteria
+
+- No module named `numba_kernels` remains unless it is imported by
+  `battery.py` on a live code path.
+- If a kernel is kept, a parity test asserts JIT output equals the pure-Python
+  reference to within tolerance for at least one full year at both `h` and
+  `15min` resolution.
+- `pyproject.toml` has no `fast` extra pointing at dead code.
+
+### Suggested PR
+
+`refactor(perf): remove unreachable numba kernels` — removal only. Any
+re-introduction of a day kernel is a separate, later PR with its own parity
+tests.
+
+---
+
+## Phase C2 — Remove the Polysun comparison baseline
+
+### Objective
+
+`breos/polysun_degradation.py` (293 lines) implements a Wöhler/Miner
+comparison baseline built for an article. Nothing calls it. It has no tests.
+`tests/test_public_api.py:40` lists `PolysunDegradationConfig` under
+`intentionally_excluded` — it is exported from `breos/__init__.py:169` and
+simultaneously asserted to be outside the stable API.
+
+Its dependents form a self-contained subsystem:
+
+| File | What |
+|---|---|
+| `breos/polysun_degradation.py` | whole module, 293 lines |
+| `breos/plotting.py:3327-3430` | `plot_degradation_methodology_comparison` |
+| `breos/plotting.py:3433-3494` | `plot_lifetime_prediction_comparison` |
+| `breos/plotting.py:3497-3567` | `plot_temperature_sensitivity_comparison` |
+| `breos/constants.py:119-148` | Wöhler curve and calendar-lifetime constants |
+| `breos/__init__.py:168-175` | re-exports |
+| `docs/api/appendix.md:15` | autodoc entry |
+| `ATTRIBUTIONS.md:77-79` | three attribution rows |
+
+`plot_temperature_sensitivity_comparison` is the only one of the three with a
+docs reference; all three are uncalled and untested.
+
+### Proposed shape
+
+Remove all of the above. Keep the ATTRIBUTIONS rows only if the underlying
+methodology is still cited elsewhere in the paper trail; otherwise drop them
+with the code. Note in `CHANGELOG.md` that the comparison baseline was
+article-scoped and has been retired.
+
+If the comparison is worth preserving for reproducibility, its home is the
+article's own repository, not the shipped package.
+
+### Acceptance criteria
+
+- No `polysun` identifier remains in `breos/`.
+- `tests/test_public_api.py` no longer needs a `PolysunDegradationConfig` entry
+  in `intentionally_excluded`.
+- Sphinx builds clean with `-W` after the appendix entry is removed.
+
+### Suggested PR
+
+`refactor: retire the Polysun comparison baseline`.
+
+---
+
+## Phase C3 — Remove uncalled, undocumented plotting functions
+
+### Objective
+
+Of 60 functions in the 3 567-line `breos/plotting.py`, this set has no caller,
+no test, **and** no reference in `docs/api/plotting.md`. They exist only as
+names in `_LAZY_PLOTTING_EXPORTS`.
+
+| Function | Lines | Span |
+|---|---:|---|
+| `plot_loo_param_stability` | 58 | `plotting.py:2916-2973` |
+| `plot_loo_predictions` | 56 | `plotting.py:2976-3031` |
+| `plot_loo_cv_summary` | 44 | `plotting.py:2870-2913` |
+| `plot_smart_charging_sweep` | 42 | `plotting.py:2207-2248` |
+| `plot_optimization_results_3d` | 40 | `plotting.py:2251-2290` |
+| `plot_optimization_results_2d` | 40 | `plotting.py:2293-2332` |
+
+The three `plot_loo_*` functions plot leave-one-out cross-validation of a
+parameter fit. `tools/validate_cec_fit.py` is the closest live consumer of
+`breos/cec_fit.py` and does not use them. Confirm they are not wanted for CEC
+fit validation before deleting; if they are, wire them into that tool instead
+and the phase shrinks by 158 lines.
+
+`plot_optimization_results_2d/3d` overlap in intent with
+`plot_pareto_front_analysis` (`plotting.py:2750`, also uncalled but documented)
+and with `tools/azitilt_optimizer.py`, which draws its own landscapes via
+`plot_azitilt_landscape_2d/3d`.
+
+### Acceptance criteria
+
+- Removed names are gone from `_LAZY_PLOTTING_EXPORTS` in the same PR.
+- `tests/test_public_api.py::test_top_level_plotting_compatibility_is_lazy`
+  still passes.
+
+### Suggested PR
+
+`refactor(plotting): drop uncalled undocumented figures`.
+
+---
+
+## Phase C4 — Remove orphaned module-level helpers
+
+### Objective
+
+Public functions with no call site anywhere in the repository.
+
+**`breos/io.py`** — the module is imported only by `breos/__init__.py:134`.
+`export_results` / `load_results` are live public API; these three are not:
+
+- `save_simulation_report` — `io.py:184-260` (77 lines)
+- `export_monthly_summary` — `io.py:287-322` (36)
+- `export_yearly_summary` — `io.py:325-357` (33)
+
+**`breos/weather.py`**
+
+- `csv_hourly_to_15min` — `weather.py:650-701` (52)
+- `csv_15min_to_hourly` — `weather.py:607-647` (41)
+- `resample_to_hourly` — `weather.py:584-604` (21)
+- `fetch_tmy_nsrdb` — `weather.py:824-891` (68) — documented, uncalled, and
+  reaches an external API that is not covered by any test or fixture. Either
+  give it a recorded-response test or drop it; an untested network path in the
+  public surface is a support liability.
+
+**`breos/solar.py`**
+
+- `calculate_pv_production_tmy` — `solar.py:1065` (53). Superseded by
+  `calculate_pv_production_dc`, which is what `App` and `__all__` use.
+- `zeb_sizer` — `solar.py:1281` (38). Overlaps `optimization.size_for_zeb`.
+
+**`breos/optimization.py`** — both documented but uncalled:
+
+- `optimize_tilt_brent` — `optimization.py:129-193` (65). A second optimizer
+  beside the live `optimize_tilt`.
+- `size_for_zeb` — `optimization.py:287-318` (32). See `zeb_sizer` above; keep
+  at most one.
+
+**`breos/utils.py`**
+
+- `count_leap_years` — `utils.py:48-59` (12)
+- `number_of_cores` — `utils.py:94-103` (10). Was presumably for the numba
+  parallel path; dies with Phase C1.
+
+### Acceptance criteria
+
+- Each removal drops the corresponding `breos/__init__.py` import and `__all__`
+  entry.
+- `docs/api/*.md` autodoc entries for removed symbols are removed in the same
+  PR so `sphinx-build -W` stays green.
+
+### Suggested PR
+
+Split by module: `refactor(io):`, `refactor(weather):`, `refactor(solar):`,
+`refactor(optimization):`, `refactor(utils):`. Each is small and independently
+revertable.
+
+---
+
+## Phase C5 — Reconcile the duplicated resistance-fade derate
+
+### Objective
+
+This one is a latent correctness problem, not just bloat.
+
+`breos/battery.py:1815` defines and exports `resistance_to_efficiency`.
+Nothing calls it — not `battery.py` itself, not the tests. Meanwhile the live
+dispatch path inlines its own derate at `breos/battery.py:1133-1136`:
+
+```python
+if battery_config.enable_resistance_fade and resistance_growth > 0.0:
+    _rte_derate = math.sqrt(1.0 + resistance_growth)
+    eff_charge /= _rte_derate
+    eff_discharge /= _rte_derate
+```
+
+So the exported, documented (`docs/api/battery.md:71`) function and the code
+that actually runs are two independent implementations of the same physics,
+free to diverge. `test_resistance_fade_derates_energy_loop_efficiency`
+(`tests/test_battery.py:202`) exercises the inline path only.
+
+The 0.5.0 dispatch-seam extraction moved this code but did not reconcile it —
+the duplication survived the refactor, which is exactly why it is worth fixing
+before any further work lands on that path.
+
+### Proposed shape
+
+Make the inline block call `resistance_to_efficiency`, or delete the function
+and stop documenting it. Prefer the former: it is the shape a future day-kernel
+seam (Phase C1) needs, since the kernel must receive already-derated
+efficiencies as scalars computed once at the day boundary.
+
+Also in this area, three trivially small helpers are exported and uncalled:
+`compute_halfcycle_energy_throughput` (`battery.py:1678`), `k_c_rate_Q`
+(`1684`), `k_doc_Q` (`1690`). `update_battery_soc` (`battery.py:2016`) is
+documented and uncalled.
+
+### Acceptance criteria
+
+- Exactly one implementation of the resistance-to-efficiency mapping exists.
+- `test_resistance_fade_derates_energy_loop_efficiency` still passes unchanged —
+  this refactor must not move any number.
+
+### Suggested PR
+
+`refactor(battery): route resistance fade through resistance_to_efficiency`.
+
+---
+
+## Phase C6 — Prune `tools/`
+
+### Objective
+
+**`tools/analyze_results.py`** (74 lines) is committed scratch work: bare
+module-level statements, no `main()`, no argument parsing, `exit(1)` on missing
+input, and a hardcoded `results_dir = "results/complete_optimization"` that does
+not exist in the repository. Delete.
+
+**`tools/compare_two_results.py`** (93 lines) is strictly subsumed by
+`tools/compare_results.py`, which accepts N folders — including N=2 — with
+`--labels` and `--output`. The two-folder script predates it. Delete, and check
+`docs/` for any usage example that names it.
+
+The remaining twelve tools are each distinct. Note that `fetch_weather.py`
+(TMY + historical, single location, `configs/base/locations.json`) and
+`fetch_historical_weather.py` (batch, multi-city, JSON-config-driven) look
+redundant by name but are not — leave both.
+
+### Acceptance criteria
+
+- `tools/verify_release_artifacts.py` still passes.
+- No doc references a deleted script.
+
+### Suggested PR
+
+`chore(tools): remove scratch and superseded scripts`.
+
+---
+
+## Phase C7 — Decide the status of the documented-only plotting surface
+
+### Objective
+
+Roughly 25 functions in `plotting.py` are referenced only by
+`docs/api/plotting.md` — documented, never called by `breos/`, `tools/`,
+`validation/`, or any test. Examples: `plot_validation_soh_comparison`,
+`plot_validation_residuals`, `plot_validation_parity`,
+`plot_validation_multi_system`, `plot_validation_degradation_split`,
+`plot_cell_temperature`, `plot_monthly_comparison`, `plot_monthly_balance`,
+`monthly_graphs`, `yearly_graphs`, `weekly_graphs`, `degradation_plots`,
+`create_cost_plots`, `plot_battery_soh_timeseries`, `plot_tilt_optimization`,
+`plot_weather_monthly_comparison`, `plot_weather_annual_ghi_distribution`,
+`plot_calendar_aging_sensitivity`, `plot_pareto_front_analysis`.
+
+Only one plotting function has a real test: `plot_pv_loss_waterfall`
+(`tests/test_plotting.py`), plus `plot_montecarlo_simulation` via
+`tests/test_montecarlo_plotting.py`.
+
+This is a legitimate public plotting library, so "uncalled" is not by itself a
+defect. But an entirely unverified 3 500-line module will rot silently — a
+matplotlib or pandas API change breaks a user's figure and no CI run notices.
+
+### Proposed shape
+
+Not a removal phase. Add one smoke test that, for every name in
+`_LAZY_PLOTTING_EXPORTS`, calls the function with a minimal synthetic frame
+under the `Agg` backend and asserts a file is written. Roughly 60 assertions
+from one parametrized test and a small fixture factory. This converts the whole
+surface from unverified to at least import-and-render verified.
+
+The `plotting.py` split into submodules (`plotting/montecarlo.py`,
+`plotting/validation.py`, `plotting/economics.py`) is worth considering once
+Phases C2 and C3 have taken ~950 lines out of it, but it is not urgent and
+should not block the cleanup.
+
+### Suggested PR
+
+`test(plotting): smoke-render every exported figure`.
+
+---
+
+## Phase C8 — Consolidate redundant tests
+
+### Objective
+
+Test volume is fine overall; the redundancy is localized.
+
+**`tests/test_app.py`** — `TestAppValidation` is a long run of near-identical
+tests, each a `pytest.raises` over the same base config with one field
+perturbed. This collapses to one `@pytest.mark.parametrize` table. Two of them
+are the same call with different regexes:
+
+```python
+def test_unknown_config_key_rejected(self):                  # match="Unknown config key"
+def test_unknown_config_key_lists_the_offending_key(self):   # match="batery_kwh"
+```
+
+`tests/test_app_validation_correctness.py` (123 lines) already does exactly
+this, parametrized, over a different field set. The two files should be one; the
+"correctness" split is a release artefact, not a boundary.
+
+The same applies to the other `*_correctness` files —
+`tests/test_cli_correctness.py` (53 lines, 2 tests) belongs in
+`tests/test_cli.py`, and `tests/test_optimization_public.py` (43 lines, 2 tests)
+in `tests/test_optimization.py`. These were carved out per release; nothing
+distinguishes them now.
+
+**`tests/test_solar.py`** — a five-test template
+(`test_default_matches_explicit_X`, `test_case_insensitive`,
+`test_invalid_X_raises`, `test_tracking_accepts_X`, plus a shape check) is
+repeated across six option families: transposition model, solar position
+method, diffuse IAM, temperature model, ground reflectance, Perez coefficients.
+The `test_case_insensitive` and `test_invalid_*_raises` pairs — twelve tests —
+all cover the same string-normalization and validation helper and reduce to one
+parametrized test over `(option_name, valid_value, invalid_value)`. Note that
+0.5.0 added further option families here, so re-count before starting.
+
+**Fixture duplication** — `_write_multiyear_weather` and a synthetic weather
+frame builder are defined independently in `tests/test_montecarlo.py` and
+`tests/test_release_smoke.py`, while `tests/conftest.py` already has
+`_build_synthetic_weather`. Promote one multi-year variant to `conftest.py`.
+
+### Non-objective
+
+The six BLAST test files (`test_blast_engine`, `test_blast_integration`,
+`test_blast_vendoring`, `test_blast_endurance`, `test_blast_parity_tooling`,
+`test_blast_multicondition_parity`, 1 330 lines total) look excessive by count
+but each covers a distinct concern — unit, end-to-end, vendored-source
+provenance, multi-year endurance, fixture-generation reproducibility, and
+upstream parity. Leave them alone.
+
+### Acceptance criteria
+
+- Test count may drop; **coverage of each validated field must not**. Verify by
+  diffing the set of field names asserted before and after.
+- No `*_correctness.py` file remains as a separate module.
+
+### Suggested PR
+
+`test: parametrize config-validation and option-normalization suites`.
+
+---
+
+## Deliberately retained
+
+Do not remove these in a future sweep — they are uncalled today by design.
+
+- **`plot_tariff_comparison`** (`plotting.py:2067`) and
+  **`plot_tariff_comparison_manual`** (`plotting.py:2005`).
+  Uncalled and undocumented, so they match the Phase C3 criteria, but they are
+  the figure BREOS will want once time-of-use tariffs land (ROADMAP,
+  "Time-of-use tariff structures", 0.6.0 target). Keep them, and add a
+  module-level comment above `plot_tariff_comparison_manual` saying so, so the
+  next dead-code pass does not re-flag them.
+
+- **`breos/cec_fit.py`** — uncalled from `breos/` but exercised by
+  `tests/test_cec_fit.py` and `tools/validate_cec_fit.py` against the
+  `nrel-pysam` oracle. Live.
+
+- **`tests/fixtures/blast/synthetic_field_year.json`** (312 KB) — large, but it
+  is the pinned deterministic input for the endurance test and must stay
+  committed for reproducibility.
+
+## Out of scope
+
+- Splitting `plotting.py` into a package (revisit after C2/C3).
+- Any change to BLAST vendoring, parity fixtures, or the degradation protocol —
+  covered by the 0.4.x refactor plan.
+- `docs/_static/BREOS.png` and `BREOS_black.png` (~870 KB of raster logo
+  alongside a 29 KB SVG). Real, but cosmetic and unrelated to code health.
+
+## Recommended execution order
+
+1. **C6** — `tools/` pruning. Zero public surface, zero risk, immediate.
+2. **C1 removal half** — delete `numba_kernels.py`, `_get_numba`, and the
+   `fast` extra. Largest single win at 770 lines.
+3. **C2** — Polysun retirement. Self-contained, ~550 lines.
+4. **C3** — uncalled undocumented plots, ~478 lines.
+5. **C5** — resistance-fade reconciliation. Do this before any kernel work,
+   since the seam depends on it.
+6. **C4** — orphaned helpers, one PR per module.
+7. **C8** — test consolidation. Independent of everything above; can run in
+   parallel.
+8. **C7** — plotting smoke tests. Do last, so it covers the post-cleanup set.
+9. **C1 rebuild half** — day-kernel implementation, if wanted. Separate PR,
+   own parity tests, no other cleanup mixed in.
+
+Phases 1-6 remove roughly 2 100 lines of source. Phase 7 adds about 80 lines of
+test and covers roughly 3 000 previously unverified ones.

--- a/design/architecture/0.5x-cleanup-plan.md
+++ b/design/architecture/0.5x-cleanup-plan.md
@@ -3,13 +3,16 @@
 ## Purpose
 
 This plan inventories unreachable, duplicated, and unverified code carried into
-the 0.5.x tree, and proposes an ordered set of small PRs to remove or repair it
-during 0.5.x.
+the 0.5.x tree, and proposes an ordered set of small PRs to repair it, deprecate
+questionable public surface during 0.5.x, and remove confirmed public dead code
+in the next minor release.
 
 The tree is not bloated by test volume: 7 840 test lines against 20 937 source
-lines is a healthy ratio. The bloat is concentrated in **public API surface that
-nothing calls, nothing tests, and in two cases nothing documents** — roughly
-2 000 lines of source, plus a second copy of the dispatch physics.
+lines is a healthy ratio. The bloat is concentrated in **public API surface with
+no in-repository caller, no test, and in two cases no documentation** — roughly
+2 000 lines of source, plus duplicate dispatch physics. Repository reachability
+says nothing about external users, however, so it is an inventory signal rather
+than sufficient evidence for immediate removal.
 
 Several items are load-bearing for planned work rather than dead weight. Those
 are called out in "Deliberately retained" so a future sweep does not remove
@@ -22,8 +25,11 @@ PV-model-core refactor and battery dispatch-seam extraction moved code within
 
 ## Invariants for every PR
 
-- Public removals are announced in `CHANGELOG.md` under a `Removed` heading and
-  land in a minor bump, never a patch.
+- Public removals are deprecated and announced during 0.5.x, then land in 0.6.0
+  under a `Removed` heading in `CHANGELOG.md`; they never land in a patch.
+- Before deprecating an exported or documented symbol, search public downstream
+  code for imports/calls and record the result in its delivery PR. A missing
+  in-repository caller alone is not proof that users do not depend on it.
 - Native Naumann/Lam remains the default degradation engine; BLAST stays
   explicit opt-in.
 - The 0.3.4 energy ledger, cross-year stored-energy/PV-origin continuity, and
@@ -42,6 +48,13 @@ uv run ruff format --check breos tests tools
 uv run python tools/verify_release_artifacts.py
 uv run --extra docs sphinx-build -W -b html docs docs/_build/html
 ```
+
+## Release boundary
+
+Phases C1-C4 touch advertised extras, exported symbols, or documented public
+APIs. Their 0.5.x work is usage auditing, deprecation, and any non-breaking
+preparation; confirmed removals land in 0.6.0. Phases C5-C8 are internal code,
+tooling, or test work and may land in 0.5.x when they preserve behaviour.
 
 ## Inventory
 
@@ -121,32 +134,38 @@ whole-loop kernel:
 
 ### Proposed shape for BREOS
 
-1. Delete `breos/numba_kernels.py` and `_get_numba`. This is a clean removal:
-   nothing depends on it.
-2. If the fast path is wanted in 0.5.x, re-add it as a day kernel only —
-   dispatch compiled, degradation and replacement in Python — with the
-   orchestrator in `breos/battery.py`, following the reference design above.
+1. During 0.5.x, audit downstream use and deprecate `breos.numba_kernels` and
+   the advertised `fast` extra if the accelerated path is not being retained.
+   Announce the intended 0.6.0 removal; do not delete them in a patch release.
+2. In 0.6.0, delete `breos/numba_kernels.py`, `_get_numba`, and the `fast`
+   extra if the deprecation audit confirms removal. No production path in this
+   repository depends on them, but that does not establish external usage.
+3. If the fast path is wanted, replace the current parallel module in a
+   separate feature PR with a day kernel only — dispatch compiled, degradation
+   and replacement in Python — and put the orchestrator in `breos/battery.py`,
+   following the reference design above.
    BREOS is LFP-only and `BatteryConfig` already rejects non-LFP, so the
    chemistry-code mapping collapses to a single entry.
-3. Decide whether numba stays an optional extra. Keeping it optional means the
+4. Decide whether numba stays an optional extra. Keeping it optional means the
    orchestrator needs a documented pure-Python fallback and both paths need
    parity coverage — that is the more expensive option, and it should be a
    deliberate choice rather than the current accident.
-4. If the fast path is *not* wanted in 0.5.x, drop the `fast` extra in the same
-   PR so `pyproject.toml` stops advertising it. Note that PR #101 corrected the
-   *description* of this extra; the extra itself still points at dead code.
+   Note that PR #101 corrected the *description* of the current extra; it did
+   not connect the extra to a live production path.
 
 A TOU variant of the same day-kernel seam is the natural follow-on when
 time-of-use tariffs land — see Deliberately retained.
 
 ### Acceptance criteria
 
-- No module named `numba_kernels` remains unless it is imported by
-  `battery.py` on a live code path.
+- The 0.5.x deprecation PR records the downstream-usage check and names the
+  earliest removal release.
+- After the 0.6.0 removal, no module named `numba_kernels` remains unless it is
+  imported by `battery.py` on a live code path.
 - If a kernel is kept, a parity test asserts JIT output equals the pure-Python
   reference to within tolerance for at least one full year at both `h` and
   `15min` resolution.
-- `pyproject.toml` has no `fast` extra pointing at dead code.
+- After removal, `pyproject.toml` has no `fast` extra pointing at dead code.
 
 ### Suggested PR
 
@@ -161,7 +180,8 @@ tests.
 ### Objective
 
 `breos/polysun_degradation.py` (293 lines) implements a Wöhler/Miner
-comparison baseline built for an article. Nothing calls it. It has no tests.
+comparison baseline built for an article. It has no in-repository caller and no
+tests; downstream use still needs the audit required above.
 `tests/test_public_api.py:40` lists `PolysunDegradationConfig` under
 `intentionally_excluded` — it is exported from `breos/__init__.py:169` and
 simultaneously asserted to be outside the stable API.
@@ -298,7 +318,7 @@ Public functions with no call site anywhere in the repository.
 
 Split by module: `refactor(io):`, `refactor(weather):`, `refactor(solar):`,
 `refactor(optimization):`, `refactor(utils):`. Each is small and independently
-revertable.
+revertible.
 
 ---
 
@@ -309,8 +329,10 @@ revertable.
 This one is a latent correctness problem, not just bloat.
 
 `breos/battery.py:1815` defines and exports `resistance_to_efficiency`.
-Nothing calls it — not `battery.py` itself, not the tests. Meanwhile the live
-dispatch path inlines its own derate at `breos/battery.py:1133-1136`:
+Nothing calls it — not `battery.py` itself, not the tests. Meanwhile two live
+paths implement a different mapping directly: the daily resistance update at
+`breos/battery.py:790-792` and initial dispatch setup at
+`breos/battery.py:1133-1136`:
 
 ```python
 if battery_config.enable_resistance_fade and resistance_growth > 0.0:
@@ -319,10 +341,14 @@ if battery_config.enable_resistance_fade and resistance_growth > 0.0:
     eff_discharge /= _rte_derate
 ```
 
-So the exported, documented (`docs/api/battery.md:71`) function and the code
-that actually runs are two independent implementations of the same physics,
-free to diverge. `test_resistance_fade_derates_energy_loop_efficiency`
-(`tests/test_battery.py:202`) exercises the inline path only.
+The two live paths divide each original one-way efficiency by the same
+`sqrt(1 + resistance_growth)` derate, preserving any charge/discharge
+asymmetry. The exported, documented helper (`docs/api/battery.md:71`) instead
+computes one shared `sqrt(rte_new)`, caps it against each base efficiency, and
+applies a `0.01` RTE floor. It has the same product in the common symmetric,
+unclamped case but changes one-way efficiencies for asymmetric inputs and at
+the clamp. `test_resistance_fade_derates_energy_loop_efficiency`
+(`tests/test_battery.py:202`) exercises only the symmetric live path.
 
 The 0.5.0 dispatch-seam extraction moved this code but did not reconcile it —
 the duplication survived the refactor, which is exactly why it is worth fixing
@@ -330,21 +356,29 @@ before any further work lands on that path.
 
 ### Proposed shape
 
-Make the inline block call `resistance_to_efficiency`, or delete the function
-and stop documenting it. Prefer the former: it is the shape a future day-kernel
-seam (Phase C1) needs, since the kernel must receive already-derated
-efficiencies as scalars computed once at the day boundary.
+First make `resistance_to_efficiency` exactly reproduce the live mapping: return
+the base efficiencies for non-positive growth; otherwise divide each base by
+`sqrt(1 + resistance_growth)` with no additional floor or rebalance. Then route
+both the daily-update and initial-dispatch sites through it. Alternatively,
+delete the helper and stop documenting it. Prefer consolidation: it is the
+shape a future day-kernel seam (Phase C1) needs, since the kernel must receive
+already-derated efficiencies as scalars computed once at the day boundary.
 
 Also in this area, three trivially small helpers are exported and uncalled:
 `compute_halfcycle_energy_throughput` (`battery.py:1678`), `k_c_rate_Q`
 (`1684`), `k_doc_Q` (`1690`). `update_battery_soc` (`battery.py:2016`) is
-documented and uncalled.
+documented and uncalled. Treat those as C4 public-surface candidates: audit and
+deprecate them separately rather than removing them in this 0.5.x behaviour-
+preserving reconciliation.
 
 ### Acceptance criteria
 
 - Exactly one implementation of the resistance-to-efficiency mapping exists.
 - `test_resistance_fade_derates_energy_loop_efficiency` still passes unchanged —
   this refactor must not move any number.
+- Focused tests pin the pre-refactor live outputs for asymmetric charge and
+  discharge efficiencies and for growth large enough to distinguish the old
+  helper's floor.
 
 ### Suggested PR
 
@@ -516,19 +550,28 @@ Do not remove these in a future sweep — they are uncalled today by design.
 
 ## Recommended execution order
 
-1. **C6** — `tools/` pruning. Zero public surface, zero risk, immediate.
-2. **C1 removal half** — delete `numba_kernels.py`, `_get_numba`, and the
-   `fast` extra. Largest single win at 770 lines.
-3. **C2** — Polysun retirement. Self-contained, ~550 lines.
-4. **C3** — uncalled undocumented plots, ~478 lines.
-5. **C5** — resistance-fade reconciliation. Do this before any kernel work,
-   since the seam depends on it.
-6. **C4** — orphaned helpers, one PR per module.
-7. **C8** — test consolidation. Independent of everything above; can run in
-   parallel.
-8. **C7** — plotting smoke tests. Do last, so it covers the post-cleanup set.
-9. **C1 rebuild half** — day-kernel implementation, if wanted. Separate PR,
-   own parity tests, no other cleanup mixed in.
+During 0.5.x:
 
-Phases 1-6 remove roughly 2 100 lines of source. Phase 7 adds about 80 lines of
-test and covers roughly 3 000 previously unverified ones.
+1. **C6** — `tools/` pruning. Zero public surface, low risk, immediate.
+2. **C5** — resistance-fade reconciliation. Do this before any kernel work,
+   since the seam depends on it.
+3. **C8** — test consolidation. Independent of the public-surface decisions.
+4. **C7** — plotting smoke tests, establishing coverage before deciding which
+   exports can be retired.
+5. **C1-C4 audits/deprecations** — check downstream use, record evidence, and
+   announce only those 0.6.0 removals the evidence supports.
+
+During 0.6.0:
+
+6. **C1 removal half** — remove `numba_kernels.py`, `_get_numba`, and the
+   `fast` extra if the deprecation decision stands. Largest single win at 770
+   lines.
+7. **C2** — Polysun retirement, if confirmed. Self-contained, ~550 lines.
+8. **C3** — confirmed uncalled undocumented plots, ~478 lines.
+9. **C4** — confirmed orphaned helpers, one PR per module.
+10. **C1 rebuild half** — day-kernel implementation, if wanted. Separate PR,
+    own parity tests, no other cleanup mixed in.
+
+The confirmed 0.6.0 removals target roughly 2 100 lines of source. C7 adds
+about 80 lines of test and covers roughly 3 000 previously unverified ones;
+update its parameter set alongside any later public removal.

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -9,6 +9,7 @@ or implementation history.
 | [Third-party module wrapping](third-party-wrapping.md) | Proposed; tracked by GitHub issue #11 |
 | [String inverter sizing](string-inverter-sizing.md) | Proposed capability |
 | [0.4.x refactor and onboarding plan](0.4x-refactor-plan.md) | Historical delivery plan |
+| [0.5.x dead code and bloat cleanup plan](0.5x-cleanup-plan.md) | Proposed delivery plan |
 | [Battery degradation policy](battery-degradation-policy.md) | Active maintainer policy |
 | [BLAST degradation engine](blast-degradation-engine.md) | Implementation record with deferred work |
 


### PR DESCRIPTION
Records a compatibility-aware delivery plan for unreachable, duplicated, and unverified code found in the 0.5.x tree. Repository reachability is treated as an inventory signal, not proof that exported APIs have no external users. Document only; no runtime change.

## Release boundary

Internal behaviour-preserving work may land during 0.5.x. Advertised extras and exported or documented symbols require a downstream-usage audit and deprecation during 0.5.x; confirmed public removals land in 0.6.0, never a patch release.

## Resistance-fade correction

`resistance_to_efficiency` is unused, but the plan no longer describes it as identical to one live inline implementation. There are two live sites (`battery.py:790-792` and `battery.py:1133-1136`), and both divide each original one-way efficiency by `sqrt(1 + resistance_growth)`. The helper instead rebalances through a shared square root and adds a floor, which changes asymmetric or highly degraded cases.

Phase C5 now requires the helper to reproduce the live mapping exactly, routes both live sites through it, and adds asymmetric/high-growth regression cases. Unrelated exported helpers remain in the public-surface audit rather than being removed in that 0.5.x refactor.

## Other plan constraints

- Public downstream imports/calls must be searched and recorded before deprecation.
- The Numba extra/module is deprecated in 0.5.x if retirement is chosen and removed no earlier than 0.6.0.
- Private research-tree references remain excluded; the plan stays under `design/architecture/`, outside the Sphinx user site.

## Verification

`uv run pytest -q tests/test_docs_content.py` → 3 passed.
