### PR TITLE
Add economic cost overrides and dotted sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Added
+- Add a validated `[costs]` override table with explicit user override → named
+  preset → `CostParams` default precedence, plus dotted `[sweep]` keys such as
+  `costs.electricity_cost` for economic sensitivity runs. Unknown cost keys and
+  invalid values now fail with actionable errors; existing flat configurations
+  retain their previous resolved costs.
+
 ## [0.5.1] - 2026-08-11
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -468,10 +468,10 @@ the four standard techno-economic analyses:
   P10/P50/P90 NPV and LCOE, alongside the weather-year and load uncertainty
   Monte Carlo already samples.
 
-**Sequencing.** Phase 0 is a 0.5.x item; phases 1–3 follow the 0.6.0 TOU and
-currency work, which restructures the same preset/economics surface from scalar
-prices to price time series. Building the scenario layer on today's scalar
-surface would mean building it twice — the same reasoning that put the
+**Sequencing.** Phase 0 is delivered in 0.5.x; phases 1–3 still follow the 0.6.0
+TOU and currency work, which restructures the same preset/economics surface from
+scalar prices to price time series. Building the scenario layer on today's
+scalar surface would mean building it twice — the same reasoning that put the
 declarative config schema before TOU.
 
 **Architectural note: economics is downstream of the energy balance.** Dispatch
@@ -497,17 +497,12 @@ requirements, not optimisation details.
 
 Phases:
 
-- **Phase 0 — cost-override seam (0.5.x).** Today every price and capex term
-  (`electricity_cost`, `electricity_sold_cost`, `module_cost_per_w`,
-  `storage_cost_per_kwh`, …) reaches `CostParams` *only* through `cost_preset`
-  in `resolve_costs`; only `inflation_rate`, `sell_price_inflation`, and
-  `discount_rate` are top-level keys. And `_sweep` merges the grid at the top
-  level (`{**config, **varied}`), so it cannot reach a nested key. The result is
-  that electricity price and capex cannot be swept at all without authoring one
-  throwaway preset per value. Add a `[costs]` override table layered over
-  preset → dataclass defaults, and dotted-key support in `[sweep]`, both with
-  the existing `Unknown key '...'. Available: ...` error style. Small,
-  independently useful, and unaffected by the TOU restructure.
+- **Phase 0 — cost-override seam (delivered in 0.5.x).** A validated `[costs]`
+  table now layers explicit user overrides over the selected preset and
+  `CostParams` defaults. Dotted `[sweep]` keys can vary nested economic inputs
+  such as `costs.electricity_cost`, with actionable unknown-key errors. Existing
+  flat configurations retain their resolved costs bit-for-bit. This seam stays
+  independently useful and is unaffected by the TOU restructure.
 - **Phase 1 — escalator decomposition (0.6.x).** A single `inflation_rate`
   currently escalates import cost, O&M, the standing charge, *and* battery
   replacement capex alike. That conflates general inflation with energy-price

--- a/breos/app_config.py
+++ b/breos/app_config.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from breos.degradation.profiles import ENABLED_BLAST_MODEL_KEYS, apply_battery_profile_defaults
-from breos.economics import CostParams, calculate_costs
+from breos.economics import COST_CONFIG_KEY_TO_PARAM, CostParams, calculate_costs
 from breos.emissions import EmissionsParams
 from breos.pv.model_options import is_known_model, is_valid_albedo, is_valid_gcr, normalise_model_name
 from breos.pv.temperature import validate_temperature_inputs
@@ -347,6 +347,7 @@ APP_CONFIG_FIELDS: dict[str, AppConfigField] = {
         cli_help="Simulation start date, YYYY-MM-DD.",
     ),
     # Config-file/API-only fields.
+    "costs": AppConfigField(),
     "pv_arrays": AppConfigField(default=None, default_order=1),
     "tracking": AppConfigField(default="fixed", default_order=7),
     "axis_tilt": AppConfigField(default=0.0, default_order=8),
