### PR TITLE
Centralize App configuration metadata

### DIFF
--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -6,7 +6,8 @@ import math
 from dataclasses import dataclass
 from datetime import date
 from numbers import Real
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from breos.degradation.profiles import ENABLED_BLAST_MODEL_KEYS, apply_battery_profile_defaults
@@ -36,73 +37,347 @@ from breos.solar import (
 )
 from breos.solar import default_azimuth as default_azimuth_fn
 
-DEFAULTS: dict[str, Any] = {
-    "battery_kwh": 0.0,
-    "pv_arrays": None,
-    "pv_module": None,
-    "load_profile": "1",
-    "rlp_directory": None,
-    "tilt": None,
-    "azimuth": None,
-    "tracking": "fixed",
-    "axis_tilt": 0.0,
-    "axis_azimuth": None,
-    "max_angle": 60.0,
-    "backtrack": True,
-    "gcr": 0.35,
-    "cross_axis_tilt": 0.0,
-    "dual_axis_max_tilt": 90.0,
-    "transposition_model": DEFAULT_TRANSPOSITION_MODEL,
-    "albedo": None,
-    "surface_type": None,
-    "model_perez": DEFAULT_PEREZ_MODEL,
-    "solar_position": DEFAULT_SOLAR_POSITION,
-    "iam_model": DEFAULT_IAM_MODEL,
-    "diffuse_iam": DEFAULT_DIFFUSE_IAM,
-    "temperature_model": DEFAULT_TEMPERATURE_MODEL,
-    "bifacial_model": DEFAULT_BIFACIAL_MODEL,
-    "pvrow_height": None,
-    "pvrow_pitch": None,
-    "resolution": "h",
-    "projection_years": 20,
-    "cost_preset": None,
-    "inflation_rate": 0.02,
-    "sell_price_inflation": 0.0,
-    "discount_rate": 0.03,
-    "emissions_country": None,
-    "export_emissions_factor_gco2_kwh": None,
-    "pv_degradation_rate": 0.005,
-    "calendar_model": "naumann_lam_field_calibrated",
-    "degradation_engine": "native",
-    "blast_model": None,
-    "battery_min_soc": 0.10,
-    "battery_max_soc": 0.90,
-    "battery_eol_percentage": 0.70,
-    "battery_rte": None,
-    "battery_max_charge_power_w": None,
-    "battery_max_discharge_power_w": None,
-    "enable_resistance_fade": False,
-    "dc_coupled": True,
-    "inverter_efficiency": 0.96,
-    "inverter_loading_ratio": 1.25,
-    "pv_loss_overrides": None,
-    "start_date": "2023-01-01",
+_NO_DEFAULT = object()
+
+
+@dataclass(frozen=True)
+class AppConfigField:
+    """Declarative metadata for one public App configuration key.
+
+    Scientific constraints intentionally remain in the focused validators
+    below. This registry owns the mechanical contract that had previously
+    drifted across defaults, the allowed-key list, CLI arguments, and CLI
+    override propagation.
+    """
+
+    default: Any = _NO_DEFAULT
+    default_order: int | None = None
+    cli_flags: tuple[str, ...] = ()
+    cli_type: Callable[[str], Any] | None = None
+    cli_choices: tuple[str, ...] | None = None
+    cli_action: str | None = None
+    cli_help: str | None = None
+    cli_normalizer: Callable[[Any], Any] | None = None
+
+    @property
+    def has_default(self) -> bool:
+        return self.default is not _NO_DEFAULT
+
+
+def _lower(value: str) -> str | None:
+    return value.lower() if value else None
+
+
+def _upper(value: str) -> str | None:
+    return value.upper() if value else None
+
+
+def _underscored(value: str) -> str | None:
+    return value.replace("-", "_") if value else None
+
+
+APP_CONFIG_FIELDS: dict[str, AppConfigField] = {
+    # CLI-exposed fields are kept in parser display order. Required inputs have
+    # no default; argparse still leaves them optional so --config can supply
+    # them, and the existing App validators remain the source of required-key
+    # errors.
+    "location": AppConfigField(
+        cli_flags=("--location",),
+        cli_help="Location preset key, for example 'porto'.",
+        cli_normalizer=_lower,
+    ),
+    "n_modules": AppConfigField(cli_flags=("--n-modules",), cli_type=int, cli_help="Number of PV modules."),
+    "annual_consumption_kwh": AppConfigField(
+        cli_flags=("--annual-consumption-kwh",),
+        cli_type=float,
+        cli_help="Annual electricity demand in kWh.",
+    ),
+    "battery_kwh": AppConfigField(
+        default=0.0,
+        default_order=0,
+        cli_flags=("--battery-kwh",),
+        cli_type=float,
+        cli_help="Battery capacity in kWh.",
+    ),
+    "battery_max_charge_power_w": AppConfigField(
+        default=None,
+        default_order=42,
+        cli_flags=("--battery-max-charge-power-w",),
+        cli_type=float,
+        cli_help="Maximum DC power entering the battery charge path in W (default: unlimited).",
+    ),
+    "battery_max_discharge_power_w": AppConfigField(
+        default=None,
+        default_order=43,
+        cli_flags=("--battery-max-discharge-power-w",),
+        cli_type=float,
+        cli_help="Maximum battery AC power delivered to load in W (default: unlimited).",
+    ),
+    "cost_preset": AppConfigField(
+        default=None,
+        default_order=28,
+        cli_flags=("--cost-preset",),
+        cli_help="Cost preset key, for example 'residential-pt'.",
+        cli_normalizer=_underscored,
+    ),
+    "emissions_country": AppConfigField(
+        default=None,
+        default_order=32,
+        cli_flags=("--emissions-country",),
+        cli_help="Country code for emissions, for example 'pt'.",
+        cli_normalizer=_upper,
+    ),
+    "pv_module": AppConfigField(
+        default=None, default_order=2, cli_flags=("--pv-module",), cli_help="PV module catalogue key."
+    ),
+    "load_profile": AppConfigField(
+        default="1", default_order=3, cli_flags=("--load-profile",), cli_help="Load profile type."
+    ),
+    "rlp_directory": AppConfigField(
+        default=None,
+        default_order=4,
+        cli_flags=("--rlp-directory",),
+        cli_type=Path,
+        cli_help="Directory containing licensed external RLP CSV files.",
+        cli_normalizer=str,
+    ),
+    "tilt": AppConfigField(
+        default=None,
+        default_order=5,
+        cli_flags=("--tilt",),
+        cli_type=float,
+        cli_help="PV tilt angle in degrees.",
+    ),
+    "azimuth": AppConfigField(
+        default=None,
+        default_order=6,
+        cli_flags=("--azimuth",),
+        cli_type=float,
+        cli_help="PV surface azimuth in degrees.",
+    ),
+    "transposition_model": AppConfigField(
+        default=DEFAULT_TRANSPOSITION_MODEL,
+        default_order=15,
+        cli_flags=("--transposition-model", "--sky-model"),
+        cli_choices=tuple(TRANSPOSITION_MODELS),
+        cli_help="Sky-diffusion model for POA transposition (default: isotropic).",
+    ),
+    "albedo": AppConfigField(
+        default=None,
+        default_order=16,
+        cli_flags=("--albedo",),
+        cli_type=float,
+        cli_help="Ground reflectance 0-1 (default: pvlib 0.25). Excludes --surface-type.",
+    ),
+    "surface_type": AppConfigField(
+        default=None,
+        default_order=17,
+        cli_flags=("--surface-type",),
+        cli_choices=tuple(SURFACE_TYPES),
+        cli_help="Named ground cover mapped to an albedo (alternative to --albedo).",
+    ),
+    "model_perez": AppConfigField(
+        default=DEFAULT_PEREZ_MODEL,
+        default_order=18,
+        cli_flags=("--perez-model",),
+        cli_choices=tuple(PEREZ_MODELS),
+        cli_help="Perez coefficient set (only used with --transposition-model perez).",
+    ),
+    "solar_position": AppConfigField(
+        default=DEFAULT_SOLAR_POSITION,
+        default_order=19,
+        cli_flags=("--solar-position",),
+        cli_choices=tuple(SOLAR_POSITION_METHODS),
+        cli_help=(
+            "Where within each timestep the sun position is evaluated. 'mid-interval' matches "
+            "PVWatts/SAM for interval-averaged weather (default: interval-start)."
+        ),
+    ),
+    "iam_model": AppConfigField(
+        default=DEFAULT_IAM_MODEL,
+        default_order=20,
+        cli_flags=("--iam-model",),
+        cli_choices=tuple(IAM_MODELS),
+        cli_help="Beam incidence-angle modifier (default: ashrae, historical compatibility).",
+    ),
+    "diffuse_iam": AppConfigField(
+        default=DEFAULT_DIFFUSE_IAM,
+        default_order=21,
+        cli_flags=("--diffuse-iam",),
+        cli_choices=tuple(DIFFUSE_IAM_METHODS),
+        cli_help=(
+            "Whether IAM is also applied to the diffuse POA components. 'marion' weighs sky- and "
+            "ground-diffuse with the view-factor-integrated selected IAM model (default: none, beam-only)."
+        ),
+    ),
+    "temperature_model": AppConfigField(
+        default=DEFAULT_TEMPERATURE_MODEL,
+        default_order=22,
+        cli_flags=("--temperature-model",),
+        cli_choices=tuple(TEMPERATURE_MODELS),
+        cli_help=(
+            "Cell-temperature model / mounting preset. The pvsyst-* and sapm-* presets use documented "
+            "mounting coefficients; noct-sam additionally requires sourced module NOCT and efficiency "
+            "metadata (not yet bundled). Default: faiman, open rack."
+        ),
+    ),
+    "bifacial_model": AppConfigField(
+        default=DEFAULT_BIFACIAL_MODEL,
+        default_order=23,
+        cli_flags=("--bifacial-model",),
+        cli_choices=tuple(BIFACIAL_MODELS),
+        cli_help=(
+            "Rear-irradiance model (default: none; infinite_sheds requires bifacial module metadata and row geometry)."
+        ),
+    ),
+    "pvrow_height": AppConfigField(
+        default=None,
+        default_order=24,
+        cli_flags=("--pvrow-height",),
+        cli_type=float,
+        cli_help="PV row center height above ground; use the same unit as --pvrow-pitch.",
+    ),
+    "pvrow_pitch": AppConfigField(
+        default=None,
+        default_order=25,
+        cli_flags=("--pvrow-pitch",),
+        cli_type=float,
+        cli_help="Distance between PV rows; use the same unit as --pvrow-height.",
+    ),
+    "gcr": AppConfigField(
+        default=0.35,
+        default_order=12,
+        cli_flags=("--gcr",),
+        cli_type=float,
+        cli_help="PV row ground coverage ratio (default: 0.35).",
+    ),
+    "resolution": AppConfigField(
+        default="h",
+        default_order=26,
+        cli_flags=("--resolution",),
+        cli_choices=("h", "15min"),
+        cli_help="Simulation time resolution.",
+    ),
+    "projection_years": AppConfigField(
+        default=20,
+        default_order=27,
+        cli_flags=("--projection-years",),
+        cli_type=int,
+        cli_help="Economic projection horizon.",
+    ),
+    "inflation_rate": AppConfigField(
+        default=0.02,
+        default_order=29,
+        cli_flags=("--inflation-rate",),
+        cli_type=float,
+        cli_help="Annual electricity price inflation.",
+    ),
+    "sell_price_inflation": AppConfigField(
+        default=0.0,
+        default_order=30,
+        cli_flags=("--sell-price-inflation",),
+        cli_type=float,
+        cli_help="Annual inflation of the grid export (sell) price. Default 0.",
+    ),
+    "export_emissions_factor_gco2_kwh": AppConfigField(
+        default=None,
+        default_order=33,
+        cli_flags=("--export-emissions-factor-gco2-kwh",),
+        cli_type=float,
+        cli_help="Exported-generation displacement factor in gCO2/kWh (default: grid avoided factor).",
+    ),
+    "discount_rate": AppConfigField(
+        default=0.03,
+        default_order=31,
+        cli_flags=("--discount-rate",),
+        cli_type=float,
+        cli_help="Discount rate for NPV calculations.",
+    ),
+    "pv_degradation_rate": AppConfigField(
+        default=0.005,
+        default_order=34,
+        cli_flags=("--pv-degradation-rate",),
+        cli_type=float,
+        cli_help="Annual PV degradation rate.",
+    ),
+    "calendar_model": AppConfigField(
+        default="naumann_lam_field_calibrated",
+        default_order=35,
+        cli_flags=("--calendar-model",),
+        cli_help="Battery calendar aging model.",
+    ),
+    "degradation_engine": AppConfigField(
+        default="native",
+        default_order=36,
+        cli_flags=("--degradation-engine",),
+        cli_choices=("native", "blast"),
+        cli_help="Battery degradation engine (default: native Naumann/Lam).",
+    ),
+    "blast_model": AppConfigField(
+        default=None,
+        default_order=37,
+        cli_flags=("--blast-model",),
+        cli_help="Stable BLAST battery-model key; requires --degradation-engine blast.",
+    ),
+    "dc_coupled": AppConfigField(
+        default=True,
+        default_order=45,
+        cli_flags=("--dc-coupled",),
+        cli_action="store_true",
+        cli_help="Use the supported DC-coupled/hybrid battery model.",
+    ),
+    "inverter_efficiency": AppConfigField(
+        default=0.96,
+        default_order=46,
+        cli_flags=("--inverter-efficiency",),
+        cli_type=float,
+        cli_help="Inverter efficiency.",
+    ),
+    "inverter_loading_ratio": AppConfigField(
+        default=1.25,
+        default_order=47,
+        cli_flags=("--inverter-loading-ratio",),
+        cli_type=float,
+        cli_help="DC/AC oversizing ratio.",
+    ),
+    "start_date": AppConfigField(
+        default="2023-01-01",
+        default_order=49,
+        cli_flags=("--start-date",),
+        cli_help="Simulation start date, YYYY-MM-DD.",
+    ),
+    # Config-file/API-only fields.
+    "pv_arrays": AppConfigField(default=None, default_order=1),
+    "tracking": AppConfigField(default="fixed", default_order=7),
+    "axis_tilt": AppConfigField(default=0.0, default_order=8),
+    "axis_azimuth": AppConfigField(default=None, default_order=9),
+    "max_angle": AppConfigField(default=60.0, default_order=10),
+    "backtrack": AppConfigField(default=True, default_order=11),
+    "cross_axis_tilt": AppConfigField(default=0.0, default_order=13),
+    "dual_axis_max_tilt": AppConfigField(default=90.0, default_order=14),
+    "battery_min_soc": AppConfigField(default=0.10, default_order=38),
+    "battery_max_soc": AppConfigField(default=0.90, default_order=39),
+    "battery_eol_percentage": AppConfigField(default=0.70, default_order=40),
+    "battery_rte": AppConfigField(default=None, default_order=41),
+    "enable_resistance_fade": AppConfigField(default=False, default_order=44),
+    "pv_loss_overrides": AppConfigField(default=None, default_order=48),
+    # Runner sections are accepted by App resolution so each workflow can use
+    # the same base config validation. The CLI validates their own structure.
+    "montecarlo": AppConfigField(),
+    "sweep": AppConfigField(),
+    # Kept solely to preserve the existing actionable legacy-selector error.
+    "battery_type": AppConfigField(),
 }
 
-# Required inputs are not in DEFAULTS (they have no default); ``montecarlo`` and
-# ``sweep`` are optional config-file sections consumed by their dedicated
-# runners/CLI commands, which validate the same dict through resolve_app_config.
-# Everything else at the top level must be a known key so typos (e.g.
-# ``batery_kwh``) fail loudly instead of being silently dropped by
-# merge_defaults.
-ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(DEFAULTS) | {
-    "location",
-    "annual_consumption_kwh",
-    "n_modules",
-    "montecarlo",
-    "sweep",
-    "battery_type",
-}
+_DEFAULT_FIELDS = sorted(
+    ((name, field) for name, field in APP_CONFIG_FIELDS.items() if field.has_default),
+    key=lambda item: item[1].default_order if item[1].default_order is not None else math.inf,
+)
+DEFAULTS: dict[str, Any] = {name: field.default for name, field in _DEFAULT_FIELDS}
+
+# Everything at the top level must be registered so typos (e.g.
+# ``batery_kwh``) fail loudly instead of being silently dropped by defaults.
+ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(APP_CONFIG_FIELDS)
 
 
 @dataclass(frozen=True)

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -13,22 +13,12 @@ from pathlib import Path
 from typing import Any, Sequence
 
 from breos.app import App
-from breos.app_config import resolve_app_config
+from breos.app_config import APP_CONFIG_FIELDS, resolve_app_config
 from breos.degradation import get_battery_model_profile, list_battery_models
 from breos.load_profiles import PROFILE_ALIASES, PROFILE_NAMES
 from breos.pv_modules import MODULES
 from breos.resources import load_config_json
-from breos.solar import (
-    BIFACIAL_MODELS,
-    DIFFUSE_IAM_METHODS,
-    IAM_MODELS,
-    PEREZ_MODELS,
-    SOLAR_POSITION_METHODS,
-    SURFACE_TYPES,
-    TEMPERATURE_MODELS,
-    TRANSPOSITION_MODELS,
-    resolve_pvwatts_losses,
-)
+from breos.solar import resolve_pvwatts_losses
 
 
 def _package_version() -> str:
@@ -58,57 +48,21 @@ def _load_config(path: Path) -> dict[str, Any]:
     return {key.replace("-", "_"): value for key, value in data.items()}
 
 
-def _add_override(overrides: dict[str, Any], key: str, value: Any) -> None:
-    if value is not None:
-        overrides[key] = value
-
-
 def _build_config(args: argparse.Namespace) -> dict[str, Any]:
     config = _load_config(args.config) if args.config else {}
 
     overrides: dict[str, Any] = {}
-    _add_override(overrides, "location", args.location.lower() if args.location else None)
-    _add_override(overrides, "n_modules", args.n_modules)
-    _add_override(overrides, "annual_consumption_kwh", args.annual_consumption_kwh)
-    _add_override(overrides, "battery_kwh", args.battery_kwh)
-    _add_override(overrides, "battery_max_charge_power_w", args.battery_max_charge_power_w)
-    _add_override(overrides, "battery_max_discharge_power_w", args.battery_max_discharge_power_w)
-    _add_override(overrides, "pv_module", args.pv_module)
-    _add_override(overrides, "load_profile", args.load_profile)
-    _add_override(overrides, "rlp_directory", str(args.rlp_directory) if args.rlp_directory else None)
-    _add_override(overrides, "tilt", args.tilt)
-    _add_override(overrides, "azimuth", args.azimuth)
-    _add_override(overrides, "transposition_model", args.transposition_model)
-    _add_override(overrides, "albedo", args.albedo)
-    _add_override(overrides, "surface_type", args.surface_type)
-    _add_override(overrides, "model_perez", args.model_perez)
-    _add_override(overrides, "solar_position", args.solar_position)
-    _add_override(overrides, "iam_model", args.iam_model)
-    _add_override(overrides, "diffuse_iam", args.diffuse_iam)
-    _add_override(overrides, "temperature_model", args.temperature_model)
-    _add_override(overrides, "bifacial_model", args.bifacial_model)
-    _add_override(overrides, "pvrow_height", args.pvrow_height)
-    _add_override(overrides, "pvrow_pitch", args.pvrow_pitch)
-    _add_override(overrides, "gcr", args.gcr)
-    _add_override(overrides, "resolution", args.resolution)
-    _add_override(overrides, "projection_years", args.projection_years)
-    _add_override(overrides, "inflation_rate", args.inflation_rate)
-    _add_override(overrides, "sell_price_inflation", args.sell_price_inflation)
-    _add_override(overrides, "export_emissions_factor_gco2_kwh", args.export_emissions_factor_gco2_kwh)
-    _add_override(overrides, "discount_rate", args.discount_rate)
-    _add_override(overrides, "pv_degradation_rate", args.pv_degradation_rate)
-    _add_override(overrides, "calendar_model", args.calendar_model)
-    _add_override(overrides, "degradation_engine", args.degradation_engine)
-    _add_override(overrides, "blast_model", args.blast_model)
-    _add_override(overrides, "dc_coupled", args.dc_coupled)
-    _add_override(overrides, "inverter_efficiency", args.inverter_efficiency)
-    _add_override(overrides, "inverter_loading_ratio", args.inverter_loading_ratio)
-    _add_override(overrides, "start_date", args.start_date)
-
-    if args.cost_preset:
-        overrides["cost_preset"] = args.cost_preset.replace("-", "_")
-    if args.emissions_country:
-        overrides["emissions_country"] = args.emissions_country.upper()
+    for key, field in APP_CONFIG_FIELDS.items():
+        if not field.cli_flags:
+            continue
+        value = getattr(args, key)
+        if value is None:
+            continue
+        if field.cli_normalizer is not None:
+            value = field.cli_normalizer(value)
+        if value is None:
+            continue
+        overrides[key] = value
 
     return {**config, **overrides}
 
@@ -509,6 +463,24 @@ def _montecarlo(args: argparse.Namespace) -> int:
     return 0
 
 
+def _add_run_config_arguments(parser: argparse.ArgumentParser) -> None:
+    """Generate App config override flags from the field registry."""
+    for key, field in APP_CONFIG_FIELDS.items():
+        if not field.cli_flags:
+            continue
+
+        kwargs: dict[str, Any] = {"dest": key, "help": field.cli_help}
+        if field.cli_type is not None:
+            kwargs["type"] = field.cli_type
+        if field.cli_choices is not None:
+            kwargs["choices"] = field.cli_choices
+        if field.cli_action is not None:
+            kwargs["action"] = field.cli_action
+            # A missing boolean flag must not overwrite a config-file value.
+            kwargs["default"] = None
+        parser.add_argument(*field.cli_flags, **kwargs)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="breos", description="Run BREOS simulations from the command line.")
     parser.add_argument("--version", action="version", version=f"breos {_package_version()}")
