### PR TITLE
Consolidate resistance-fade efficiency mapping

### DIFF
--- a/breos/battery.py
+++ b/breos/battery.py
@@ -784,12 +784,13 @@ def _apply_resistance_fade(
     aging.cumulative_resistance_cycle += dR_cycle
     aging.cumulative_resistance_calendar += dR_calendar
 
-    # Feed the resistance penalty back into the energy loop, split evenly
-    # across charge and discharge so their product equals the effective
-    # round-trip efficiency.
-    rte_derate = math.sqrt(1.0 + aging.resistance_growth)
-    aging.eff_charge = battery_config.charge_efficiency / rte_derate
-    aging.eff_discharge = battery_config.discharge_efficiency / rte_derate
+    # Feed the resistance penalty back into the energy loop using the same
+    # mapping as the initial dispatch state.
+    aging.eff_charge, aging.eff_discharge = resistance_to_efficiency(
+        aging.resistance_growth,
+        battery_config.charge_efficiency,
+        battery_config.discharge_efficiency,
+    )
     return aging.eff_charge * aging.eff_discharge
 
 
@@ -1130,10 +1131,12 @@ def simulate_energy_balance(
     # fade model is enabled; updated after each daily degradation step.
     eff_charge = battery_config.charge_efficiency
     eff_discharge = battery_config.discharge_efficiency
-    if battery_config.enable_resistance_fade and resistance_growth > 0.0:
-        _rte_derate = math.sqrt(1.0 + resistance_growth)
-        eff_charge /= _rte_derate
-        eff_discharge /= _rte_derate
+    if battery_config.enable_resistance_fade:
+        eff_charge, eff_discharge = resistance_to_efficiency(
+            resistance_growth,
+            battery_config.charge_efficiency,
+            battery_config.discharge_efficiency,
+        )
 
     degradation_tracking: List[Dict[str, Any]] = []
     T_cell_day_sum = 0.0
@@ -1820,8 +1823,9 @@ def resistance_to_efficiency(
     """
     Convert resistance growth to effective charge/discharge efficiencies.
 
-    Internal resistance growth increases ohmic losses proportionally.
-    The efficiency penalty is split equally between charge and discharge.
+    Internal resistance growth increases ohmic losses proportionally. Both
+    baseline efficiencies receive the same ``sqrt(1 + growth)`` derating,
+    preserving their original ratio.
 
     RTE_new = RTE_base / (1 + resistance_growth)
 
@@ -1836,15 +1840,8 @@ def resistance_to_efficiency(
     if resistance_growth <= 0:
         return base_charge_eff, base_discharge_eff
 
-    rte_base = base_charge_eff * base_discharge_eff
-    rte_new = rte_base / (1.0 + resistance_growth)
-
-    # Split new RTE as sqrt across charge and discharge
-    sqrt_rte_new = math.sqrt(max(0.01, rte_new))
-    eff_charge = min(base_charge_eff, sqrt_rte_new)
-    eff_discharge = min(base_discharge_eff, sqrt_rte_new)
-
-    return eff_charge, eff_discharge
+    derate = math.sqrt(1.0 + resistance_growth)
+    return base_charge_eff / derate, base_discharge_eff / derate
 
 
 def _normalise_battery_type(battery_type: str) -> str:

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -10,6 +10,7 @@ from breos.battery import (
     BatteryConfig,
     _get_degradation_params,
     apply_indoor_temperature_model,
+    resistance_to_efficiency,
     simulate_energy_balance,
     update_battery_soh_cyclewise,
 )
@@ -126,6 +127,30 @@ class TestBatteryConfig:
         assert v2_n == LAM_SOC_EXPONENT_N
         assert v2_ea > default_ea
         assert v2_n > default_n
+
+
+class TestResistanceToEfficiency:
+    @pytest.mark.parametrize("resistance_growth", [0.0, -0.25])
+    def test_non_positive_growth_preserves_base_efficiencies(self, resistance_growth):
+        assert resistance_to_efficiency(resistance_growth, 0.98, 0.91) == (0.98, 0.91)
+
+    def test_asymmetric_efficiencies_keep_the_same_ratio(self):
+        growth = 0.44
+        expected_derate = np.sqrt(1.0 + growth)
+
+        eff_charge, eff_discharge = resistance_to_efficiency(growth, 0.99, 0.81)
+
+        assert eff_charge == pytest.approx(0.99 / expected_derate)
+        assert eff_discharge == pytest.approx(0.81 / expected_derate)
+        assert eff_charge / eff_discharge == pytest.approx(0.99 / 0.81)
+
+    def test_high_growth_has_no_efficiency_floor(self):
+        eff_charge, eff_discharge = resistance_to_efficiency(9999.0, 0.98, 0.82)
+
+        assert eff_charge == pytest.approx(0.0098)
+        assert eff_discharge == pytest.approx(0.0082)
+        assert eff_charge < 0.01
+        assert eff_discharge < 0.01
 
 
 class TestSimulateEnergyBalance:


### PR DESCRIPTION
## Summary

- route initial dispatch and daily resistance updates through one efficiency mapping
- preserve the configured charge/discharge efficiency ratio as resistance grows
- remove the helper's artificial efficiency floor and cover edge cases explicitly

## Why

The simulation had two implementations of the same resistance-to-efficiency conversion. The exported helper also rebalanced asymmetric efficiencies and imposed a floor, while the live daily update divided both configured efficiencies by the same resistance derating. Consolidating the paths prevents those behaviors from drifting.

For non-positive growth, configured efficiencies remain unchanged. For positive growth, both are divided by `sqrt(1 + resistance_growth)`, so their product retains the intended round-trip-efficiency derating.

## Validation

- `uv run pytest -q tests/test_battery.py` — 82 passed
- `uv run ruff check breos tests`
- `uv run ruff format --check breos tests`
- full combined validation before splitting — 792 passed, 7 skipped, 2 deselected