@@ -378,6 +379,11 @@ DEFAULTS: dict[str, Any] = {name: field.default for name, field in _DEFAULT_FIEL
 # Everything at the top level must be registered so typos (e.g.
 # ``batery_kwh``) fail loudly instead of being silently dropped by defaults.
 ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(APP_CONFIG_FIELDS)
+
+# Cost override keys deliberately use the existing preset-catalog vocabulary;
+# the canonical translation to CostParams lives in ``breos.economics`` so the
+# App and lower-level construction helper cannot drift.
+COST_OVERRIDE_KEYS: frozenset[str] = frozenset(COST_CONFIG_KEY_TO_PARAM)
 
 
 @dataclass(frozen=True)
@@ -692,6 +698,21 @@ def _validate_economics(cfg: dict[str, Any]) -> None:
             raise ValueError(f"'{key}' must be greater than -1")
     if not -1 < _finite_real(cfg["sell_price_inflation"], "sell_price_inflation") < 1:
         raise ValueError("'sell_price_inflation' must be between -1 and 1 (exclusive)")
+    if "costs" in cfg:
+        overrides = cfg["costs"]
+        if not isinstance(overrides, dict):
+            raise TypeError("'costs' must be a table/dict of cost overrides")
+        unknown = set(overrides) - COST_OVERRIDE_KEYS
+        if unknown:
+            available = ", ".join(f"costs.{key}" for key in sorted(COST_OVERRIDE_KEYS))
+            if len(unknown) == 1:
+                unknown_text = f"Unknown key 'costs.{next(iter(unknown))}'"
+            else:
+                unknown_text = "Unknown keys " + ", ".join(f"'costs.{key}'" for key in sorted(unknown))
+            raise ValueError(f"{unknown_text}. Available: {available}")
+        for key, value in overrides.items():
+            if _finite_real(value, f"costs.{key}") < 0:
+                raise ValueError(f"'costs.{key}' must be >= 0")
     if cfg["export_emissions_factor_gco2_kwh"] is not None:
         if _finite_real(cfg["export_emissions_factor_gco2_kwh"], "export_emissions_factor_gco2_kwh") < 0:
             raise ValueError("'export_emissions_factor_gco2_kwh' must be >= 0 when configured")
@@ -890,7 +911,6 @@ def resolve_costs(cfg: dict[str, Any]) -> CostParams:
     preset is configured, so the two paths cannot diverge.
     """
     params: dict[str, Any] = {}
-    defaults = CostParams()
 
     if cfg.get("cost_preset"):
         costs_db = load_json("costs.json")
@@ -899,28 +919,15 @@ def resolve_costs(cfg: dict[str, Any]) -> CostParams:
             available = ", ".join(sorted(costs_db))
             raise ValueError(f"Unknown cost preset '{preset_key}'. Available: {available}")
         preset = costs_db[preset_key]
+        for config_key, param_key in COST_CONFIG_KEY_TO_PARAM.items():
+            if config_key in preset:
+                params[param_key] = preset[config_key]
 
-        params["electricity_cost"] = preset.get("electricity_cost", defaults.electricity_cost)
-        params["electricity_sold_cost"] = preset.get("electricity_sold_cost", defaults.electricity_sold_cost)
-        params["daily_power_cost"] = preset.get("daily_power_cost", defaults.daily_power_cost)
-        params["module_cost_per_w"] = preset.get("module_cost_per_w", defaults.module_cost_per_w)
-        params["battery_cost_per_kwh"] = preset.get("storage_cost_per_kwh", defaults.battery_cost_per_kwh)
-        params["inverter_cost_per_kw"] = preset.get("inverter_cost_per_kw_hybrid", defaults.inverter_cost_per_kw)
-        params["inverter_cost_per_kw_nobatt"] = preset.get(
-            "inverter_cost_per_kw_simple", defaults.inverter_cost_per_kw_nobatt
-        )
-        params["installation_cost_per_module"] = preset.get(
-            "installation_cost_per_module", defaults.installation_cost_per_module
-        )
-        params["battery_installation_cost"] = preset.get(
-            "installation_cost_battery", defaults.battery_installation_cost
-        )
-        params["maintenance_cost_per_panel"] = preset.get(
-            "maintenance_cost_per_panel", defaults.maintenance_cost_per_panel
-        )
-        params["maintenance_cost_fixed"] = preset.get("maintenance_cost", defaults.maintenance_cost_fixed)
-        params["other_cost_per_module"] = preset.get("other_cost_per_module", defaults.other_cost_per_module)
-        params["other_cost_fixed"] = preset.get("other_costs", defaults.other_cost_fixed)
+    # Explicit values are the final layer: user overrides > named preset >
+    # CostParams defaults. Validation has already guaranteed this is a known,
+    # finite, non-negative table.
+    for config_key, value in cfg.get("costs", {}).items():
+        params[COST_CONFIG_KEY_TO_PARAM[config_key]] = value
 
     params["dc_ac_ratio"] = cfg["inverter_loading_ratio"]
     params.setdefault("inflation_rate", cfg["inflation_rate"])

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -341,6 +341,11 @@ def _normalise_sweep_grid(raw_grid: Any) -> dict[str, list[Any]]:
         if top_level not in ALLOWED_CONFIG_KEYS:
             available = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
             raise ValueError(f"Unknown sweep key '{key}'. Available: {available}")
+        if separator and top_level != "costs":
+            available = ", ".join(f"costs.{name}" for name in sorted(COST_OVERRIDE_KEYS))
+            raise ValueError(
+                f"Unknown sweep key '{key}'. Dotted keys are supported only under 'costs'. Available: {available}"
+            )
         if top_level == "costs" and (not separator or nested not in COST_OVERRIDE_KEYS):
             available = ", ".join(f"costs.{name}" for name in sorted(COST_OVERRIDE_KEYS))
             raise ValueError(f"Unknown sweep key '{key}'. Available: {available}")

--- a/breos/cli.py
+++ b/breos/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import csv
 import itertools
 import json
@@ -13,7 +14,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 from breos.app import App
-from breos.app_config import APP_CONFIG_FIELDS, resolve_app_config
+from breos.app_config import ALLOWED_CONFIG_KEYS, APP_CONFIG_FIELDS, COST_OVERRIDE_KEYS, resolve_app_config
 from breos.degradation import get_battery_model_profile, list_battery_models
 from breos.load_profiles import PROFILE_ALIASES, PROFILE_NAMES
 from breos.pv_modules import MODULES
@@ -316,15 +317,60 @@ def _normalise_sweep_grid(raw_grid: Any) -> dict[str, list[Any]]:
         raise TypeError("Sweep config must contain a [sweep] table with parameter arrays.")
 
     grid: dict[str, list[Any]] = {}
-    for key, values in raw_grid.items():
-        normalised_key = key.replace("-", "_")
-        if not isinstance(values, list) or not values:
-            raise ValueError(f"sweep.{key} must be a non-empty array of values")
-        grid[normalised_key] = values
+
+    def add_entries(entries: dict[str, Any], prefix: str = "") -> None:
+        for raw_key, values in entries.items():
+            key = raw_key.replace("-", "_")
+            dotted_key = f"{prefix}.{key}" if prefix else key
+            if isinstance(values, dict):
+                add_entries(values, dotted_key)
+                continue
+            if not isinstance(values, list) or not values:
+                raise ValueError(f"sweep.{dotted_key} must be a non-empty array of values")
+            if dotted_key in grid:
+                raise ValueError(f"Duplicate sweep key '{dotted_key}'")
+            grid[dotted_key] = values
+
+    add_entries(raw_grid)
 
     if not grid:
         raise ValueError("Sweep config must define at least one parameter under [sweep].")
+
+    for key in grid:
+        top_level, separator, nested = key.partition(".")
+        if top_level not in ALLOWED_CONFIG_KEYS:
+            available = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
+            raise ValueError(f"Unknown sweep key '{key}'. Available: {available}")
+        if top_level == "costs" and (not separator or nested not in COST_OVERRIDE_KEYS):
+            available = ", ".join(f"costs.{name}" for name in sorted(COST_OVERRIDE_KEYS))
+            raise ValueError(f"Unknown sweep key '{key}'. Available: {available}")
+
+    keys = set(grid)
+    for key in keys:
+        parts = key.split(".")
+        for index in range(1, len(parts)):
+            parent = ".".join(parts[:index])
+            if parent in keys:
+                raise ValueError(f"Sweep keys '{parent}' and '{key}' conflict")
     return grid
+
+
+def _apply_sweep_values(config: dict[str, Any], varied: dict[str, Any]) -> dict[str, Any]:
+    """Return a run config with top-level or dotted sweep values applied."""
+    result = copy.deepcopy(config)
+    for key, value in varied.items():
+        parts = key.split(".")
+        target = result
+        for part in parts[:-1]:
+            child = target.get(part)
+            if child is None:
+                child = {}
+                target[part] = child
+            if not isinstance(child, dict):
+                raise TypeError(f"Cannot apply sweep key '{key}': '{part}' is not a table/dict")
+            target = child
+        target[parts[-1]] = value
+    return result
 
 
 def _csv_cell(value: Any) -> Any:
@@ -370,7 +416,7 @@ def _sweep(args: argparse.Namespace) -> int:
 
     for run_idx, values in enumerate(itertools.product(*(grid[key] for key in param_keys)), start=1):
         varied = dict(zip(param_keys, values))
-        run_config = {**config, **varied}
+        run_config = _apply_sweep_values(config, varied)
         resolved = _resolved_config_summary(run_config)
 
         app = App(run_config)

--- a/breos/economics.py
+++ b/breos/economics.py
@@ -21,6 +21,27 @@ BATTERY_REPLACEMENT_COST_PER_KWH: float = 500.0
 
 SYSTEM_AC_PRODUCTION_COLUMNS = ("PV_AC_To_Load", "Battery_AC_To_Load_PV")
 
+# Canonical translation from the public cost-catalogue/config vocabulary to
+# CostParams attributes. App presets, App ``[costs]`` overrides, and the
+# lower-level ``cost_params_from_config`` helper all share this mapping.
+COST_CONFIG_KEY_TO_PARAM: dict[str, str] = {
+    "electricity_cost": "electricity_cost",
+    "electricity_sold_cost": "electricity_sold_cost",
+    "daily_power_cost": "daily_power_cost",
+    "module_cost_per_w": "module_cost_per_w",
+    "storage_cost_per_kwh": "battery_cost_per_kwh",
+    "inverter_cost_per_kw_hybrid": "inverter_cost_per_kw",
+    "inverter_cost_per_kw_simple": "inverter_cost_per_kw_nobatt",
+    "installation_cost_per_module": "installation_cost_per_module",
+    "installation_cost_battery": "battery_installation_cost",
+    "other_cost_per_module": "other_cost_per_module",
+    "other_costs": "other_cost_fixed",
+    "land_cost": "land_cost",
+    "maintenance_cost_per_panel": "maintenance_cost_per_panel",
+    "maintenance_cost": "maintenance_cost_fixed",
+    "operation_cost": "operation_cost",
+}
+
 
 def system_ac_production_power(results_df: pd.DataFrame) -> pd.Series:
     """Return usable PV-system AC production in the frame's power unit.
@@ -89,37 +110,23 @@ def cost_params_from_config(
     financials_config = financials_config or {}
     defaults = CostParams()
 
-    return CostParams(
-        electricity_cost=costs_config.get(
-            "electricity_cost",
-            financials_config.get("electricity_cost", defaults.electricity_cost),
-        ),
-        electricity_sold_cost=costs_config.get(
-            "electricity_sold_cost",
-            financials_config.get("electricity_sold_cost", defaults.electricity_sold_cost),
-        ),
-        daily_power_cost=costs_config.get("daily_power_cost", defaults.daily_power_cost),
-        module_cost_per_w=costs_config.get("module_cost_per_w", defaults.module_cost_per_w),
-        battery_cost_per_kwh=costs_config.get("storage_cost_per_kwh", defaults.battery_cost_per_kwh),
+    params = {
+        param_key: costs_config.get(config_key, getattr(defaults, param_key))
+        for config_key, param_key in COST_CONFIG_KEY_TO_PARAM.items()
+    }
+    # Historical lower-level callers can supply the two energy prices through
+    # ``financials_config``; an explicit costs value still takes precedence.
+    for key in ("electricity_cost", "electricity_sold_cost"):
+        if key not in costs_config:
+            params[key] = financials_config.get(key, getattr(defaults, key))
+    params.update(
         dc_ac_ratio=costs_config.get("dc_ac_ratio", defaults.dc_ac_ratio),
-        inverter_cost_per_kw=costs_config.get("inverter_cost_per_kw_hybrid", defaults.inverter_cost_per_kw),
-        inverter_cost_per_kw_nobatt=costs_config.get(
-            "inverter_cost_per_kw_simple", defaults.inverter_cost_per_kw_nobatt
-        ),
-        installation_cost_per_module=costs_config.get(
-            "installation_cost_per_module", defaults.installation_cost_per_module
-        ),
-        battery_installation_cost=costs_config.get("installation_cost_battery", defaults.battery_installation_cost),
-        other_cost_per_module=costs_config.get("other_cost_per_module", defaults.other_cost_per_module),
-        other_cost_fixed=costs_config.get("other_costs", defaults.other_cost_fixed),
-        maintenance_cost_per_panel=costs_config.get("maintenance_cost_per_panel", defaults.maintenance_cost_per_panel),
-        maintenance_cost_fixed=costs_config.get("maintenance_cost", defaults.maintenance_cost_fixed),
-        operation_cost=costs_config.get("operation_cost", defaults.operation_cost),
         inflation_rate=financials_config.get("inflation_rate", defaults.inflation_rate),
         sell_price_inflation=financials_config.get("sell_price_inflation", defaults.sell_price_inflation),
         discount_rate=financials_config.get("discount_rate", defaults.discount_rate),
         pv_degradation_rate=financials_config.get("pv_degradation_rate", defaults.pv_degradation_rate),
     )
+    return CostParams(**params)
 
 
 def calculate_costs(

--- a/configs/README.md
+++ b/configs/README.md
@@ -86,9 +86,11 @@ any example and edit it for your own scenario.
 - For external RLPs, use [`examples/external-rlp.toml`](examples/external-rlp.toml)
   as a template and put the licensed CSV files in a local directory such as
   `external_rlp/` (do not commit third-party RLPs).
-- `breos run` configs are **flat** key/value files (TOML or JSON). The only
-  recognised table for `breos run` is `[[pv_arrays]]`. The `[sweep]` and
-  `[montecarlo]` tables are read by their dedicated CLI commands.
+- `breos run` configs are mostly flat key/value files (TOML or JSON).
+  `[[pv_arrays]]` describes multiple arrays and `[costs]` holds explicit cost
+  overrides. The `[sweep]` and `[montecarlo]` tables are read by their dedicated
+  CLI commands; sweep entries can use quoted dotted keys such as
+  `"costs.electricity_cost"`.
 - Configs written for the research `pvbat` engine — with nested model sections,
   inheritance, or simulation-type blocks — are **not** compatible. BREOS
   rejects unknown top-level keys rather than silently applying defaults.

--- a/configs/examples/sweep.toml
+++ b/configs/examples/sweep.toml
@@ -2,8 +2,9 @@
 #
 #   breos sweep --config configs/examples/sweep.toml --output sweep_results.csv
 #
-# The top-level keys are the base App config. Each key under [sweep] replaces
-# the matching top-level App config key for that run.
+# The top-level keys and tables are the base App config. Each key under
+# [sweep] replaces the matching App config value for that run. Quote dotted
+# keys to reach values inside tables such as [costs].
 
 location = "porto"
 n_modules = 10
@@ -15,6 +16,10 @@ emissions_country = "PT"
 projection_years = 20
 resolution = "h"
 
+[costs]
+electricity_cost = 0.2582
+
 [sweep]
 n_modules = [8, 10, 12]
 battery_kwh = [0.0, 5.0]
+"costs.electricity_cost" = [0.20, 0.30]

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -49,6 +49,7 @@ weather/data access, load profiles, PV system data, and cost assumptions; see
 | `resolution` | `"h"` | Time resolution (`"h"` or `"15min"`) |
 | `projection_years` | `20` | Economic projection horizon |
 | `cost_preset` | `None` | Cost preset key from packaged defaults |
+| `costs` | *unset* | Optional cost overrides layered over the selected preset and built-in defaults; see [below](#cost-and-emissions-presets) |
 | `inflation_rate` | `0.02` | Annual electricity price inflation |
 | `sell_price_inflation` | `0.0` | Annual inflation of the grid export (sell) price |
 | `discount_rate` | `0.03` | Discount rate for NPV |
@@ -361,7 +362,9 @@ location/era-specific fits from the Perez papers and are only consulted when
 
 Built-in presets are packaged with BREOS. Editable copies and examples live
 in `configs/base/` and `configs/examples/`.
-Pass the key:
+Pass the key, then use the optional `costs` table for project-specific values.
+Explicit overrides win over the named preset; preset values win over
+{py:class}`~breos.CostParams` defaults:
 
 ```python
 breos.App({
@@ -369,9 +372,32 @@ breos.App({
     "n_modules": 10,
     "annual_consumption_kwh": 4000,
     "cost_preset": "residential_pt",
+    "costs": {
+        "electricity_cost": 0.22,
+        "storage_cost_per_kwh": 425.0,
+    },
     "emissions_country": "PT",
 })
 ```
+
+TOML uses a dedicated table:
+
+```toml
+cost_preset = "residential_pt"
+
+[costs]
+electricity_cost = 0.22
+storage_cost_per_kwh = 425.0
+```
+
+The accepted keys follow the packaged cost-catalogue names:
+`electricity_cost`, `electricity_sold_cost`, `daily_power_cost`,
+`module_cost_per_w`, `storage_cost_per_kwh`,
+`inverter_cost_per_kw_hybrid`, `inverter_cost_per_kw_simple`,
+`installation_cost_per_module`, `installation_cost_battery`,
+`other_cost_per_module`, `other_costs`, `land_cost`,
+`maintenance_cost_per_panel`, `maintenance_cost`, and `operation_cost`.
+Unknown keys and negative or non-finite values are rejected before simulation.
 
 For full control, build a {py:class}`~breos.CostParams` and
 {py:class}`~breos.EmissionsParams` yourself and call the lower-level

--- a/docs/getting-started/recipes.md
+++ b/docs/getting-started/recipes.md
@@ -117,8 +117,9 @@ From the CLI, the equivalent flag is `--transposition-model perez`
 
 Use `breos sweep` when you want to run the same scenario over an explicit grid
 of App config values. The top-level keys define the base scenario; every key
-under `[sweep]` replaces the matching top-level key for each run. The command
-runs the Cartesian product and writes one CSV row per combination:
+under `[sweep]` replaces the matching key for each run. Quote dotted keys to
+vary values inside a table such as `[costs]`. The command runs the Cartesian
+product and writes one CSV row per combination:
 
 ```toml
 location = "porto"
@@ -134,13 +135,15 @@ resolution = "h"
 [sweep]
 n_modules = [8, 10, 12]
 battery_kwh = [0.0, 5.0]
+"costs.electricity_cost" = [0.20, 0.30]
 ```
 
 ```bash
 breos sweep --config config.toml --output sweep_results.csv
 ```
 
-The output includes the varied parameters (`param_*` columns), resolved system
+The output includes the varied parameters (`param_*` columns, including for
+example `param_costs.electricity_cost`), resolved system
 sizing, the BREOS version, and top-level scalar result metrics such as grid
 independence, NPV, payback, LCOE, and battery replacement totals. This is
 explicit enumeration, not an optimizer; use the optimization API for searching

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -59,6 +59,53 @@ class TestAppValidation:
         with pytest.raises(ValueError, match="Unknown cost preset"):
             App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "cost_preset": "fake_preset"})
 
+    def test_cost_overrides_must_be_a_table(self):
+        with pytest.raises(TypeError, match="'costs' must be a table/dict"):
+            App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "costs": 0.25})
+
+    def test_unknown_cost_override_is_actionable(self):
+        with pytest.raises(ValueError, match=r"Unknown key 'costs\.electricty_cost'.*costs\.electricity_cost"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "costs": {"electricty_cost": 0.25},
+                }
+            )
+
+    def test_cost_overrides_resolve_through_app_facade(self):
+        app = App(
+            {
+                "location": "porto",
+                "n_modules": 10,
+                "annual_consumption_kwh": 4000,
+                "cost_preset": "residential_pt",
+                "costs": {
+                    "electricity_cost": 0.22,
+                    "storage_cost_per_kwh": 425.0,
+                    "land_cost": 1000.0,
+                },
+            }
+        )
+
+        assert app._resolved.cost_params.electricity_cost == 0.22
+        assert app._resolved.cost_params.battery_cost_per_kwh == 425.0
+        assert app._resolved.cost_params.land_cost == 1000.0
+        assert app._resolved.cost_params.module_cost_per_w == 0.125
+
+    @pytest.mark.parametrize("value", [-0.01, float("inf"), True])
+    def test_cost_overrides_must_be_non_negative_finite_numbers(self, value):
+        with pytest.raises((TypeError, ValueError), match=r"costs\.electricity_cost"):
+            App(
+                {
+                    "location": "porto",
+                    "n_modules": 10,
+                    "annual_consumption_kwh": 4000,
+                    "costs": {"electricity_cost": value},
+                }
+            )
+
     def test_invalid_emissions_country(self):
         with pytest.raises(ValueError, match="Unknown emissions country"):
             App({"location": "porto", "n_modules": 10, "annual_consumption_kwh": 4000, "emissions_country": "XX"})