@@ -517,127 +489,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     run = subparsers.add_parser("run", help="Run a PV + battery simulation.")
     run.add_argument("--config", type=Path, help="TOML or JSON file with App configuration.")
-    run.add_argument("--location", help="Location preset key, for example 'porto'.")
-    run.add_argument("--n-modules", type=int, help="Number of PV modules.")
-    run.add_argument("--annual-consumption-kwh", type=float, help="Annual electricity demand in kWh.")
-    run.add_argument("--battery-kwh", type=float, help="Battery capacity in kWh.")
-    run.add_argument(
-        "--battery-max-charge-power-w",
-        type=float,
-        help="Maximum DC power entering the battery charge path in W (default: unlimited).",
-    )
-    run.add_argument(
-        "--battery-max-discharge-power-w",
-        type=float,
-        help="Maximum battery AC power delivered to load in W (default: unlimited).",
-    )
-    run.add_argument("--cost-preset", help="Cost preset key, for example 'residential-pt'.")
-    run.add_argument("--emissions-country", help="Country code for emissions, for example 'pt'.")
-    run.add_argument("--pv-module", help="PV module catalogue key.")
-    run.add_argument("--load-profile", help="Load profile type.")
-    run.add_argument("--rlp-directory", type=Path, help="Directory containing licensed external RLP CSV files.")
-    run.add_argument("--tilt", type=float, help="PV tilt angle in degrees.")
-    run.add_argument("--azimuth", type=float, help="PV surface azimuth in degrees.")
-    run.add_argument(
-        "--transposition-model",
-        "--sky-model",
-        dest="transposition_model",
-        choices=TRANSPOSITION_MODELS,
-        help="Sky-diffusion model for POA transposition (default: isotropic).",
-    )
-    run.add_argument(
-        "--albedo", type=float, help="Ground reflectance 0-1 (default: pvlib 0.25). Excludes --surface-type."
-    )
-    run.add_argument(
-        "--surface-type",
-        choices=SURFACE_TYPES,
-        help="Named ground cover mapped to an albedo (alternative to --albedo).",
-    )
-    run.add_argument(
-        "--perez-model",
-        dest="model_perez",
-        choices=PEREZ_MODELS,
-        help="Perez coefficient set (only used with --transposition-model perez).",
-    )
-    run.add_argument(
-        "--solar-position",
-        dest="solar_position",
-        choices=SOLAR_POSITION_METHODS,
-        help=(
-            "Where within each timestep the sun position is evaluated. 'mid-interval' matches "
-            "PVWatts/SAM for interval-averaged weather (default: interval-start)."
-        ),
-    )
-    run.add_argument(
-        "--iam-model",
-        choices=IAM_MODELS,
-        help="Beam incidence-angle modifier (default: ashrae, historical compatibility).",
-    )
-    run.add_argument(
-        "--diffuse-iam",
-        dest="diffuse_iam",
-        choices=DIFFUSE_IAM_METHODS,
-        help=(
-            "Whether IAM is also applied to the diffuse POA components. 'marion' weighs sky- and "
-            "ground-diffuse with the view-factor-integrated selected IAM model (default: none, beam-only)."
-        ),
-    )
-    run.add_argument(
-        "--temperature-model",
-        dest="temperature_model",
-        choices=TEMPERATURE_MODELS,
-        help=(
-            "Cell-temperature model / mounting preset. The pvsyst-* and sapm-* presets use documented "
-            "mounting coefficients; noct-sam additionally requires sourced module NOCT and efficiency "
-            "metadata (not yet bundled). Default: faiman, open rack."
-        ),
-    )
-    run.add_argument(
-        "--bifacial-model",
-        choices=BIFACIAL_MODELS,
-        help="Rear-irradiance model (default: none; infinite_sheds requires bifacial module metadata and row geometry).",
-    )
-    run.add_argument(
-        "--pvrow-height",
-        type=float,
-        help="PV row center height above ground; use the same unit as --pvrow-pitch.",
-    )
-    run.add_argument(
-        "--pvrow-pitch",
-        type=float,
-        help="Distance between PV rows; use the same unit as --pvrow-height.",
-    )
-    run.add_argument("--gcr", type=float, help="PV row ground coverage ratio (default: 0.35).")
-    run.add_argument("--resolution", choices=("h", "15min"), help="Simulation time resolution.")
-    run.add_argument("--projection-years", type=int, help="Economic projection horizon.")
-    run.add_argument("--inflation-rate", type=float, help="Annual electricity price inflation.")
-    run.add_argument(
-        "--sell-price-inflation", type=float, help="Annual inflation of the grid export (sell) price. Default 0."
-    )
-    run.add_argument(
-        "--export-emissions-factor-gco2-kwh",
-        type=float,
-        help="Exported-generation displacement factor in gCO2/kWh (default: grid avoided factor).",
-    )
-    run.add_argument("--discount-rate", type=float, help="Discount rate for NPV calculations.")
-    run.add_argument("--pv-degradation-rate", type=float, help="Annual PV degradation rate.")
-    run.add_argument("--calendar-model", help="Battery calendar aging model.")
-    run.add_argument(
-        "--degradation-engine",
-        choices=("native", "blast"),
-        help="Battery degradation engine (default: native Naumann/Lam).",
-    )
-    run.add_argument("--blast-model", help="Stable BLAST battery-model key; requires --degradation-engine blast.")
-    run.add_argument(
-        "--dc-coupled",
-        dest="dc_coupled",
-        action="store_true",
-        default=None,
-        help="Use the supported DC-coupled/hybrid battery model.",
-    )
-    run.add_argument("--inverter-efficiency", type=float, help="Inverter efficiency.")
-    run.add_argument("--inverter-loading-ratio", type=float, help="DC/AC oversizing ratio.")
-    run.add_argument("--start-date", help="Simulation start date, YYYY-MM-DD.")
+    _add_run_config_arguments(run)
     run.add_argument("--output", type=Path, help="Write JSON results to this file instead of stdout.")
     run.add_argument("--indent", type=int, default=2, help="JSON indentation. Use 0 for compact output.")
     run.add_argument("--dry-run", action="store_true", help="Validate and print resolved config without simulation.")

--- a/tests/test_app_config_registry.py
+++ b/tests/test_app_config_registry.py
@@ -1,0 +1,206 @@
+"""Characterization tests for declarative App configuration metadata."""
+
+import argparse
+
+from breos import cli
+from breos.app_config import ALLOWED_CONFIG_KEYS, APP_CONFIG_FIELDS, DEFAULTS
+
+EXPECTED_DEFAULTS = {
+    "battery_kwh": 0.0,
+    "pv_arrays": None,
+    "pv_module": None,
+    "load_profile": "1",
+    "rlp_directory": None,
+    "tilt": None,
+    "azimuth": None,
+    "tracking": "fixed",
+    "axis_tilt": 0.0,
+    "axis_azimuth": None,
+    "max_angle": 60.0,
+    "backtrack": True,
+    "gcr": 0.35,
+    "cross_axis_tilt": 0.0,
+    "dual_axis_max_tilt": 90.0,
+    "transposition_model": "isotropic",
+    "albedo": None,
+    "surface_type": None,
+    "model_perez": "allsitescomposite1990",
+    "solar_position": "interval-start",
+    "iam_model": "ashrae",
+    "diffuse_iam": "none",
+    "temperature_model": "faiman",
+    "bifacial_model": "none",
+    "pvrow_height": None,
+    "pvrow_pitch": None,
+    "resolution": "h",
+    "projection_years": 20,
+    "cost_preset": None,
+    "inflation_rate": 0.02,
+    "sell_price_inflation": 0.0,
+    "discount_rate": 0.03,
+    "emissions_country": None,
+    "export_emissions_factor_gco2_kwh": None,
+    "pv_degradation_rate": 0.005,
+    "calendar_model": "naumann_lam_field_calibrated",
+    "degradation_engine": "native",
+    "blast_model": None,
+    "battery_min_soc": 0.10,
+    "battery_max_soc": 0.90,
+    "battery_eol_percentage": 0.70,
+    "battery_rte": None,
+    "battery_max_charge_power_w": None,
+    "battery_max_discharge_power_w": None,
+    "enable_resistance_fade": False,
+    "dc_coupled": True,
+    "inverter_efficiency": 0.96,
+    "inverter_loading_ratio": 1.25,
+    "pv_loss_overrides": None,
+    "start_date": "2023-01-01",
+}
+
+EXPECTED_CLI_FIELDS = [
+    "location",
+    "n_modules",
+    "annual_consumption_kwh",
+    "battery_kwh",
+    "battery_max_charge_power_w",
+    "battery_max_discharge_power_w",
+    "cost_preset",
+    "emissions_country",
+    "pv_module",
+    "load_profile",
+    "rlp_directory",
+    "tilt",
+    "azimuth",
+    "transposition_model",
+    "albedo",
+    "surface_type",
+    "model_perez",
+    "solar_position",
+    "iam_model",
+    "diffuse_iam",
+    "temperature_model",
+    "bifacial_model",
+    "pvrow_height",
+    "pvrow_pitch",
+    "gcr",
+    "resolution",
+    "projection_years",
+    "inflation_rate",
+    "sell_price_inflation",
+    "export_emissions_factor_gco2_kwh",
+    "discount_rate",
+    "pv_degradation_rate",
+    "calendar_model",
+    "degradation_engine",
+    "blast_model",
+    "dc_coupled",
+    "inverter_efficiency",
+    "inverter_loading_ratio",
+    "start_date",
+]
+
+
+def _run_parser() -> argparse.ArgumentParser:
+    parser = cli.build_parser()
+    subcommands = next(action for action in parser._actions if isinstance(action, argparse._SubParsersAction))
+    return subcommands.choices["run"]
+
+
+def test_registry_preserves_defaults_and_allowed_top_level_keys():
+    assert DEFAULTS == EXPECTED_DEFAULTS
+    assert list(DEFAULTS) == list(EXPECTED_DEFAULTS)
+    default_orders = [field.default_order for field in APP_CONFIG_FIELDS.values() if field.has_default]
+    assert sorted(default_orders) == list(range(len(EXPECTED_DEFAULTS)))
+    assert ALLOWED_CONFIG_KEYS == frozenset(
+        set(EXPECTED_DEFAULTS)
+        | {
+            "location",
+            "annual_consumption_kwh",
+            "n_modules",
+            "montecarlo",
+            "sweep",
+            "battery_type",
+        }
+    )
+
+
+def test_registry_generates_every_app_config_cli_option():
+    run_actions = _run_parser()._actions
+    actions = {action.dest: action for action in run_actions}
+    registered_cli_fields = {key for key, field in APP_CONFIG_FIELDS.items() if field.cli_flags}
+    non_config_destinations = {"help", "config", "output", "indent", "dry_run"}
+
+    assert set(actions) - non_config_destinations == registered_cli_fields
+    assert [action.dest for action in run_actions if action.dest not in non_config_destinations] == EXPECTED_CLI_FIELDS
+    for key in registered_cli_fields:
+        field = APP_CONFIG_FIELDS[key]
+        action = actions[key]
+        assert tuple(action.option_strings) == field.cli_flags
+        assert action.type is field.cli_type
+        assert action.help == field.cli_help
+        assert action.default is None
+        actual_choices = tuple(action.choices) if action.choices is not None else None
+        assert actual_choices == field.cli_choices
+        if field.cli_action == "store_true":
+            assert action.const is True
+            assert action.default is None
+
+
+def test_registry_generated_cli_values_all_reach_config_overrides():
+    argv = ["run"]
+    expected: dict[str, object] = {}
+    for key, field in APP_CONFIG_FIELDS.items():
+        if not field.cli_flags:
+            continue
+        argv.append(field.cli_flags[0])
+        if field.cli_action == "store_true":
+            expected[key] = True
+            continue
+        if field.cli_choices is not None:
+            raw: object = field.cli_choices[0]
+        elif field.cli_type is int:
+            raw = 2
+        elif field.cli_type is float:
+            raw = 0.5
+        elif key == "cost_preset":
+            raw = "some-preset"
+        elif key == "emissions_country":
+            raw = "pt"
+        elif key == "location":
+            raw = "PORTO"
+        else:
+            raw = "/tmp/value" if field.cli_type is not None else "value"
+        argv.append(str(raw))
+        expected[key] = field.cli_normalizer(raw) if field.cli_normalizer is not None else raw
+
+    args = cli.build_parser().parse_args(argv)
+
+    assert cli._build_config(args) == expected
+
+
+def test_empty_normalized_cli_values_do_not_overwrite_config_file(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        'location = "berlin"\ncost_preset = "residential_de"\nemissions_country = "DE"\n',
+        encoding="utf-8",
+    )
+    args = cli.build_parser().parse_args(
+        [
+            "run",
+            "--config",
+            str(config_path),
+            "--location",
+            "",
+            "--cost-preset",
+            "",
+            "--emissions-country",
+            "",
+        ]
+    )
+
+    config = cli._build_config(args)
+
+    assert config["location"] == "berlin"
+    assert config["cost_preset"] == "residential_de"
+    assert config["emissions_country"] == "DE"


### PR DESCRIPTION
## Summary

- introduce one declarative registry for public App configuration metadata
- derive `DEFAULTS`, allowed top-level keys, run-command options, and CLI override handling from that registry
- preserve historical default ordering, aliases, normalizers, choices, and config-file precedence
- add registry invariants, shipped-example validation, and structural sweep validation

## Why

Configuration metadata was duplicated across `app_config.py` and `cli.py`, making new keys easy to expose inconsistently. The registry centralizes the mechanical contract while leaving scientific constraints in the existing focused validators, preserving their validation order, exception types, and messages.

Config/API-only fields remain intentionally absent from the CLI. Workflow sections and the legacy `battery_type` key retain their existing special handling.

## Validation

- focused config and CLI compatibility suite — 58 passed
- full combined validation before splitting — 792 passed, 7 skipped, 2 deselected
- slow suite — 2 passed
- `uv run ruff check breos tests`
- `uv run ruff format --check breos tests`
- source distribution and wheel built successfully