--- a/tests/test_app_config_registry.py
+++ b/tests/test_app_config_registry.py
@@ -118,6 +118,7 @@ def test_registry_preserves_defaults_and_allowed_top_level_keys():
             "location",
             "annual_consumption_kwh",
             "n_modules",
+            "costs",
             "montecarlo",
             "sweep",
             "battery_type",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -574,3 +574,26 @@ annual_consumption_kwh = 3500
     error = capsys.readouterr().err
     assert "Unknown sweep key 'costs.electricty_cost'" in error
     assert "costs.electricity_cost" in error
+
+
+def test_validate_config_rejects_dotted_sweep_key_outside_costs(tmp_path, capsys):
+    config_path = tmp_path / "invalid-nested-sweep.toml"
+    config_path.write_text(
+        """
+location = "porto"
+n_modules = 8
+annual_consumption_kwh = 3500
+
+[sweep]
+"location.foo" = ["ignored-before-validation"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["validate-config", str(config_path)])
+
+    assert exit_code == 1
+    error = capsys.readouterr().err
+    assert "Unknown sweep key 'location.foo'" in error
+    assert "Dotted keys are supported only under 'costs'" in error
+    assert "costs.electricity_cost" in error

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -473,3 +473,104 @@ battery_kwh = [0.0, 5.0]
     assert rows[-1]["param_battery_kwh"] == "5.0"
     assert "yearly" not in rows[0]
     assert rows[0]["grid_independence_pct"] == "48.0"
+
+
+def test_sweep_applies_dotted_cost_keys_without_mutating_base_config(monkeypatch, tmp_path, capsys):
+    seen_configs = []
+
+    class SweepFakeApp:
+        def __init__(self, config):
+            self.config = config
+            seen_configs.append(config)
+
+        def simulate(self):
+            return None
+
+        def result(self):
+            return {"npv_savings_eur": self.config["costs"]["electricity_cost"] * 1000}
+
+    monkeypatch.setattr(cli, "App", SweepFakeApp)
+    config_path = tmp_path / "cost-sweep.toml"
+    config_path.write_text(
+        """
+location = "porto"
+n_modules = 8
+annual_consumption_kwh = 3500
+cost_preset = "residential_pt"
+
+[costs]
+storage_cost_per_kwh = 420.0
+
+[sweep]
+"costs.electricity_cost" = [0.20, 0.30]
+""".strip(),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "cost-sweep.csv"
+
+    exit_code = cli.main(["sweep", "--config", str(config_path), "--output", str(output_path), "--json"])
+
+    assert exit_code == 0
+    assert [config["costs"] for config in seen_configs] == [
+        {"storage_cost_per_kwh": 420.0, "electricity_cost": 0.20},
+        {"storage_cost_per_kwh": 420.0, "electricity_cost": 0.30},
+    ]
+    rows = list(csv.DictReader(output_path.open(encoding="utf-8")))
+    assert [row["param_costs.electricity_cost"] for row in rows] == ["0.2", "0.3"]
+    assert [row["npv_savings_eur"] for row in rows] == ["200.0", "300.0"]
+
+
+def test_sweep_accepts_unquoted_toml_dotted_cost_key(monkeypatch, tmp_path, capsys):
+    seen_configs = []
+
+    class SweepFakeApp:
+        def __init__(self, config):
+            seen_configs.append(config)
+
+        def simulate(self):
+            return None
+
+        def result(self):
+            return {}
+
+    monkeypatch.setattr(cli, "App", SweepFakeApp)
+    config_path = tmp_path / "nested-cost-sweep.toml"
+    config_path.write_text(
+        """
+location = "porto"
+n_modules = 8
+annual_consumption_kwh = 3500
+
+[sweep]
+costs.electricity_cost = [0.20, 0.30]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["sweep", "--config", str(config_path), "--output", str(tmp_path / "out.csv")])
+
+    assert exit_code == 0
+    assert [config["costs"]["electricity_cost"] for config in seen_configs] == [0.20, 0.30]
+    assert "Sweep: 2 runs" in capsys.readouterr().out
+
+
+def test_validate_config_rejects_unknown_dotted_sweep_cost_key(tmp_path, capsys):
+    config_path = tmp_path / "invalid-cost-sweep.toml"
+    config_path.write_text(
+        """
+location = "porto"
+n_modules = 8
+annual_consumption_kwh = 3500
+
+[sweep]
+"costs.electricty_cost" = [0.20, 0.30]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(["validate-config", str(config_path)])
+
+    assert exit_code == 1
+    error = capsys.readouterr().err
+    assert "Unknown sweep key 'costs.electricty_cost'" in error
+    assert "costs.electricity_cost" in error

--- a/tests/test_economics.py
+++ b/tests/test_economics.py
@@ -22,6 +22,12 @@ class TestCostDefaultsSingleSource:
         # config-driven and direct-construction paths cannot diverge.
         assert cost_params_from_config({}, {}) == CostParams()
 
+    def test_cost_params_from_config_maps_land_cost(self):
+        params = cost_params_from_config({"land_cost": 1250.0}, {})
+
+        assert params.land_cost == 1250.0
+        assert params.operation_cost == CostParams().operation_cost
+
     def test_resolve_costs_preset_fallbacks_match_dataclass_defaults(self, monkeypatch):
         from breos import app_config
 
@@ -43,6 +49,77 @@ class TestCostDefaultsSingleSource:
             inflation_rate=0.02,
             sell_price_inflation=0.01,
             discount_rate=0.0,
+            pv_degradation_rate=0.005,
+        )
+
+    def test_app_cost_overrides_layer_over_preset_and_defaults(self, monkeypatch):
+        from breos import app_config
+
+        monkeypatch.setattr(
+            app_config,
+            "load_json",
+            lambda name: {
+                "partial": {
+                    "electricity_cost": 0.31,
+                    "storage_cost_per_kwh": 450.0,
+                    "maintenance_cost": 12.0,
+                }
+            },
+        )
+        cfg = {
+            "cost_preset": "partial",
+            "costs": {
+                "electricity_cost": 0.42,
+                "storage_cost_per_kwh": 375.0,
+                "operation_cost": 20.0,
+            },
+            "inverter_loading_ratio": 1.4,
+            "inflation_rate": 0.025,
+            "sell_price_inflation": 0.01,
+            "discount_rate": 0.04,
+            "pv_degradation_rate": 0.006,
+        }
+
+        params = app_config.resolve_costs(cfg)
+
+        assert params.electricity_cost == 0.42  # explicit override
+        assert params.battery_cost_per_kwh == 375.0  # catalog name maps to CostParams
+        assert params.maintenance_cost_fixed == 12.0  # preset value remains
+        assert params.operation_cost == 20.0  # default-only term can be overridden
+        assert params.module_cost_per_w == CostParams().module_cost_per_w
+        assert params.dc_ac_ratio == 1.4
+        assert params.inflation_rate == 0.025
+
+    def test_flat_preset_resolution_is_unchanged(self):
+        from breos import app_config
+
+        cfg = {
+            "cost_preset": "residential_pt",
+            "inverter_loading_ratio": 1.25,
+            "inflation_rate": 0.02,
+            "sell_price_inflation": 0.0,
+            "discount_rate": 0.03,
+            "pv_degradation_rate": 0.005,
+        }
+
+        assert app_config.resolve_costs(cfg) == CostParams(
+            electricity_cost=0.2582,
+            electricity_sold_cost=0.04,
+            daily_power_cost=0.3,
+            module_cost_per_w=0.125,
+            battery_cost_per_kwh=500,
+            dc_ac_ratio=1.25,
+            inverter_cost_per_kw=102.58,
+            inverter_cost_per_kw_nobatt=48.37,
+            installation_cost_per_module=350,
+            battery_installation_cost=350,
+            other_cost_per_module=30,
+            other_cost_fixed=0,
+            maintenance_cost_per_panel=10,
+            maintenance_cost_fixed=0,
+            inflation_rate=0.02,
+            sell_price_inflation=0.0,
+            discount_rate=0.03,
             pv_degradation_rate=0.005,
         )
 


### PR DESCRIPTION
This makes BREOS's economic assumptions directly configurable and sweepable without requiring a throwaway cost preset for every price or CAPEX value. It delivers Phase 0 of the economic-scenario roadmap while keeping the existing flat-pricing model and preset results unchanged.

## Summary

- add a validated `[costs]` override table with explicit precedence: user override → named preset → `CostParams` default
- use the existing cost-catalog vocabulary for electricity, export, standing, PV, battery, inverter, installation, land, maintenance, operation, and other costs
- centralize the public-key-to-`CostParams` mapping so App presets and lower-level config construction cannot drift
- support quoted and native TOML dotted sweep keys such as `"costs.electricity_cost"` and `costs.storage_cost_per_kwh`
- deep-copy each sweep configuration so nested overrides preserve sibling cost values and cannot mutate later runs
- reject unknown, empty, duplicate, and conflicting sweep keys with actionable available-key messages
- document the configuration and sweep workflow and update the shipped sweep example

## Compatibility

Existing configurations need no changes. With no `[costs]` table, named presets and dataclass defaults resolve exactly as before; the residential Portugal preset is pinned character-for-character in a regression test. Sweep CSV columns retain the existing `param_...` convention, including dotted names such as `param_costs.electricity_cost`.

This is intentionally only the override seam. Escalator decomposition, scenario orchestration, switching values, currency, and time-of-use valuation remain in their roadmap phases.

## Validation

- full non-slow suite: 812 passed, 7 skipped, 2 deselected
- focused App/config/CLI/economics suite: 188 passed
- Ruff lint and formatting checks passed
- strict offline Sphinx build with `-W` passed
- release artifact verification passed for the sdist, wheel, installed package data, and all 14 BLAST models
