### PR TITLE
Add projected lifetime optimization as the sizing default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
-# Agent Guide
+# BREOS
 
-This repository is the open-source core of BREOS. Keep changes scoped and preserve the `breos.App` facade as the most stable public entrypoint.
+BREOS is an open source simulator for PV and storage systems for buildings. Built with a modular architecture, it invites users to "bring-your-own" data and simulate solar systems.
 
 ## Project map
+
+Keep changes scoped and preserve the `breos.App` facade as the most stable public entrypoint.
 
 - `breos/app.py` - public facade that wires weather, PV, load, battery, economics, and emissions.
 - `breos/load_profiles.py` - bundled demandlib H0 profile support plus user-supplied external RLPs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   handling and AC dispatch methodology.
 - Added `evaluate_projected_design` for detailed evaluation of a fixed design.
   It returns the projected metrics, annual energy and degradation-state
-  ledger, and discounted financial ledger without requiring an NSGA-II run.
+  ledger, discounted financial ledger, LCOE, and configured lifetime
+  avoided-emissions totals without requiring an NSGA-II run.
 - Added opt-in hourly-energy conservation to `resample_to_15min`. It preserves
   each source hour's GHI, DNI, and DHI energy after clear-sky interpolation;
   the established resampling output remains the default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   remains the default; projected ZEB is a diagnostic or optional feasibility
   constraint, not a third objective.
 - Added a version-controlled Article 1 configuration, deterministic
-  fixed-candidate reproduction command, opt-in licensed-profile regression,
-  and comparison report. The report preserves the archived values while
+  fixed-candidate reproduction command, per-candidate yearly and financial
+  source tables, opt-in licensed-profile regression, and comparison report.
+  The report preserves the archived values while
   explaining corrected drift from the original hourly-to-15-minute weather
   handling and AC dispatch methodology.
+- Added `evaluate_projected_design` for detailed evaluation of a fixed design.
+  It returns the projected metrics, annual energy and degradation-state
+  ledger, and discounted financial ledger without requiring an NSGA-II run.
 - Added opt-in hourly-energy conservation to `resample_to_15min`. It preserves
   each source hour's GHI, DNI, and DHI energy after clear-sky interpolation;
   the established resampling output remains the default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+### Added
+- Added an opt-in projected multi-objective optimizer that evaluates each
+  candidate over a repeated-TMY project lifetime, carries battery degradation
+  and physical state between years, records actual replacements, and optimizes
+  lifetime grid independence and NPV. Existing annual three-objective behavior
+  remains the default; projected ZEB is a diagnostic or optional feasibility
+  constraint, not a third objective.
+- Added a version-controlled Article 1 configuration, deterministic
+  fixed-candidate reproduction command, opt-in licensed-profile regression,
+  and comparison report. The report preserves the archived values while
+  explaining corrected drift from the original hourly-to-15-minute weather
+  handling and AC dispatch methodology.
+- Added opt-in hourly-energy conservation to `resample_to_15min`. It preserves
+  each source hour's GHI, DNI, and DHI energy after clear-sky interpolation;
+  the established resampling output remains the default.
+
 ## [0.5.2] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   lifetime grid independence and NPV. Existing annual three-objective behavior
   remains the default; projected ZEB is a diagnostic or optional feasibility
   constraint, not a third objective.
-- Added a version-controlled Article 1 configuration, deterministic
-  fixed-candidate reproduction command, per-candidate yearly and financial
-  source tables, opt-in licensed-profile regression, and comparison report.
+- Added a version-controlled configuration for the forthcoming publication
+  study, a deterministic fixed-candidate reproduction command, per-candidate
+  yearly and financial source tables, an opt-in licensed-profile regression,
+  and a comparison report.
   The report preserves the archived values while
   explaining corrected drift from the original hourly-to-15-minute weather
   handling and AC dispatch methodology.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 ## [Unreleased]
 
 ### Added
-- Added an opt-in projected multi-objective optimizer that evaluates each
-  candidate over a repeated-TMY project lifetime, carries battery degradation
-  and physical state between years, records actual replacements, and optimizes
-  lifetime grid independence and NPV. Existing annual three-objective behavior
-  remains the default; projected ZEB is a diagnostic or optional feasibility
-  constraint, not a third objective.
+- Added a projected multi-objective optimizer that evaluates each candidate
+  over a repeated-TMY project lifetime, carries battery degradation and
+  physical state between years, records actual replacements, and optimizes
+  lifetime grid independence and NPV. This is now the default objective basis;
+  projected ZEB is a diagnostic or optional feasibility constraint, not a third
+  objective.
 - Added a version-controlled configuration for the forthcoming publication
   study, a deterministic fixed-candidate reproduction command, per-candidate
   yearly and financial source tables, an opt-in licensed-profile regression,
@@ -25,6 +25,17 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 - Added opt-in hourly-energy conservation to `resample_to_15min`. It preserves
   each source hour's GHI, DNI, and DHI energy after clear-sky interpolation;
   the established resampling output remains the default.
+
+### Changed
+- `optimization.objective_basis` now defaults to `"projected"`. Multi-objective
+  sizing scores each candidate over the full project lifetime, with PV
+  degradation, propagated battery state, and actual replacement events, and
+  optimizes two objectives: lifetime grid independence and lifetime NPV. The
+  previous single-year basis remains available as
+  `optimization.objective_basis = "steady_state"`, which keeps the annual
+  three-objective search with ZEB ratio as a third objective. Runs that relied
+  on the implicit annual default now cost `years_projection` simulated years
+  per candidate and return a two-objective front.
 
 ## [0.5.2] - 2026-08-19
 

--- a/breos/__init__.py
+++ b/breos/__init__.py
@@ -158,6 +158,8 @@ from breos.montecarlo import (
 # Optimization
 from breos.optimization import (
     OptimizationResult,
+    ProjectedDesignResult,
+    evaluate_projected_design,
     optimize_battery_size,
     optimize_system_multi_objective,
     optimize_tilt,
@@ -364,6 +366,8 @@ __all__ = [
     "optimize_tilt_brent",
     "optimize_battery_size",
     "optimize_system_multi_objective",
+    "evaluate_projected_design",
+    "ProjectedDesignResult",
     # Monte Carlo
     "run_montecarlo",
     "MonteCarloSettings",

--- a/breos/optimization.py
+++ b/breos/optimization.py
@@ -15,7 +15,12 @@ import pandas as pd
 
 from breos._deprecations import deprecated
 from breos.battery import BatteryConfig, simulate_energy_balance
-from breos.economics import calculate_costs, cost_params_from_config, system_ac_production_power
+from breos.economics import (
+    calculate_costs,
+    cost_analysis_projection,
+    cost_params_from_config,
+    system_ac_production_power,
+)
 from breos.solar import PVModuleParams, calculate_pv_production_dc, default_azimuth
 from breos.utils import get_hours_per_step
 
@@ -491,6 +496,7 @@ def _build_battery_config_from_spec(
     initial_soh: float = 100.0,
     enable_replacement: bool = False,
     inverter_ac_capacity_w: Optional[float] = None,
+    replacement_cost: Optional[float] = None,
 ) -> BatteryConfig:
     """Build a BatteryConfig for optimization paths without dropping supported settings."""
     return BatteryConfig(
@@ -510,8 +516,289 @@ def _build_battery_config_from_spec(
         dc_coupled=batt_spec.get("dc_coupled", True),
         calendar_model=batt_spec.get("calendar_model", "naumann_lam_field_calibrated"),
         enable_replacement=enable_replacement,
+        replacement_cost=replacement_cost,
         enable_resistance_fade=batt_spec.get("enable_resistance_fade", False),
     )
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    """Return a finite scalar ratio, or zero when the denominator is zero."""
+    denominator = float(denominator)
+    if abs(denominator) < 1e-12:
+        return 0.0
+    return float(numerator) / denominator
+
+
+def _projected_replacement_cost(batt_spec: Dict[str, Any], battery_kwh: float, storage_cost: float) -> float:
+    """Resolve a projected replacement event cost from explicit or calculated input."""
+    configured = batt_spec.get("replacement_cost")
+    if configured is None or (isinstance(configured, str) and configured.strip().lower() in {"auto", "calculate"}):
+        return float(battery_kwh) * float(storage_cost)
+    if isinstance(configured, bool):
+        raise ValueError("battery.replacement_cost must be a non-negative number or 'calculate'")
+    replacement_cost = float(configured)
+    if not np.isfinite(replacement_cost) or replacement_cost < 0.0:
+        raise ValueError("battery.replacement_cost must be a non-negative number or 'calculate'")
+    return replacement_cost
+
+
+def _interpolate_payback_year(cost_projection: pd.DataFrame) -> Optional[float]:
+    """Interpolate discounted payback from cumulative NPV savings."""
+    if "Savings_Cumulative_NPV" not in cost_projection.columns or cost_projection.empty:
+        return None
+
+    savings = cost_projection["Savings_Cumulative_NPV"].to_numpy(dtype=float)
+    years = cost_projection["Year"].to_numpy(dtype=float)
+    if savings[0] >= 0.0:
+        return float(years[0])
+
+    for idx in range(1, len(savings)):
+        if savings[idx] >= 0.0 and savings[idx - 1] < 0.0:
+            delta = savings[idx] - savings[idx - 1]
+            if abs(delta) < 1e-12:
+                return float(years[idx])
+            return float(years[idx - 1] - savings[idx - 1] / delta)
+    return None
+
+
+def _projected_year_summary(
+    *,
+    year: int,
+    results_df: pd.DataFrame,
+    freq: str,
+    pv_degradation_factor: float,
+    battery_soh: float,
+    replacements: int,
+    replacement_cost: float,
+) -> Dict[str, Any]:
+    """Aggregate one simulated project year from the canonical energy ledger."""
+    hours_per_step = get_hours_per_step(freq)
+
+    def energy_kwh(column: str) -> float:
+        return float(pd.to_numeric(results_df[column], errors="coerce").fillna(0.0).sum() * hours_per_step / 1000.0)
+
+    def optional_energy_kwh(column: str) -> float:
+        return energy_kwh(column) if column in results_df.columns else 0.0
+
+    load_kwh = energy_kwh("Houseload")
+    import_kwh = energy_kwh("Import_From_Grid")
+    export_kwh = energy_kwh("Sell_To_Grid")
+    pv_kwh = float(system_ac_production_power(results_df).sum() * hours_per_step / 1000.0)
+    grid_independence = 100.0 * (1.0 - _safe_ratio(import_kwh, load_kwh)) if load_kwh > 0.0 else 0.0
+    return {
+        "Year": int(year),
+        "PV_Production_kWh": pv_kwh,
+        "PV_DC_kWh": optional_energy_kwh("PV_DC"),
+        "PV_DC_Curtailed_kWh": optional_energy_kwh("PV_DC_Curtailed"),
+        "Inverter_Loss_kWh": optional_energy_kwh("Inverter_Loss"),
+        "Load_kWh": load_kwh,
+        "Import_kWh": import_kwh,
+        "Export_kWh": export_kwh,
+        "Grid_Independence_%": grid_independence,
+        "Battery_SOH_%": float(battery_soh),
+        "Replacements": int(replacements),
+        "Replacement_Cost": float(replacement_cost),
+        "PV_Degradation_Factor": float(pv_degradation_factor),
+    }
+
+
+def _summarize_projected_lifetime_metrics(yearly_summary_df: pd.DataFrame) -> Dict[str, float]:
+    """Summarize lifetime metrics from actual simulated yearly values."""
+    if yearly_summary_df.empty:
+        raise ValueError("yearly_summary_df must contain at least one year")
+
+    load = yearly_summary_df["Load_kWh"].astype(float)
+    production = yearly_summary_df["PV_Production_kWh"].astype(float)
+    imports = yearly_summary_df["Import_kWh"].astype(float)
+    annual_gi = yearly_summary_df["Grid_Independence_%"].astype(float)
+    annual_zeb = np.divide(
+        production.to_numpy(dtype=float),
+        load.to_numpy(dtype=float),
+        out=np.zeros(len(yearly_summary_df), dtype=float),
+        where=load.to_numpy(dtype=float) > 0.0,
+    )
+
+    return {
+        "Projected_Grid_Independence_%": 100.0 * (1.0 - _safe_ratio(imports.sum(), load.sum())),
+        "Projected_Grid_Independence_Year1_%": float(annual_gi.iloc[0]),
+        "Projected_Grid_Independence_FinalYear_%": float(annual_gi.iloc[-1]),
+        "Projected_Grid_Independence_Mean_%": float(annual_gi.mean()),
+        "Projected_Grid_Independence_Min_%": float(annual_gi.min()),
+        "Projected_ZEB_Ratio": _safe_ratio(production.sum(), load.sum()),
+        "Projected_ZEB_Ratio_Year1": float(annual_zeb[0]),
+        "Projected_ZEB_Ratio_FinalYear": float(annual_zeb[-1]),
+        "Projected_ZEB_Ratio_Mean": float(np.mean(annual_zeb)),
+        "Projected_ZEB_Ratio_Min": float(np.min(annual_zeb)),
+    }
+
+
+def _evaluate_projected_design_metrics(
+    *,
+    base_dc_power: pd.Series,
+    tmy_data: pd.DataFrame,
+    houseload: pd.DataFrame,
+    temperature_series: pd.Series,
+    pv_params: PVModuleParams,
+    batt_spec: Dict[str, Any],
+    costs_cfg: Dict[str, Any],
+    fin_cfg: Dict[str, Any],
+    freq: str,
+    years_projection: int,
+    degradation_rate: float,
+    n_modules: int,
+    battery_kwh: float,
+    inverter_efficiency: float,
+    inverter_ac_capacity_w: Optional[float],
+    return_tables: bool = False,
+) -> Dict[str, Any]:
+    """Evaluate one design over repeated TMY years using production engines."""
+    if years_projection < 1:
+        raise ValueError("projected optimization requires at least one project year")
+    if not 0.0 <= float(degradation_rate) < 1.0:
+        raise ValueError("projected PV degradation rate must be between 0 and 1")
+
+    cost_params = cost_params_from_config(costs_cfg, fin_cfg)
+    costs = calculate_costs(
+        n_modules=n_modules,
+        module_power_w=pv_params.Mpp,
+        battery_capacity_wh=battery_kwh * 1000.0,
+        cost_params=cost_params,
+    )
+    replacement_cost = _projected_replacement_cost(
+        batt_spec,
+        battery_kwh,
+        cost_params.battery_cost_per_kwh,
+    )
+    has_battery = battery_kwh > 0.0
+    current_soh = float(batt_spec.get("initial_soh", 100.0)) if has_battery else 100.0
+    cumulative_fec = 0.0
+    cumulative_cal_seconds = 0.0
+    cumulative_resistance_growth = 0.0
+    cumulative_cycle_deg = 0.0
+    cumulative_cal_deg = 0.0
+    carried_energy_wh: Optional[float] = None
+    carried_pv_origin_energy_wh: Optional[float] = None
+    degradation_engine = str(batt_spec.get("degradation_engine", "native")).strip().lower()
+    blast_model = batt_spec.get("blast_model")
+    degradation_state: Optional[Dict[str, Any]] = None
+    total_replacements = 0
+    total_replacement_cost = 0.0
+    yearly_summaries: list[Dict[str, Any]] = []
+    first_year_results_df: Optional[pd.DataFrame] = None
+
+    for year_idx in range(years_projection):
+        degradation_factor = (1.0 - float(degradation_rate)) ** year_idx
+        dc_power = base_dc_power * degradation_factor
+        battery_config = _build_battery_config_from_spec(
+            batt_spec,
+            nominal_energy_wh=battery_kwh * 1000.0,
+            inverter_efficiency=inverter_efficiency,
+            initial_soh=current_soh,
+            enable_replacement=bool(batt_spec.get("enable_replacement", True)) and has_battery,
+            inverter_ac_capacity_w=inverter_ac_capacity_w,
+            replacement_cost=replacement_cost,
+        )
+        state_kwargs: Dict[str, float] = {}
+        if carried_energy_wh is not None:
+            state_kwargs = {
+                "initial_energy_wh": carried_energy_wh,
+                "initial_pv_origin_energy_wh": carried_pv_origin_energy_wh or 0.0,
+            }
+
+        simulation = simulate_energy_balance(
+            pv_dc=dc_power,
+            houseload=houseload,
+            battery_config=battery_config,
+            start_time=dc_power.index[0],
+            end_time=dc_power.index[-1],
+            freq=freq,
+            temperature_series=temperature_series if has_battery else None,
+            initial_fec=cumulative_fec,
+            initial_calendar_seconds=cumulative_cal_seconds,
+            initial_resistance_growth=cumulative_resistance_growth,
+            initial_cumulative_cycle_deg=cumulative_cycle_deg,
+            initial_cumulative_cal_deg=cumulative_cal_deg,
+            degradation_engine=degradation_engine,
+            blast_model=blast_model,
+            initial_degradation_state=degradation_state if degradation_engine == "blast" else None,
+            return_degradation_state=True,
+            debug=False,
+            **state_kwargs,
+        )
+        (
+            results_df,
+            _total_pv_wh,
+            _summary_df,
+            year_replacement_cost,
+            year_replacements,
+            degradation_df,
+            degradation_state,
+        ) = simulation
+
+        if first_year_results_df is None:
+            first_year_results_df = results_df
+        if has_battery:
+            carried_energy_wh = float(results_df["Battery_Energy_End"].iloc[-1])
+            carried_pv_origin_energy_wh = float(results_df["Battery_PV_Origin_Energy_End"].iloc[-1])
+            if not degradation_df.empty:
+                cumulative_fec = float(degradation_df["Cumulative_FEC"].iloc[-1])
+                cumulative_cal_seconds = float(degradation_df["Cumulative_Calendar_Seconds"].iloc[-1])
+                cumulative_cycle_deg = float(degradation_df["Cumulative_Cycle_Degradation"].iloc[-1])
+                cumulative_cal_deg = float(degradation_df["Cumulative_Calendar_Degradation"].iloc[-1])
+                current_soh = float(degradation_df["SOH"].iloc[-1])
+                if "Resistance_Growth" in degradation_df.columns:
+                    cumulative_resistance_growth = float(degradation_df["Resistance_Growth"].iloc[-1])
+
+        total_replacements += int(year_replacements)
+        total_replacement_cost += float(year_replacement_cost)
+        yearly_summaries.append(
+            _projected_year_summary(
+                year=year_idx + 1,
+                results_df=results_df,
+                freq=freq,
+                pv_degradation_factor=degradation_factor,
+                battery_soh=current_soh,
+                replacements=int(year_replacements),
+                replacement_cost=float(year_replacement_cost),
+            )
+        )
+
+    yearly_summary_df = pd.DataFrame(yearly_summaries)
+    if first_year_results_df is None:
+        raise RuntimeError("projected design evaluation produced no simulation years")
+    cost_projection = cost_analysis_projection(
+        results_df=first_year_results_df,
+        costs=costs,
+        num_years=years_projection,
+        inflation_rate=float(fin_cfg.get("inflation_rate", DEFAULT_INFLATION_ELEC)),
+        sell_price_inflation=float(fin_cfg.get("sell_price_inflation", 0.0)),
+        discount_rate=float(fin_cfg.get("discount_rate", DEFAULT_DISCOUNT_RATE)),
+        freq=freq,
+        yearly_summary_df=yearly_summary_df,
+        total_replacement_cost=total_replacement_cost,
+    )
+    payback_year = cost_projection.attrs.get("payback_year")
+    payback_exact = _interpolate_payback_year(cost_projection)
+    metrics: Dict[str, Any] = {
+        **_summarize_projected_lifetime_metrics(yearly_summary_df),
+        "Projected_NPV_Eur": float(cost_projection["Savings_Cumulative_NPV"].iloc[-1]),
+        "Projected_Breakeven_Year": float(payback_year) if payback_year is not None else np.nan,
+        "Projected_Breakeven_Year_Exact": payback_exact if payback_exact is not None else np.nan,
+        "Projected_Initial_Cost_Eur": float(costs["total_initial_cost"]),
+        "Projected_Replacement_Cost_Eur": float(total_replacement_cost),
+        "Projected_Total_Replacements": int(total_replacements),
+        "Projected_Final_SOH_%": float(current_soh),
+        "Projected_PV_Production_Year1_kWh": float(yearly_summary_df["PV_Production_kWh"].iloc[0]),
+        "Projected_PV_Production_FinalYear_kWh": float(yearly_summary_df["PV_Production_kWh"].iloc[-1]),
+        "Projected_PV_DC_Year1_kWh": float(yearly_summary_df["PV_DC_kWh"].iloc[0]),
+        "Projected_PV_DC_FinalYear_kWh": float(yearly_summary_df["PV_DC_kWh"].iloc[-1]),
+        "Projected_PV_DC_Curtailed_Year1_kWh": float(yearly_summary_df["PV_DC_Curtailed_kWh"].iloc[0]),
+        "Projected_Inverter_Loss_Year1_kWh": float(yearly_summary_df["Inverter_Loss_kWh"].iloc[0]),
+    }
+    if return_tables:
+        metrics["_yearly_summary_df"] = yearly_summary_df
+        metrics["_cost_projection_df"] = cost_projection
+    return metrics
 
 
 def calculate_financials(
@@ -697,7 +984,25 @@ try:
             self.max_battery_kwh = self.constraints.get("max_battery_kwh", 30)
             self.max_modules = self.constraints.get("max_modules", 60)
             self.max_tilt_deg = _resolve_max_tilt_deg(self.constraints, self.location["latitude"])
+            self.enforce_zeb = bool(self.constraints.get("enforce_zeb", False))
             self.freq = config.get("simulation", {}).get("resolution", "h")
+            self.opt_cfg = config.get("optimization", {}) or {}
+            self.objective_basis = str(self.opt_cfg.get("objective_basis", "steady_state")).strip().lower()
+            if self.objective_basis not in {"steady_state", "projected"}:
+                raise ValueError("optimization.objective_basis must be 'steady_state' or 'projected'")
+            self.projected_objectives = self.objective_basis == "projected"
+            self.projected_years = int(
+                config.get("simulation", {}).get(
+                    "years_projection",
+                    config.get("financials", {}).get("project_lifespan", DEFAULT_PROJECT_LIFESPAN),
+                )
+            )
+            self.projected_degradation_rate = float(
+                config.get("pv", {}).get(
+                    "degradation_rate",
+                    config.get("financials", {}).get("pv_degradation_rate", 0.005),
+                )
+            )
             self.pv_params, self.module_area_m2 = _resolve_pv_module_and_area(config)
             self.batt_temp_cfg = config.get("battery", {}).get("temperature", "weather")
             self.indoor_model = config.get("battery", {}).get("indoor_model")
@@ -712,9 +1017,15 @@ try:
             )
 
             self.battery_replacement_treatment = {
-                "method": "repeat_simulated_year_1_soh_loss_to_eol",
+                "method": (
+                    "simulated_yearly_state_propagation"
+                    if self.projected_objectives
+                    else "repeat_simulated_year_1_soh_loss_to_eol"
+                ),
                 "description": (
-                    "Steady-state candidate scoring repeats its simulated year-1 SOH loss, "
+                    "Projected scoring simulates every year and records actual replacement events."
+                    if self.projected_objectives
+                    else "Steady-state candidate scoring repeats its simulated year-1 SOH loss, "
                     "replaces at the configured EOL threshold, resets SOH to 100%, and applies "
                     "the configured storage cost in each estimated replacement year."
                 ),
@@ -750,8 +1061,8 @@ try:
 
             super().__init__(
                 n_var=n_var,
-                n_obj=3,  # Obj1: Grid Indep, Obj2: ROI (NPV), Obj3: ZEB Ratio
-                n_ieq_constr=2,  # Constr1: Budget, Constr2: Area
+                n_obj=2 if self.projected_objectives else 3,
+                n_ieq_constr=3 if self.enforce_zeb else 2,
                 xl=xl,
                 xu=xu,
                 elementwise_runner=elementwise_runner or _serial_elementwise_runner,
@@ -891,6 +1202,47 @@ try:
             # Obj 3: ZEB Status (Maximize Ratio -> Minimize Negative)
             zeb_ratio = total_ac_prod / total_load if total_load > 0 else 0
 
+            steady_state_gi = (1.0 - grid_dependence_ratio) * 100.0
+            out["SteadyState_Grid_Independence_%"] = steady_state_gi
+            out["SteadyState_NPV_Eur"] = npv
+            out["SteadyState_ZEB_Ratio"] = zeb_ratio
+
+            objective_grid_dependence = grid_dependence_ratio
+            objective_npv = npv
+            objective_zeb = zeb_ratio
+            if self.projected_objectives:
+                projected_metrics = _evaluate_projected_design_metrics(
+                    base_dc_power=dc_production,
+                    tmy_data=self.tmy_data,
+                    houseload=houseload_df,
+                    temperature_series=temperature_series,
+                    pv_params=pv_params,
+                    batt_spec=batt_spec,
+                    costs_cfg=self.config.get("costs", {}) or {},
+                    fin_cfg=self.config.get("financials", {}) or {},
+                    freq=self.freq,
+                    years_projection=self.projected_years,
+                    degradation_rate=self.projected_degradation_rate,
+                    n_modules=n_modules,
+                    battery_kwh=float(battery_kwh),
+                    inverter_efficiency=self.inverter_efficiency,
+                    inverter_ac_capacity_w=inverter_ac_capacity_w,
+                )
+                out.update(projected_metrics)
+                objective_grid_dependence = 1.0 - float(projected_metrics["Projected_Grid_Independence_%"]) / 100.0
+                objective_npv = float(projected_metrics["Projected_NPV_Eur"])
+                objective_zeb = float(projected_metrics["Projected_ZEB_Ratio"])
+
+            out["ZEB_Ratio"] = objective_zeb
+            out["Objective_Grid_Independence_%"] = (
+                float(projected_metrics["Projected_Grid_Independence_%"])
+                if self.projected_objectives
+                else steady_state_gi
+            )
+            out["Objective_NPV_Eur"] = objective_npv
+            if not self.projected_objectives:
+                out["Objective_ZEB_Ratio"] = objective_zeb
+
             # --- 4. Constraints Calculation ---
             # g1: Price <= Budget (g1 <= 0 means satisfied)
             g1 = capex - self.budget_limit
@@ -898,13 +1250,74 @@ try:
             # g2: Area <= Max Area
             g2 = system_area - self.area_limit
 
-            # Return
-            out["F"] = [grid_dependence_ratio, -npv, -zeb_ratio]
-            out["G"] = [g1, g2]
+            constraints = [g1, g2]
+            if self.enforce_zeb:
+                constraints.append(1.0 - objective_zeb)
+
+            if self.projected_objectives:
+                out["F"] = [objective_grid_dependence, -objective_npv]
+            else:
+                out["F"] = [objective_grid_dependence, -objective_npv, -objective_zeb]
+            out["G"] = constraints
 
 except ImportError:
     # If pymoo is not installed, these classes won't be available
     pass
+
+
+def _build_multi_objective_termination(n_gen: int, early_stop: Any):
+    """Build the configured pymoo generation cap and objective-space stop."""
+    if early_stop in (None, False):
+        return ("n_gen", n_gen), None
+    if early_stop is True:
+        early_stop = {}
+    if not isinstance(early_stop, dict):
+        raise ValueError("optimization.early_stop must be a boolean or a mapping")
+    if early_stop.get("enabled", True) is False:
+        return ("n_gen", n_gen), None
+
+    from pymoo.core.termination import Termination
+    from pymoo.termination.collection import TerminationCollection
+    from pymoo.termination.ftol import MultiObjectiveSpaceTermination
+    from pymoo.termination.max_gen import MaximumGenerationTermination
+    from pymoo.termination.robust import RobustTermination
+
+    class _MinGenerationTermination(Termination):
+        def __init__(self, termination, minimum: int) -> None:
+            super().__init__()
+            self.termination = termination
+            self.minimum = max(1, int(minimum))
+
+        def _update(self, algorithm):
+            progress = self.termination.update(algorithm)
+            return 0.0 if algorithm.n_gen < self.minimum else progress
+
+    ftol = float(early_stop.get("ftol", 0.0025))
+    if ftol <= 0.0:
+        raise ValueError("optimization.early_stop.ftol must be greater than zero")
+    period = max(1, int(early_stop.get("period", 10)))
+    n_skip = max(0, int(early_stop.get("n_skip", 0)))
+    min_gen = max(1, int(early_stop.get("min_gen", min(20, n_gen))))
+    only_feasible = bool(early_stop.get("only_feasible", True))
+    objective_stop = RobustTermination(
+        MultiObjectiveSpaceTermination(tol=ftol, only_feas=only_feasible, n_skip=n_skip),
+        period=period,
+    )
+    metadata = {
+        "n_gen_cap": int(n_gen),
+        "ftol": ftol,
+        "period": period,
+        "n_skip": n_skip,
+        "min_gen": min_gen,
+        "only_feasible": only_feasible,
+    }
+    return (
+        TerminationCollection(
+            MaximumGenerationTermination(n_gen),
+            _MinGenerationTermination(objective_stop, minimum=min_gen),
+        ),
+        metadata,
+    )
 
 
 def optimize_system_multi_objective(
@@ -917,13 +1330,17 @@ def optimize_system_multi_objective(
     n_offsprings: int | None = None,
     seed: int = 1,
     verbose: bool = False,
+    n_procs: int = 1,
 ) -> OptimizationResult:
     """Run NSGA-II multi-objective PV/battery sizing.
 
     This is the public wrapper around :class:`SolarDesignProblem`. It optimizes
     module count, battery capacity, tilt, and optionally azimuth. Objectives are
-    grid independence, NPV, and ZEB ratio. Install ``breos[optimization]`` to
-    provide the pymoo dependency.
+    By default, objectives are annual grid independence, NPV, and ZEB ratio.
+    With ``optimization.objective_basis = "projected"``, objectives are
+    lifetime grid independence and NPV; ZEB remains a diagnostic unless
+    ``constraints.enforce_zeb`` enables it as a feasibility constraint.
+    Install ``breos[optimization]`` to provide the pymoo dependency.
 
     Args:
         tmy_data: One-year weather DataFrame.
@@ -938,11 +1355,13 @@ def optimize_system_multi_objective(
             algorithm default when ``None``.
         seed: Random seed passed to pymoo.
         verbose: Print pymoo progress.
+        n_procs: Candidate-evaluation worker processes. The default ``1``
+            preserves serial behavior.
 
     Returns:
         :class:`OptimizationResult` whose ``details["pareto"]`` is a DataFrame
-        with ``Modules``, ``Battery_kWh``, ``Tilt``, ``Azimuth``,
-        ``Grid_Independence_%``, ``NPV_Eur``, and ``ZEB_Ratio``.
+        with ``Modules``, ``Battery_kWh``, ``Tilt``, ``Azimuth``, objective
+        values, ZEB diagnostics, and explicit steady-state/projected fields.
 
     Raises:
         ImportError: If pymoo is not installed.
@@ -975,14 +1394,46 @@ def optimize_system_multi_objective(
     if n_offsprings is not None:
         algorithm_kwargs["n_offsprings"] = n_offsprings
 
-    problem = SolarDesignProblem(tmy_data, houseload, config, results_dir)
-    result = minimize(
-        problem,
-        NSGA2(**algorithm_kwargs),
-        ("n_gen", n_gen),
-        seed=seed,
-        verbose=verbose,
+    if isinstance(n_procs, bool) or int(n_procs) < 1:
+        raise ValueError("n_procs must be a positive integer")
+    n_procs = int(n_procs)
+
+    pool = None
+    elementwise_runner = None
+    if n_procs > 1:
+        from multiprocessing import Pool
+
+        try:
+            from pymoo.parallelization import StarmapParallelization
+        except ImportError:  # pymoo 0.6.1 compatibility
+            from pymoo.core.problem import StarmapParallelization
+
+        pool = Pool(n_procs)
+        elementwise_runner = StarmapParallelization(pool.starmap)
+
+    problem = SolarDesignProblem(
+        tmy_data,
+        houseload,
+        config,
+        results_dir,
+        elementwise_runner=elementwise_runner,
     )
+    termination, early_stop_metadata = _build_multi_objective_termination(
+        n_gen,
+        (config.get("optimization") or {}).get("early_stop"),
+    )
+    try:
+        result = minimize(
+            problem,
+            NSGA2(**algorithm_kwargs),
+            termination,
+            seed=seed,
+            verbose=verbose,
+        )
+    finally:
+        if pool is not None:
+            pool.close()
+            pool.join()
 
     if result.X is None or result.F is None:
         raise RuntimeError("Multi-objective optimization found no feasible solutions.")
@@ -1000,9 +1451,36 @@ def optimize_system_multi_objective(
     pareto["Battery_kWh"] = pareto["Battery_kWh"].round().astype(float)
     pareto["Grid_Independence_%"] = (1 - f[:, 0]) * 100
     pareto["NPV_Eur"] = -f[:, 1]
-    pareto["ZEB_Ratio"] = -f[:, 2]
+    if problem.projected_objectives:
+        diagnostic_rows: list[Dict[str, Any]] = []
+        for candidate in x:
+            diagnostics: Dict[str, Any] = {}
+            problem._evaluate(candidate.copy(), diagnostics)
+            diagnostic_rows.append(
+                {
+                    key: value
+                    for key, value in diagnostics.items()
+                    if key.startswith("SteadyState_")
+                    or key.startswith("Projected_")
+                    or key.startswith("Objective_")
+                    or key == "ZEB_Ratio"
+                }
+            )
+        diagnostics_df = pd.DataFrame(diagnostic_rows)
+        for column in diagnostics_df.columns:
+            pareto[column] = diagnostics_df[column].to_numpy()
+        pareto["Grid_Independence_%"] = pareto["Projected_Grid_Independence_%"]
+        pareto["NPV_Eur"] = pareto["Projected_NPV_Eur"]
+        pareto["ZEB_Ratio"] = pareto["Projected_ZEB_Ratio"]
+    else:
+        pareto["ZEB_Ratio"] = -f[:, 2]
+        pareto["Objective_Grid_Independence_%"] = pareto["Grid_Independence_%"]
+        pareto["Objective_NPV_Eur"] = pareto["NPV_Eur"]
+        pareto["Objective_ZEB_Ratio"] = pareto["ZEB_Ratio"]
 
-    actual_generations = int(getattr(result.algorithm, "n_gen", n_gen))
+    # pymoo advances the counter after its termination update. Report the last
+    # completed generation, matching the research workflow's saved metadata.
+    actual_generations = max(0, int(getattr(result.algorithm, "n_gen", n_gen + 1)) - 1)
     return OptimizationResult(
         optimal_value=float("nan"),
         objective_value=float("nan"),
@@ -1011,6 +1489,14 @@ def optimize_system_multi_objective(
             "pareto": pareto,
             "pymoo_result": result,
             "problem": problem,
+            "objective_basis": problem.objective_basis,
+            "objective_names": (
+                ["Projected_Grid_Independence_%", "Projected_NPV_Eur"]
+                if problem.projected_objectives
+                else ["SteadyState_Grid_Independence_%", "SteadyState_NPV_Eur", "SteadyState_ZEB_Ratio"]
+            ),
+            "early_stop": early_stop_metadata,
+            "n_procs": n_procs,
             "battery_replacement_treatment": problem.battery_replacement_treatment,
         },
     )

--- a/breos/optimization.py
+++ b/breos/optimization.py
@@ -17,10 +17,12 @@ from breos._deprecations import deprecated
 from breos.battery import BatteryConfig, simulate_energy_balance
 from breos.economics import (
     calculate_costs,
+    calculate_lcoe_from_projection,
     cost_analysis_projection,
     cost_params_from_config,
     system_ac_production_power,
 )
+from breos.emissions import EmissionsParams
 from breos.solar import PVModuleParams, calculate_pv_production_dc, default_azimuth
 from breos.utils import get_hours_per_step
 
@@ -673,6 +675,7 @@ def _evaluate_projected_design_metrics(
     battery_kwh: float,
     inverter_efficiency: float,
     inverter_ac_capacity_w: Optional[float],
+    emissions_params: Optional[EmissionsParams] = None,
     return_tables: bool = False,
 ) -> Dict[str, Any]:
     """Evaluate one design over repeated TMY years using production engines."""
@@ -805,6 +808,7 @@ def _evaluate_projected_design_metrics(
         freq=freq,
         yearly_summary_df=yearly_summary_df,
         total_replacement_cost=total_replacement_cost,
+        emissions_params=emissions_params,
     )
     payback_year = cost_projection.attrs.get("payback_year")
     payback_exact = _interpolate_payback_year(cost_projection)
@@ -823,7 +827,23 @@ def _evaluate_projected_design_metrics(
         "Projected_PV_DC_FinalYear_kWh": float(yearly_summary_df["PV_DC_kWh"].iloc[-1]),
         "Projected_PV_DC_Curtailed_Year1_kWh": float(yearly_summary_df["PV_DC_Curtailed_kWh"].iloc[0]),
         "Projected_Inverter_Loss_Year1_kWh": float(yearly_summary_df["Inverter_Loss_kWh"].iloc[0]),
+        "Projected_LCOE_Eur_kWh": float(
+            calculate_lcoe_from_projection(
+                cost_projection,
+                total_investment=float(costs["total_initial_cost"]),
+                discount_rate=float(fin_cfg.get("discount_rate", DEFAULT_DISCOUNT_RATE)),
+            )
+        ),
     }
+    if "CO2_Avoided_Total_Cumulative_kg" in cost_projection:
+        metrics.update(
+            {
+                "Projected_CO2_Avoided_Total_kg": float(cost_projection["CO2_Avoided_Total_Cumulative_kg"].iloc[-1]),
+                "Projected_CO2_Avoided_SelfConsumed_kg": float(
+                    cost_projection["CO2_Avoided_SelfConsumed_Cumulative_kg"].iloc[-1]
+                ),
+            }
+        )
     if return_tables:
         metrics["_yearly_summary_df"] = yearly_summary_df
         metrics["_cost_projection_df"] = cost_projection
@@ -876,6 +896,7 @@ def evaluate_projected_design(
     )
     simulation = config.get("simulation", {}) or {}
     financials = config.get("financials", {}) or {}
+    emissions_config = config.get("emissions")
     pv_config = config.get("pv", {}) or {}
     battery = config.get("battery", {}) or {}
     freq = str(simulation.get("resolution", "h"))
@@ -920,6 +941,7 @@ def evaluate_projected_design(
             config.get("inverter_efficiency", (config.get("inverter", {}) or {}).get("efficiency", 0.96))
         ),
         inverter_ac_capacity_w=inverter_ac_capacity_w,
+        emissions_params=EmissionsParams(**emissions_config) if emissions_config else None,
         return_tables=True,
     )
     yearly = raw_metrics.pop("_yearly_summary_df")

--- a/breos/optimization.py
+++ b/breos/optimization.py
@@ -354,6 +354,12 @@ DEFAULT_DISCOUNT_RATE = 0.0
 
 DEFAULT_PROJECT_LIFESPAN = 20
 
+# Candidate scoring spans the project lifetime by default. A design is chosen
+# for how it performs over 20 years of PV degradation, battery fade, and
+# replacement, not for its first year, so the cheaper annual basis is the
+# opt-in screening mode rather than the default.
+DEFAULT_OBJECTIVE_BASIS = "projected"
+
 
 def _estimate_battery_replacement_treatment(
     battery_kwh: float,
@@ -1142,7 +1148,7 @@ try:
             self.enforce_zeb = bool(self.constraints.get("enforce_zeb", False))
             self.freq = config.get("simulation", {}).get("resolution", "h")
             self.opt_cfg = config.get("optimization", {}) or {}
-            self.objective_basis = str(self.opt_cfg.get("objective_basis", "steady_state")).strip().lower()
+            self.objective_basis = str(self.opt_cfg.get("objective_basis", DEFAULT_OBJECTIVE_BASIS)).strip().lower()
             if self.objective_basis not in {"steady_state", "projected"}:
                 raise ValueError("optimization.objective_basis must be 'steady_state' or 'projected'")
             self.projected_objectives = self.objective_basis == "projected"
@@ -1490,11 +1496,16 @@ def optimize_system_multi_objective(
     """Run NSGA-II multi-objective PV/battery sizing.
 
     This is the public wrapper around :class:`SolarDesignProblem`. It optimizes
-    module count, battery capacity, tilt, and optionally azimuth. Objectives are
-    By default, objectives are annual grid independence, NPV, and ZEB ratio.
-    With ``optimization.objective_basis = "projected"``, objectives are
-    lifetime grid independence and NPV; ZEB remains a diagnostic unless
+    module count, battery capacity, tilt, and optionally azimuth. By default
+    (``optimization.objective_basis = "projected"``) it optimizes two values:
+    projected lifetime grid independence and projected NPV, scoring every
+    candidate over the full project lifetime with PV degradation, battery state
+    propagation, and replacement events. ZEB remains a diagnostic unless
     ``constraints.enforce_zeb`` enables it as a feasibility constraint.
+    ``optimization.objective_basis = "steady_state"`` selects the cheaper
+    single-year screening basis: annual grid independence, NPV, and ZEB ratio
+    as a third objective, with battery replacement estimated from the
+    first-year SoH loss.
     Install ``breos[optimization]`` to provide the pymoo dependency.
 
     Args:

--- a/breos/optimization.py
+++ b/breos/optimization.py
@@ -35,6 +35,20 @@ class OptimizationResult:
     details: Dict[str, Any]
 
 
+@dataclass
+class ProjectedDesignResult:
+    """Detailed result for one fixed design evaluated over a project horizon.
+
+    ``metrics`` contains the projected headline values used by the optimizer.
+    ``yearly`` is the simulated annual energy and degradation-state ledger, and
+    ``financial`` is the corresponding discounted cost ledger.
+    """
+
+    metrics: Dict[str, Any]
+    yearly: pd.DataFrame
+    financial: pd.DataFrame
+
+
 def _serial_elementwise_runner(func: Callable[[Any], Any], args: list[Any]) -> list[Any]:
     """Fallback pymoo elementwise runner for single-process evaluation."""
     return [func(arg) for arg in args]
@@ -568,6 +582,11 @@ def _projected_year_summary(
     freq: str,
     pv_degradation_factor: float,
     battery_soh: float,
+    cumulative_fec: float,
+    cumulative_calendar_seconds: float,
+    cumulative_cycle_degradation: float,
+    cumulative_calendar_degradation: float,
+    resistance_growth: float,
     replacements: int,
     replacement_cost: float,
 ) -> Dict[str, Any]:
@@ -596,6 +615,11 @@ def _projected_year_summary(
         "Export_kWh": export_kwh,
         "Grid_Independence_%": grid_independence,
         "Battery_SOH_%": float(battery_soh),
+        "Battery_Cumulative_FEC": float(cumulative_fec),
+        "Battery_Cumulative_Calendar_Seconds": float(cumulative_calendar_seconds),
+        "Battery_Cumulative_Cycle_Degradation": float(cumulative_cycle_degradation),
+        "Battery_Cumulative_Calendar_Degradation": float(cumulative_calendar_degradation),
+        "Battery_Resistance_Growth": float(resistance_growth),
         "Replacements": int(replacements),
         "Replacement_Cost": float(replacement_cost),
         "PV_Degradation_Factor": float(pv_degradation_factor),
@@ -758,6 +782,11 @@ def _evaluate_projected_design_metrics(
                 freq=freq,
                 pv_degradation_factor=degradation_factor,
                 battery_soh=current_soh,
+                cumulative_fec=cumulative_fec,
+                cumulative_calendar_seconds=cumulative_cal_seconds,
+                cumulative_cycle_degradation=cumulative_cycle_deg,
+                cumulative_calendar_degradation=cumulative_cal_deg,
+                resistance_growth=cumulative_resistance_growth,
                 replacements=int(year_replacements),
                 replacement_cost=float(year_replacement_cost),
             )
@@ -799,6 +828,110 @@ def _evaluate_projected_design_metrics(
         metrics["_yearly_summary_df"] = yearly_summary_df
         metrics["_cost_projection_df"] = cost_projection
     return metrics
+
+
+def evaluate_projected_design(
+    tmy_data: pd.DataFrame,
+    houseload: pd.DataFrame,
+    config: Dict[str, Any],
+    *,
+    n_modules: int,
+    battery_kwh: float,
+    tilt: float,
+    azimuth: float,
+) -> ProjectedDesignResult:
+    """Evaluate one fixed PV-battery design over repeated TMY project years.
+
+    This is the detailed fixed-design counterpart to projected NSGA-II
+    scoring. It uses the same PV, battery, replacement, degradation, and
+    economics components as :func:`optimize_system_multi_objective` and
+    returns the annual source tables needed for analysis or plotting.
+
+    Args:
+        tmy_data: One-year weather DataFrame.
+        houseload: One-year load profile.
+        config: Nested projected-optimization configuration.
+        n_modules: Installed PV module count.
+        battery_kwh: Installed nominal battery capacity in kWh.
+        tilt: PV surface tilt in degrees.
+        azimuth: PV surface azimuth in degrees.
+
+    Returns:
+        Projected metrics, yearly simulation ledger, and financial ledger.
+    """
+    if int(n_modules) < 1:
+        raise ValueError("n_modules must be at least 1")
+    if float(battery_kwh) < 0.0:
+        raise ValueError("battery_kwh must be non-negative")
+
+    from pvlib.location import Location
+
+    location = config["location"]
+    loc_obj = Location(
+        float(location["latitude"]),
+        float(location["longitude"]),
+        tz=location.get("timezone", "UTC"),
+        altitude=float(location.get("altitude", 0.0)),
+        name=str(location.get("name", "")),
+    )
+    simulation = config.get("simulation", {}) or {}
+    financials = config.get("financials", {}) or {}
+    pv_config = config.get("pv", {}) or {}
+    battery = config.get("battery", {}) or {}
+    freq = str(simulation.get("resolution", "h"))
+    years_projection = int(
+        simulation.get("years_projection", financials.get("project_lifespan", DEFAULT_PROJECT_LIFESPAN))
+    )
+    degradation_rate = float(pv_config.get("degradation_rate", financials.get("pv_degradation_rate", 0.005)))
+    pv_params, _module_area = _resolve_pv_module_and_area(config)
+    base_dc_power = calculate_pv_production_dc(
+        weather_data=tmy_data,
+        location=loc_obj,
+        tilt=float(tilt),
+        surface_azimuth=float(azimuth),
+        n_modules=int(n_modules),
+        pv_params=pv_params,
+        freq=freq,
+        verbose=False,
+    )
+    temperature_series = _temperature_series_from_config(
+        battery.get("temperature", "weather"),
+        base_dc_power.index,
+        weather_df=tmy_data,
+        indoor_model=battery.get("indoor_model"),
+    )
+    dc_ac_ratio = cost_params_from_config(config.get("costs"), financials).dc_ac_ratio
+    inverter_ac_capacity_w = int(n_modules) * pv_params.Mpp / dc_ac_ratio if dc_ac_ratio > 0.0 else None
+    raw_metrics = _evaluate_projected_design_metrics(
+        base_dc_power=base_dc_power,
+        tmy_data=tmy_data,
+        houseload=houseload,
+        temperature_series=temperature_series,
+        pv_params=pv_params,
+        batt_spec=battery,
+        costs_cfg=config.get("costs", {}) or {},
+        fin_cfg=financials,
+        freq=freq,
+        years_projection=years_projection,
+        degradation_rate=degradation_rate,
+        n_modules=int(n_modules),
+        battery_kwh=float(battery_kwh),
+        inverter_efficiency=float(
+            config.get("inverter_efficiency", (config.get("inverter", {}) or {}).get("efficiency", 0.96))
+        ),
+        inverter_ac_capacity_w=inverter_ac_capacity_w,
+        return_tables=True,
+    )
+    yearly = raw_metrics.pop("_yearly_summary_df")
+    financial = raw_metrics.pop("_cost_projection_df")
+    metrics = {
+        "Modules": int(n_modules),
+        "Battery_kWh": float(battery_kwh),
+        "Tilt": float(tilt),
+        "Azimuth": float(azimuth),
+        **raw_metrics,
+    }
+    return ProjectedDesignResult(metrics=metrics, yearly=yearly, financial=financial)
 
 
 def calculate_financials(

--- a/breos/weather.py
+++ b/breos/weather.py
@@ -579,6 +579,7 @@ def resample_to_15min(
     non_negative_cols: Optional[List[str]] = None,
     latitude: Optional[float] = None,
     longitude: Optional[float] = None,
+    preserve_irradiance_energy: bool = False,
 ) -> pd.DataFrame:
     """
     Resample hourly DataFrame to 15-minute intervals.
@@ -596,6 +597,9 @@ def resample_to_15min(
         non_negative_cols: Columns to clip at zero (auto-detected for solar/wind)
         latitude: Location latitude for clear-sky scaling (optional)
         longitude: Location longitude for clear-sky scaling (optional)
+        preserve_irradiance_energy: Renormalize each source hour's four
+            irradiance values so their mean equals the source-hour value.
+            This is opt-in because it changes established interpolation output.
 
     Returns:
         DataFrame with 15-minute intervals
@@ -690,6 +694,26 @@ def resample_to_15min(
     for col in non_negative_cols:
         if col in df_15min.columns:
             df_15min[col] = np.clip(df_15min[col], 0, None)
+
+    if preserve_irradiance_energy and irrad_col_map:
+        if len(df_hourly.index) > 1:
+            intervals = df_hourly.index[1:] - df_hourly.index[:-1]
+            if not np.all(intervals == pd.Timedelta(hours=1)):
+                raise ValueError("preserve_irradiance_energy requires a regular hourly index")
+        expected_rows = len(df_hourly) * 4
+        if len(df_15min) != expected_rows:
+            raise ValueError("preserve_irradiance_energy requires four 15-minute rows per source hour")
+
+        for col in irrad_col_map:
+            if col not in df_15min.columns:
+                continue
+            hourly_values = pd.to_numeric(df_hourly[col], errors="coerce").fillna(0.0).to_numpy(dtype=float)
+            blocks = df_15min[col].to_numpy(dtype=float, copy=True).reshape(len(df_hourly), 4)
+            block_sums = blocks.sum(axis=1)
+            nonzero = block_sums > 1e-12
+            blocks[nonzero] *= (4.0 * hourly_values[nonzero] / block_sums[nonzero])[:, None]
+            blocks[~nonzero] = hourly_values[~nonzero, None]
+            df_15min[col] = np.clip(blocks.reshape(-1), 0.0, None)
 
     if weather_metadata is not None:
         df_15min.attrs[_WEATHER_METADATA_KEY] = weather_metadata

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -17,8 +17,74 @@ ZEB and financial production use usable AC system energy from the dispatch
 ledger, not raw PV DC, so inverter efficiency and clipping affect candidate
 scores. Physical size, inverter rating, and CAPEX use the selected module's
 `Mpp`; an explicit `costs.panel_wp` remains a deliberate cost-model override.
-The optimizer reports its battery-replacement treatment in result metadata;
-the App's multi-year projection remains the authoritative full trajectory.
+
+## Annual and projected objectives
+
+`optimize_system_multi_objective` supports two objective bases:
+
+- `optimization.objective_basis = "steady_state"` is the default. It preserves
+  the established annual three-objective search: grid independence, NPV, and
+  ZEB ratio. Battery replacement is estimated from the first-year SoH loss.
+- `optimization.objective_basis = "projected"` evaluates every candidate over
+  `simulation.years_projection` years, or `financials.project_lifespan` when
+  that key is absent. It optimizes two values: projected lifetime grid
+  independence and projected NPV.
+
+Projected mode repeats the configured TMY. Each year applies the configured PV
+degradation factor and carries battery stored energy, PV-origin stored energy,
+SoH, full-equivalent cycles, calendar time, cycle and calendar degradation,
+resistance growth, and supported degradation-engine state into the next year.
+Replacement remains enabled, resets the battery through the production battery
+engine, and adds the actual event cost to that year's financial ledger.
+
+Lifetime grid independence is calculated from aggregate energy, not from the
+mean annual percentage:
+
+```text
+GI_lifetime = 100 × (1 − total lifetime grid import / total lifetime load)
+```
+
+Projected NPV uses each simulated year's import, export, load, usable AC PV
+production, and replacement cost. This is a repeated-TMY scenario, not a
+forecast of distinct future weather years.
+
+ZEB remains a reported diagnostic in projected mode. Set
+`constraints.enforce_zeb = true` to require a projected lifetime ZEB ratio of
+at least one; this adds a feasibility constraint, not a third objective.
+
+Projected results expose `SteadyState_*` and `Projected_*` diagnostics. The
+ordinary `Grid_Independence_%` and `NPV_Eur` columns mirror the values used by
+the selected objective basis. In projected mode, they therefore equal
+`Projected_Grid_Independence_%` and `Projected_NPV_Eur`. `ZEB_Ratio` mirrors
+the corresponding diagnostic but is not an objective. `Objective_*` columns
+identify the metrics sent to NSGA-II explicitly; projected output has no
+`Objective_ZEB_Ratio` column.
+
+## Article 1 reproduction
+
+[`validation/article1/article1-projected-optimization.toml`](../../validation/article1/article1-projected-optimization.toml)
+pins the Article 1 15-minute, 20-year configuration, four archived comparison
+candidates, NSGA-II seed and early stopping, battery degradation, replacement,
+and financial assumptions. Its hourly TMY is interpolated with the clear-sky
+shape and opt-in hourly-energy conservation; the established general
+resampling default remains unchanged. The E-REDES household profile is
+licensed external data and is not redistributed.
+
+Run the deterministic fixed candidates before starting NSGA-II:
+
+```bash
+uv run python tools/reproduce_article1.py \
+  --rlp-directory /path/to/licensed/rlp \
+  --output results/article1
+```
+
+Add `--full-optimization` to run the configured population. Use
+`--smoke-optimization` for a four-candidate generation and `--n-procs N` to
+evaluate NSGA-II candidates in parallel. The command writes CSV results plus
+`reproduction.json`, which records the resolved config, exact
+source revision and dirty flag, command, software versions, and input hashes.
+The [reproduction report](https://github.com/Str4vinci/breos/blob/develop/validation/article1/README.md)
+explains the numerical changes caused by post-study corrections.
 
 ## Tilt
 

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -68,15 +68,16 @@ included in the metrics, while the financial table retains their annual source
 columns. These tables are intended as stable source data for custom
 analysis and plots; BREOS does not require a particular visualization layer.
 
-## Article 1 reproduction
+## Forthcoming publication study reproduction
 
 [`validation/article1/article1-projected-optimization.toml`](../../validation/article1/article1-projected-optimization.toml)
-pins the Article 1 15-minute, 20-year configuration, four archived comparison
-candidates plus the C5 low-investment benchmark, NSGA-II seed and early
-stopping, battery degradation, replacement, and financial assumptions. Its hourly TMY is interpolated with the clear-sky
-shape and opt-in hourly-energy conservation; the established general
-resampling default remains unchanged. The E-REDES household profile is
-licensed external data and is not redistributed.
+pins the 15-minute, 20-year configuration for the forthcoming publication
+study: four archived comparison candidates plus the C5 low-investment benchmark,
+NSGA-II seed and early stopping, battery degradation, replacement, and
+financial assumptions. Its hourly TMY is interpolated with the clear-sky shape
+and opt-in hourly-energy conservation. The established general resampling
+default remains unchanged. The E-REDES household profile is licensed external
+data and is not redistributed.
 
 Run the deterministic fixed candidates before starting NSGA-II:
 

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -22,13 +22,18 @@ scores. Physical size, inverter rating, and CAPEX use the selected module's
 
 `optimize_system_multi_objective` supports two objective bases:
 
-- `optimization.objective_basis = "steady_state"` is the default. It preserves
-  the established annual three-objective search: grid independence, NPV, and
-  ZEB ratio. Battery replacement is estimated from the first-year SoH loss.
-- `optimization.objective_basis = "projected"` evaluates every candidate over
-  `simulation.years_projection` years, or `financials.project_lifespan` when
-  that key is absent. It optimizes two values: projected lifetime grid
-  independence and projected NPV.
+- `optimization.objective_basis = "projected"` is the default. It evaluates
+  every candidate over `simulation.years_projection` years, or
+  `financials.project_lifespan` when that key is absent. It optimizes two
+  values: projected lifetime grid independence and projected NPV. A design is
+  selected for how it performs across the project lifetime, which is the
+  question a sizing study asks.
+- `optimization.objective_basis = "steady_state"` selects the cheaper annual
+  three-objective search: grid independence, NPV, and ZEB ratio. It scores each
+  candidate on a single simulated year and estimates battery replacement from
+  the first-year SoH loss, so it is a screening basis rather than a lifetime
+  answer. It costs one simulated year per candidate instead of
+  `years_projection`, which makes it useful for wide exploratory sweeps.
 
 Projected mode repeats the configured TMY. Each year applies the configured PV
 degradation factor and carries battery stored energy, PV-origin stored energy,

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -60,12 +60,18 @@ the corresponding diagnostic but is not an objective. `Objective_*` columns
 identify the metrics sent to NSGA-II explicitly; projected output has no
 `Objective_ZEB_Ratio` column.
 
+Use `evaluate_projected_design` when you need the detailed result for one
+fixed design instead of a Pareto search. It returns the projected metrics, the
+annual energy and degradation-state ledger, and the matching discounted
+financial ledger. These tables are intended as stable source data for custom
+analysis and plots; BREOS does not require a particular visualization layer.
+
 ## Article 1 reproduction
 
 [`validation/article1/article1-projected-optimization.toml`](../../validation/article1/article1-projected-optimization.toml)
 pins the Article 1 15-minute, 20-year configuration, four archived comparison
-candidates, NSGA-II seed and early stopping, battery degradation, replacement,
-and financial assumptions. Its hourly TMY is interpolated with the clear-sky
+candidates plus the C5 low-investment benchmark, NSGA-II seed and early
+stopping, battery degradation, replacement, and financial assumptions. Its hourly TMY is interpolated with the clear-sky
 shape and opt-in hourly-energy conservation; the established general
 resampling default remains unchanged. The E-REDES household profile is
 licensed external data and is not redistributed.
@@ -83,6 +89,13 @@ Add `--full-optimization` to run the configured population. Use
 evaluate NSGA-II candidates in parallel. The command writes CSV results plus
 `reproduction.json`, which records the resolved config, exact
 source revision and dirty flag, command, software versions, and input hashes.
+Each fixed candidate also gets `yearly_summary.csv`, `cost_projection.csv`,
+and `metrics.json`, with their hashes recorded in the report.
+
+Use `--calendar-model naumann_lam_field_calibrated_v2` or
+`--calendar-model naumann_lam` to repeat fixed-design or full optimization
+runs with the field-v2 or laboratory calendar-degradation parameters. Put each
+model in a separate `--output` directory.
 The [reproduction report](https://github.com/Str4vinci/breos/blob/develop/validation/article1/README.md)
 explains the numerical changes caused by post-study corrections.
 
@@ -103,6 +116,7 @@ explains the numerical changes caused by post-study corrections.
    :toctree: generated/
 
    breos.optimization.optimize_system_multi_objective
+   breos.optimization.evaluate_projected_design
 ```
 
 ## Battery sizing
@@ -122,4 +136,5 @@ explains the numerical changes caused by post-study corrections.
    :toctree: generated/
 
    breos.optimization.OptimizationResult
+   breos.optimization.ProjectedDesignResult
 ```

--- a/docs/api/optimization.md
+++ b/docs/api/optimization.md
@@ -63,7 +63,9 @@ identify the metrics sent to NSGA-II explicitly; projected output has no
 Use `evaluate_projected_design` when you need the detailed result for one
 fixed design instead of a Pareto search. It returns the projected metrics, the
 annual energy and degradation-state ledger, and the matching discounted
-financial ledger. These tables are intended as stable source data for custom
+financial ledger. LCOE and configured lifetime avoided-emissions totals are
+included in the metrics, while the financial table retains their annual source
+columns. These tables are intended as stable source data for custom
 analysis and plots; BREOS does not require a particular visualization layer.
 
 ## Article 1 reproduction

--- a/docs/api/weather.md
+++ b/docs/api/weather.md
@@ -84,7 +84,11 @@ filename such as `pvgis-sarah3`.
 
 Convert between hourly and 15-minute resolutions. The 15-minute path uses
 Makima interpolation on clearness indices rather than raw irradiance so
-sunrise / sunset transitions stay physically consistent.
+sunrise / sunset transitions stay physically consistent. Set
+`preserve_irradiance_energy=True` to renormalize each source hour's four GHI,
+DNI, and DHI values to the original hourly mean. This opt-in mode is useful
+when the source values represent hourly averages; the default keeps the
+established interpolation output.
 
 ```{eval-rst}
 .. autosummary::

--- a/tests/test_article1_reproduction.py
+++ b/tests/test_article1_reproduction.py
@@ -9,7 +9,7 @@ import pytest
 from tools.reproduce_article1 import DEFAULT_CONFIG, _fixed_candidates, _load_inputs, _sha256
 
 EXPECTED_RLP_SHA256 = "23becc5a7bfc927b1f7604156e0e4953dcc6bb65268ca947b38db3dc4f2b28bc"
-EXPECTED_CONFIG_SHA256 = "c44ba45c2d3d597275ef8fb66d7403551c6489af88545238f93c64c1b1f8a44f"
+EXPECTED_CONFIG_SHA256 = "b35ce7d4e90b89955a580d65d0abefe9e6d588dc729bc1cc472890efcc267631"
 EXPECTED = {
     "C1": (40.68817313425559, 5374.158425855234),
     "C2": (63.885472875836804, 3621.655066348969),
@@ -38,6 +38,7 @@ def test_article1_config_pins_projected_run_controls():
         "early_stop": {"ftol": 0.0025, "period": 10, "min_gen": 20, "n_skip": 0},
     }
     assert config["constraints"]["enforce_zeb"] is False
+    assert config["emissions"]["average_grid_carbon_intensity_gco2_kwh"] == 127.91
     assert len(config["reference_candidates"]) == 5
     assert config["reference_candidates"][-1] == {
         "label": "C5",

--- a/tests/test_article1_reproduction.py
+++ b/tests/test_article1_reproduction.py
@@ -1,4 +1,4 @@
-"""Opt-in regression against the licensed Article 1 household profile."""
+"""Opt-in regression against the licensed profile used by the forthcoming publication study."""
 
 import os
 import tomllib
@@ -9,7 +9,7 @@ import pytest
 from tools.reproduce_article1 import DEFAULT_CONFIG, _fixed_candidates, _load_inputs, _sha256
 
 EXPECTED_RLP_SHA256 = "23becc5a7bfc927b1f7604156e0e4953dcc6bb65268ca947b38db3dc4f2b28bc"
-EXPECTED_CONFIG_SHA256 = "b35ce7d4e90b89955a580d65d0abefe9e6d588dc729bc1cc472890efcc267631"
+EXPECTED_CONFIG_SHA256 = "684199bf797c19e3265666e7637342f7259793161ae67780a7b56437fdd83f54"
 EXPECTED = {
     "C1": (40.68817313425559, 5374.158425855234),
     "C2": (63.885472875836804, 3621.655066348969),
@@ -53,7 +53,7 @@ def test_article1_fixed_candidates_with_licensed_rlp(tmp_path):
     """Pin deterministic v0.6 projected values when the external RLP is available."""
     rlp_value = os.environ.get("BREOS_ARTICLE1_RLP_DIRECTORY")
     if not rlp_value:
-        pytest.skip("set BREOS_ARTICLE1_RLP_DIRECTORY to run the licensed Article 1 regression")
+        pytest.skip("set BREOS_ARTICLE1_RLP_DIRECTORY to run the forthcoming publication study regression")
 
     config = tomllib.loads(DEFAULT_CONFIG.read_text())
     weather, load, _weather_path, rlp_path = _load_inputs(config, Path(rlp_value))

--- a/tests/test_article1_reproduction.py
+++ b/tests/test_article1_reproduction.py
@@ -1,0 +1,60 @@
+"""Opt-in regression against the licensed Article 1 household profile."""
+
+import os
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from tools.reproduce_article1 import DEFAULT_CONFIG, _fixed_candidates, _load_inputs, _sha256
+
+EXPECTED_RLP_SHA256 = "23becc5a7bfc927b1f7604156e0e4953dcc6bb65268ca947b38db3dc4f2b28bc"
+EXPECTED_CONFIG_SHA256 = "675244c823f4f6dd4947efa359266ad7b1508b1a12d85218954b1c09fc3ce32e"
+EXPECTED = {
+    "C1": (40.68817313425559, 5374.158425855234),
+    "C2": (63.885472875836804, 3621.655066348969),
+    "C3": (77.60057480030382, 2456.262367231171),
+    "C4": (88.74974235783394, -5263.658994360769),
+}
+
+
+def test_article1_config_pins_projected_run_controls():
+    config = tomllib.loads(DEFAULT_CONFIG.read_text())
+
+    assert _sha256(DEFAULT_CONFIG) == EXPECTED_CONFIG_SHA256
+    assert config["simulation"] == {
+        "resolution": "15min",
+        "years_projection": 20,
+        "weather_file": "validation/data/weather/porto_tmy_2005_2023_pvgis-sarah3.csv.gz",
+        "irradiance_resampling": "clear_sky_energy_conserving",
+    }
+    assert config["optimization"] == {
+        "algorithm": "nsga2",
+        "objective_basis": "projected",
+        "pop_size": 100,
+        "n_offsprings": 50,
+        "n_gen": 40,
+        "seed": 1,
+        "early_stop": {"ftol": 0.0025, "period": 10, "min_gen": 20, "n_skip": 0},
+    }
+    assert config["constraints"]["enforce_zeb"] is False
+    assert len(config["reference_candidates"]) == 4
+
+
+def test_article1_fixed_candidates_with_licensed_rlp():
+    """Pin deterministic v0.5.3-line values when the external RLP is available."""
+    rlp_value = os.environ.get("BREOS_ARTICLE1_RLP_DIRECTORY")
+    if not rlp_value:
+        pytest.skip("set BREOS_ARTICLE1_RLP_DIRECTORY to run the licensed Article 1 regression")
+
+    config = tomllib.loads(DEFAULT_CONFIG.read_text())
+    weather, load, _weather_path, rlp_path = _load_inputs(config, Path(rlp_value))
+    assert _sha256(rlp_path) == EXPECTED_RLP_SHA256
+
+    reproduced = _fixed_candidates(config, weather, load, set()).set_index("Label")
+    for label, (expected_gi, expected_npv) in EXPECTED.items():
+        # The deterministic series are stable to much tighter precision on the
+        # reference platform. These tolerances allow only floating-point solver
+        # noise across supported Python/NumPy combinations, not model drift.
+        assert reproduced.loc[label, "BREOS_Projected_GI_%"] == pytest.approx(expected_gi, abs=5e-5)
+        assert reproduced.loc[label, "BREOS_Projected_NPV_Eur"] == pytest.approx(expected_npv, abs=0.05)

--- a/tests/test_article1_reproduction.py
+++ b/tests/test_article1_reproduction.py
@@ -9,7 +9,7 @@ import pytest
 from tools.reproduce_article1 import DEFAULT_CONFIG, _fixed_candidates, _load_inputs, _sha256
 
 EXPECTED_RLP_SHA256 = "23becc5a7bfc927b1f7604156e0e4953dcc6bb65268ca947b38db3dc4f2b28bc"
-EXPECTED_CONFIG_SHA256 = "675244c823f4f6dd4947efa359266ad7b1508b1a12d85218954b1c09fc3ce32e"
+EXPECTED_CONFIG_SHA256 = "c44ba45c2d3d597275ef8fb66d7403551c6489af88545238f93c64c1b1f8a44f"
 EXPECTED = {
     "C1": (40.68817313425559, 5374.158425855234),
     "C2": (63.885472875836804, 3621.655066348969),
@@ -38,11 +38,18 @@ def test_article1_config_pins_projected_run_controls():
         "early_stop": {"ftol": 0.0025, "period": 10, "min_gen": 20, "n_skip": 0},
     }
     assert config["constraints"]["enforce_zeb"] is False
-    assert len(config["reference_candidates"]) == 4
+    assert len(config["reference_candidates"]) == 5
+    assert config["reference_candidates"][-1] == {
+        "label": "C5",
+        "modules": 4,
+        "battery_kwh": 0.0,
+        "tilt": 35.0,
+        "azimuth": 180.0,
+    }
 
 
-def test_article1_fixed_candidates_with_licensed_rlp():
-    """Pin deterministic v0.5.3-line values when the external RLP is available."""
+def test_article1_fixed_candidates_with_licensed_rlp(tmp_path):
+    """Pin deterministic v0.6 projected values when the external RLP is available."""
     rlp_value = os.environ.get("BREOS_ARTICLE1_RLP_DIRECTORY")
     if not rlp_value:
         pytest.skip("set BREOS_ARTICLE1_RLP_DIRECTORY to run the licensed Article 1 regression")
@@ -51,10 +58,16 @@ def test_article1_fixed_candidates_with_licensed_rlp():
     weather, load, _weather_path, rlp_path = _load_inputs(config, Path(rlp_value))
     assert _sha256(rlp_path) == EXPECTED_RLP_SHA256
 
-    reproduced = _fixed_candidates(config, weather, load, set()).set_index("Label")
+    reproduced = _fixed_candidates(config, weather, load, set(EXPECTED), tmp_path).set_index("Label")
     for label, (expected_gi, expected_npv) in EXPECTED.items():
         # The deterministic series are stable to much tighter precision on the
         # reference platform. These tolerances allow only floating-point solver
         # noise across supported Python/NumPy combinations, not model drift.
         assert reproduced.loc[label, "BREOS_Projected_GI_%"] == pytest.approx(expected_gi, abs=5e-5)
         assert reproduced.loc[label, "BREOS_Projected_NPV_Eur"] == pytest.approx(expected_npv, abs=0.05)
+
+    for label in EXPECTED:
+        candidate_dir = tmp_path / "candidates" / label.lower()
+        assert (candidate_dir / "yearly_summary.csv").is_file()
+        assert (candidate_dir / "cost_projection.csv").is_file()
+        assert (candidate_dir / "metrics.json").is_file()

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -9,6 +9,83 @@ pytest.importorskip("pymoo")
 from breos.optimization import SolarDesignProblem, optimize_system_multi_objective
 
 
+def test_projected_objective_basis_uses_two_objectives_and_optional_zeb_constraint():
+    idx = pd.date_range("2025-01-01 00:00", periods=2, freq="h", tz="UTC")
+    tmy_data = pd.DataFrame({"temp_air": [15.0, 16.0], "ghi": [0.0, 0.0]}, index=idx)
+    houseload = pd.DataFrame({"Load": [500.0, 500.0]}, index=idx)
+    config = {
+        "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
+        "optimization": {"objective_basis": "projected"},
+        "constraints": {"enforce_zeb": True},
+        "mode": {"fixed_azimuth": 180},
+    }
+
+    problem = SolarDesignProblem(tmy_data, houseload, config, "results/_test_run/problem_projected")
+
+    assert problem.n_obj == 2
+    assert problem.n_ieq_constr == 3
+
+
+def test_projected_objective_basis_rejects_unknown_value():
+    idx = pd.date_range("2025-01-01", periods=2, freq="h", tz="UTC")
+    tmy_data = pd.DataFrame({"temp_air": [15.0, 16.0], "ghi": [0.0, 0.0]}, index=idx)
+    houseload = pd.DataFrame({"Load": [500.0, 500.0]}, index=idx)
+
+    with pytest.raises(ValueError, match="objective_basis"):
+        SolarDesignProblem(
+            tmy_data,
+            houseload,
+            {
+                "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
+                "optimization": {"objective_basis": "lifetime-ish"},
+            },
+            "results/_test_run/problem_invalid_basis",
+        )
+
+
+def test_projected_zeb_constraint_uses_projected_diagnostic(monkeypatch):
+    idx = pd.date_range("2025-01-01", periods=2, freq="h", tz="UTC")
+    tmy_data = pd.DataFrame({"temp_air": [15.0, 16.0], "ghi": [0.0, 0.0]}, index=idx)
+    houseload = pd.DataFrame({"Load": [500.0, 500.0]}, index=idx)
+    results = pd.DataFrame(
+        {
+            "Houseload": [500.0, 500.0],
+            "PV_AC_To_Load": [0.0, 0.0],
+            "Battery_AC_To_Load_PV": [0.0, 0.0],
+            "PV_AC_Export": [0.0, 0.0],
+        },
+        index=idx,
+    )
+    summary = pd.DataFrame({"Import [kWh]": [1.0], "Sell [kWh]": [0.0]})
+    projected = {
+        "Projected_Grid_Independence_%": 50.0,
+        "Projected_ZEB_Ratio": 0.8,
+        "Projected_NPV_Eur": 1000.0,
+    }
+    monkeypatch.setattr("breos.optimization.calculate_pv_production_dc", lambda **kwargs: pd.Series(0.0, index=idx))
+    monkeypatch.setattr(
+        "breos.optimization.simulate_energy_balance",
+        lambda **kwargs: (results, 0.0, summary, 0.0, 0, pd.DataFrame()),
+    )
+    monkeypatch.setattr("breos.optimization.calculate_financials", lambda *args, **kwargs: (0.0, 0.0))
+    monkeypatch.setattr("breos.optimization._evaluate_projected_design_metrics", lambda **kwargs: projected)
+    config = {
+        "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
+        "optimization": {"objective_basis": "projected"},
+        "constraints": {"budget_eur": 100000.0, "max_area_m2": 100.0, "enforce_zeb": True},
+        "simulation": {"resolution": "h", "years_projection": 2},
+        "financials": {"project_lifespan": 2},
+        "mode": {"fixed_azimuth": 180},
+    }
+    out = {}
+    problem = SolarDesignProblem(tmy_data, houseload, config, "results/_test_run/problem_projected_zeb")
+    problem._evaluate(np.array([2.0, 0.0, 10.0]), out)
+
+    assert out["F"] == pytest.approx([0.5, -1000.0])
+    assert out["ZEB_Ratio"] == pytest.approx(0.8)
+    assert out["G"][2] == pytest.approx(0.2)
+
+
 def test_solar_design_problem_area_constraint_uses_pv_dimensions(monkeypatch):
     idx = pd.date_range("2025-01-01 00:00", periods=2, freq="h", tz="UTC")
     tmy_data = pd.DataFrame({"temp_air": [15.0, 16.0], "ghi": [0.0, 0.0]}, index=idx)
@@ -241,3 +318,95 @@ def test_optimize_system_multi_objective_returns_pareto_dataframe(monkeypatch):
         "ZEB_Ratio",
     }
     assert result.details["battery_replacement_treatment"]["method"] == ("repeat_simulated_year_1_soh_loss_to_eol")
+
+
+def test_projected_optimization_smoke_reports_two_objective_semantics(monkeypatch):
+    idx = pd.date_range("2025-01-01", periods=4, freq="h", tz="UTC")
+    tmy_data = pd.DataFrame(
+        {
+            "temp_air": [15.0, 16.0, 17.0, 18.0],
+            "ghi": [0.0, 500.0, 500.0, 0.0],
+        },
+        index=idx,
+    )
+    houseload = pd.DataFrame({"Load": [500.0] * 4}, index=idx)
+    dc = pd.Series([0.0, 1000.0, 1000.0, 0.0], index=idx)
+    results = pd.DataFrame(
+        {
+            "Houseload": [500.0] * 4,
+            "PV_AC_To_Load": [0.0, 400.0, 400.0, 0.0],
+            "Battery_AC_To_Load_PV": [0.0] * 4,
+            "PV_AC_Export": [0.0, 100.0, 100.0, 0.0],
+        },
+        index=idx,
+    )
+    summary = pd.DataFrame({"Import [kWh]": [1.2], "Sell [kWh]": [0.2]})
+
+    def fake_projected(**kwargs):
+        modules = kwargs["n_modules"]
+        return {
+            "Projected_Grid_Independence_%": 40.0 + modules,
+            "Projected_Grid_Independence_Year1_%": 41.0 + modules,
+            "Projected_Grid_Independence_FinalYear_%": 39.0 + modules,
+            "Projected_Grid_Independence_Mean_%": 40.0 + modules,
+            "Projected_Grid_Independence_Min_%": 39.0 + modules,
+            "Projected_ZEB_Ratio": 0.8 + modules / 100.0,
+            "Projected_ZEB_Ratio_Year1": 0.81 + modules / 100.0,
+            "Projected_ZEB_Ratio_FinalYear": 0.79 + modules / 100.0,
+            "Projected_ZEB_Ratio_Mean": 0.8 + modules / 100.0,
+            "Projected_ZEB_Ratio_Min": 0.79 + modules / 100.0,
+            "Projected_NPV_Eur": 1000.0 - modules,
+            "Projected_Breakeven_Year": 8.0,
+            "Projected_Breakeven_Year_Exact": 7.5,
+            "Projected_Initial_Cost_Eur": 500.0,
+            "Projected_Replacement_Cost_Eur": 0.0,
+            "Projected_Total_Replacements": 0,
+            "Projected_Final_SOH_%": 90.0,
+            "Projected_PV_Production_Year1_kWh": 1.0,
+            "Projected_PV_Production_FinalYear_kWh": 0.9,
+        }
+
+    monkeypatch.setattr("breos.optimization.calculate_pv_production_dc", lambda **kwargs: dc)
+    monkeypatch.setattr(
+        "breos.optimization.simulate_energy_balance",
+        lambda **kwargs: (results, 1000.0, summary, 0.0, 0, pd.DataFrame()),
+    )
+    monkeypatch.setattr("breos.optimization.calculate_financials", lambda *args, **kwargs: (500.0, 750.0))
+    monkeypatch.setattr("breos.optimization._evaluate_projected_design_metrics", fake_projected)
+
+    config = {
+        "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
+        "simulation": {"resolution": "h", "years_projection": 2},
+        "optimization": {"objective_basis": "projected", "early_stop": False},
+        "constraints": {
+            "budget_eur": 100000.0,
+            "max_area_m2": 100.0,
+            "max_modules": 4,
+            "max_battery_kwh": 3.0,
+            "max_tilt_deg": 30.0,
+        },
+        "mode": {"fixed_azimuth": 180},
+        "battery": {"temperature": 20.0},
+        "financials": {"project_lifespan": 2},
+    }
+    result = optimize_system_multi_objective(
+        tmy_data,
+        houseload,
+        config,
+        pop_size=4,
+        n_gen=1,
+        seed=1,
+        verbose=False,
+    )
+
+    pareto = result.details["pareto"]
+    assert result.details["problem"].n_obj == 2
+    assert result.details["objective_basis"] == "projected"
+    assert result.iterations == 1
+    assert np.array_equal(pareto["Grid_Independence_%"], pareto["Projected_Grid_Independence_%"])
+    assert np.array_equal(pareto["NPV_Eur"], pareto["Projected_NPV_Eur"])
+    assert np.array_equal(pareto["ZEB_Ratio"], pareto["Projected_ZEB_Ratio"])
+    assert np.allclose(pareto["Objective_Grid_Independence_%"], pareto["Projected_Grid_Independence_%"])
+    assert np.allclose(pareto["Objective_NPV_Eur"], pareto["Projected_NPV_Eur"])
+    assert "Objective_ZEB_Ratio" not in pareto
+    assert result.details["objective_names"] == ["Projected_Grid_Independence_%", "Projected_NPV_Eur"]

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -26,6 +26,44 @@ def test_projected_objective_basis_uses_two_objectives_and_optional_zeb_constrai
     assert problem.n_ieq_constr == 3
 
 
+def test_objective_basis_defaults_to_projected():
+    """A design is chosen for its lifetime, so lifetime scoring is the default.
+
+    The annual basis scores a candidate on its first year alone, before any PV
+    degradation, battery fade, or replacement. Leaving that as the default made
+    the cheap approximation the one a caller got without asking.
+    """
+    idx = pd.date_range("2025-01-01 00:00", periods=2, freq="h", tz="UTC")
+    tmy_data = pd.DataFrame({"temp_air": [15.0, 16.0], "ghi": [0.0, 0.0]}, index=idx)
+    houseload = pd.DataFrame({"Load": [500.0, 500.0]}, index=idx)
+    config = {
+        "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
+        "mode": {"fixed_azimuth": 180},
+    }
+
+    problem = SolarDesignProblem(tmy_data, houseload, config, "results/_test_run/problem_default_basis")
+
+    assert problem.objective_basis == "projected"
+    assert problem.projected_objectives is True
+    assert problem.n_obj == 2
+
+
+def test_steady_state_objective_basis_is_available_as_opt_in():
+    idx = pd.date_range("2025-01-01 00:00", periods=2, freq="h", tz="UTC")
+    tmy_data = pd.DataFrame({"temp_air": [15.0, 16.0], "ghi": [0.0, 0.0]}, index=idx)
+    houseload = pd.DataFrame({"Load": [500.0, 500.0]}, index=idx)
+    config = {
+        "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
+        "optimization": {"objective_basis": "steady_state"},
+        "mode": {"fixed_azimuth": 180},
+    }
+
+    problem = SolarDesignProblem(tmy_data, houseload, config, "results/_test_run/problem_steady_state")
+
+    assert problem.projected_objectives is False
+    assert problem.n_obj == 3
+
+
 def test_projected_objective_basis_rejects_unknown_value():
     idx = pd.date_range("2025-01-01", periods=2, freq="h", tz="UTC")
     tmy_data = pd.DataFrame({"temp_air": [15.0, 16.0], "ghi": [0.0, 0.0]}, index=idx)
@@ -96,6 +134,7 @@ def test_solar_design_problem_area_constraint_uses_pv_dimensions(monkeypatch):
         "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
         "simulation": {"resolution": "h"},
         "constraints": {"budget_eur": 100000, "max_area_m2": 10.0, "max_modules": 5},
+        "optimization": {"objective_basis": "steady_state"},
         "mode": {"fixed_azimuth": 180},
         "pv": {
             "module": "Suntech_STP550S_STC",
@@ -145,6 +184,7 @@ def test_solar_design_problem_uses_configured_resolution(monkeypatch):
     config = {
         "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
         "simulation": {"resolution": "15min"},
+        "optimization": {"objective_basis": "steady_state"},
         "constraints": {"budget_eur": 100000, "max_area_m2": 100.0},
         "mode": {"fixed_azimuth": 180},
         "battery": {"temperature": 20.0, "indoor_model": {"enabled": False}},
@@ -198,6 +238,7 @@ def test_solar_design_problem_scores_zeb_from_explicit_ac_ledger(monkeypatch):
         "simulation": {"resolution": "h"},
         "constraints": {"budget_eur": 100000, "max_area_m2": 100.0},
         "mode": {"fixed_azimuth": 180},
+        "optimization": {"objective_basis": "steady_state"},
         "battery": {"temperature": 20.0},
     }
 
@@ -245,6 +286,7 @@ def test_solar_design_problem_uses_simulated_load_for_objective_denominator(monk
         "simulation": {"resolution": "h"},
         "constraints": {"budget_eur": 100000, "max_area_m2": 100.0},
         "mode": {"fixed_azimuth": 180},
+        "optimization": {"objective_basis": "steady_state"},
         "battery": {"temperature": 20.0},
     }
 
@@ -285,6 +327,7 @@ def test_optimize_system_multi_objective_returns_pareto_dataframe(monkeypatch):
             "max_tilt_deg": 30.0,
         },
         "mode": {"fixed_azimuth": 180},
+        "optimization": {"objective_basis": "steady_state"},
         "battery": {"temperature": 20.0},
     }
 

--- a/tests/test_optimization_parity.py
+++ b/tests/test_optimization_parity.py
@@ -147,6 +147,11 @@ def _problem_config(dc_ac_ratio: float = 1.6):
         "location": {"latitude": 41.15, "longitude": -8.61, "timezone": "UTC"},
         "simulation": {"resolution": "h"},
         "constraints": {"budget_eur": 100000, "max_area_m2": 100.0, "max_modules": 5},
+        # These assert the wiring of one annual scoring pass, against a fake
+        # simulate_energy_balance. The default projected basis would run the
+        # multi-year loop instead, which is a different call signature and not
+        # what is under test here.
+        "optimization": {"objective_basis": "steady_state"},
         "mode": {"fixed_azimuth": 180},
         "pv": {"module": "Suntech_STP550S_STC"},
         "battery": {"temperature": 20.0, "indoor_model": {"enabled": False}},

--- a/tests/test_projected_optimization.py
+++ b/tests/test_projected_optimization.py
@@ -1,0 +1,123 @@
+"""Projected optimization uses the canonical yearly simulation ledger."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from breos.optimization import _evaluate_projected_design_metrics, _summarize_projected_lifetime_metrics
+from breos.pv_modules import get_module
+
+
+def test_lifetime_grid_independence_uses_total_import_and_load():
+    yearly = pd.DataFrame(
+        {
+            "Year": [1, 2],
+            "Load_kWh": [100.0, 200.0],
+            "Import_kWh": [20.0, 100.0],
+            "PV_Production_kWh": [80.0, 120.0],
+            "Grid_Independence_%": [80.0, 50.0],
+        }
+    )
+
+    metrics = _summarize_projected_lifetime_metrics(yearly)
+
+    assert metrics["Projected_Grid_Independence_%"] == pytest.approx(60.0)
+    assert metrics["Projected_Grid_Independence_Mean_%"] == pytest.approx(65.0)
+    assert metrics["Projected_ZEB_Ratio"] == pytest.approx(2.0 / 3.0)
+
+
+def test_projected_evaluator_carries_physical_and_degradation_state(monkeypatch):
+    idx = pd.date_range("2025-01-01", periods=2, freq="h", tz="UTC")
+    base_dc = pd.Series([1000.0, 500.0], index=idx)
+    tmy = pd.DataFrame({"temp_air": [20.0, 20.0], "ghi": [500.0, 250.0]}, index=idx)
+    load = pd.DataFrame({"Load": [500.0, 500.0]}, index=idx)
+    temperature = pd.Series([20.0, 20.0], index=idx)
+    calls = []
+
+    def fake_balance(**kwargs):
+        calls.append(kwargs)
+        year = len(calls)
+        results = pd.DataFrame(
+            {
+                "PV_AC_To_Load": [300.0, 300.0],
+                "Battery_AC_To_Load_PV": [50.0, 50.0],
+                "PV_AC_Export": [50.0, 50.0],
+                "Houseload": [500.0, 500.0],
+                "Import_From_Grid": [150.0 * year, 150.0 * year],
+                "Sell_To_Grid": [50.0, 50.0],
+                "Battery_Energy_End": [100.0, 100.0 + year],
+                "Battery_PV_Origin_Energy_End": [50.0, 50.0 + year],
+            },
+            index=idx,
+        )
+        degradation = pd.DataFrame(
+            {
+                "Cumulative_FEC": [10.0 * year],
+                "Cumulative_Calendar_Seconds": [1000.0 * year],
+                "Cumulative_Cycle_Degradation": [0.01 * year],
+                "Cumulative_Calendar_Degradation": [0.02 * year],
+                "Resistance_Growth": [0.03 * year],
+                "SOH": [95.0 if year == 1 else 99.0],
+            }
+        )
+        replacements = 1 if year == 2 else 0
+        replacement_cost = 1000.0 if replacements else 0.0
+        return results, 0.0, pd.DataFrame(), replacement_cost, replacements, degradation, {"year": year}
+
+    captured = {}
+
+    def fake_projection(**kwargs):
+        captured["yearly"] = kwargs["yearly_summary_df"].copy()
+        projection = pd.DataFrame(
+            {
+                "Year": [1, 2],
+                "Savings_Cumulative_NPV": [-100.0, 50.0],
+            }
+        )
+        projection.attrs["payback_year"] = 2
+        return projection
+
+    monkeypatch.setattr("breos.optimization.simulate_energy_balance", fake_balance)
+    monkeypatch.setattr("breos.optimization.cost_analysis_projection", fake_projection)
+
+    metrics = _evaluate_projected_design_metrics(
+        base_dc_power=base_dc,
+        tmy_data=tmy,
+        houseload=load,
+        temperature_series=temperature,
+        pv_params=get_module("Suntech_STP550S_STC"),
+        batt_spec={
+            "min_soc": 0.1,
+            "max_soc": 0.9,
+            "enable_replacement": True,
+            "enable_resistance_fade": True,
+        },
+        costs_cfg={"storage_cost_per_kwh": 500.0},
+        fin_cfg={"project_lifespan": 2},
+        freq="h",
+        years_projection=2,
+        degradation_rate=0.10,
+        n_modules=2,
+        battery_kwh=2.0,
+        inverter_efficiency=0.96,
+        inverter_ac_capacity_w=1000.0,
+        return_tables=True,
+    )
+
+    assert np.array_equal(calls[0]["pv_dc"].to_numpy(), base_dc.to_numpy())
+    assert np.allclose(calls[1]["pv_dc"].to_numpy(), base_dc.to_numpy() * 0.9)
+    assert calls[1]["initial_fec"] == pytest.approx(10.0)
+    assert calls[1]["initial_calendar_seconds"] == pytest.approx(1000.0)
+    assert calls[1]["initial_resistance_growth"] == pytest.approx(0.03)
+    assert calls[1]["initial_cumulative_cycle_deg"] == pytest.approx(0.01)
+    assert calls[1]["initial_cumulative_cal_deg"] == pytest.approx(0.02)
+    assert calls[1]["initial_energy_wh"] == pytest.approx(101.0)
+    assert calls[1]["initial_pv_origin_energy_wh"] == pytest.approx(51.0)
+    assert calls[1]["battery_config"].replacement_cost == pytest.approx(1000.0)
+    assert captured["yearly"]["Import_kWh"].tolist() == pytest.approx([0.3, 0.6])
+    assert captured["yearly"]["Replacement_Cost"].tolist() == pytest.approx([0.0, 1000.0])
+    assert metrics["Projected_NPV_Eur"] == pytest.approx(50.0)
+    assert metrics["Projected_Total_Replacements"] == 1
+    assert metrics["Projected_Replacement_Cost_Eur"] == pytest.approx(1000.0)
+    assert metrics["Projected_Final_SOH_%"] == pytest.approx(99.0)
+    assert metrics["Projected_Breakeven_Year"] == pytest.approx(2.0)

--- a/tests/test_projected_optimization.py
+++ b/tests/test_projected_optimization.py
@@ -77,6 +77,8 @@ def test_projected_evaluator_carries_physical_and_degradation_state(monkeypatch)
             {
                 "Year": [1, 2],
                 "Savings_Cumulative_NPV": [-100.0, 50.0],
+                "CO2_Avoided_Total_Cumulative_kg": [10.0, 21.0],
+                "CO2_Avoided_SelfConsumed_Cumulative_kg": [8.0, 17.0],
             }
         )
         projection.attrs["payback_year"] = 2
@@ -84,6 +86,7 @@ def test_projected_evaluator_carries_physical_and_degradation_state(monkeypatch)
 
     monkeypatch.setattr("breos.optimization.simulate_energy_balance", fake_balance)
     monkeypatch.setattr("breos.optimization.cost_analysis_projection", fake_projection)
+    monkeypatch.setattr("breos.optimization.calculate_lcoe_from_projection", lambda *_args, **_kwargs: 0.123)
 
     metrics = _evaluate_projected_design_metrics(
         base_dc_power=base_dc,
@@ -126,6 +129,9 @@ def test_projected_evaluator_carries_physical_and_degradation_state(monkeypatch)
     assert metrics["Projected_Replacement_Cost_Eur"] == pytest.approx(1000.0)
     assert metrics["Projected_Final_SOH_%"] == pytest.approx(99.0)
     assert metrics["Projected_Breakeven_Year"] == pytest.approx(2.0)
+    assert metrics["Projected_LCOE_Eur_kWh"] == pytest.approx(0.123)
+    assert metrics["Projected_CO2_Avoided_Total_kg"] == pytest.approx(21.0)
+    assert metrics["Projected_CO2_Avoided_SelfConsumed_kg"] == pytest.approx(17.0)
     assert metrics["_yearly_summary_df"]["Battery_Cumulative_FEC"].tolist() == pytest.approx([10.0, 20.0])
     assert metrics["_yearly_summary_df"]["Battery_Cumulative_Calendar_Degradation"].tolist() == pytest.approx(
         [0.02, 0.04]

--- a/tests/test_projected_optimization.py
+++ b/tests/test_projected_optimization.py
@@ -4,7 +4,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from breos.optimization import _evaluate_projected_design_metrics, _summarize_projected_lifetime_metrics
+from breos.optimization import (
+    ProjectedDesignResult,
+    _evaluate_projected_design_metrics,
+    _summarize_projected_lifetime_metrics,
+    evaluate_projected_design,
+)
 from breos.pv_modules import get_module
 
 
@@ -121,3 +126,55 @@ def test_projected_evaluator_carries_physical_and_degradation_state(monkeypatch)
     assert metrics["Projected_Replacement_Cost_Eur"] == pytest.approx(1000.0)
     assert metrics["Projected_Final_SOH_%"] == pytest.approx(99.0)
     assert metrics["Projected_Breakeven_Year"] == pytest.approx(2.0)
+    assert metrics["_yearly_summary_df"]["Battery_Cumulative_FEC"].tolist() == pytest.approx([10.0, 20.0])
+    assert metrics["_yearly_summary_df"]["Battery_Cumulative_Calendar_Degradation"].tolist() == pytest.approx(
+        [0.02, 0.04]
+    )
+
+
+def test_public_projected_design_evaluator_returns_plot_source_tables(monkeypatch):
+    idx = pd.date_range("2025-01-01", periods=2, freq="h", tz="UTC")
+    weather = pd.DataFrame({"temp_air": [20.0, 20.0]}, index=idx)
+    load = pd.DataFrame({"Load": [500.0, 500.0]}, index=idx)
+    yearly = pd.DataFrame({"Year": [1], "Grid_Independence_%": [60.0]})
+    financial = pd.DataFrame({"Year": [1], "Savings_Cumulative_NPV": [100.0]})
+
+    monkeypatch.setattr(
+        "breos.optimization.calculate_pv_production_dc",
+        lambda **_kwargs: pd.Series([100.0, 200.0], index=idx),
+    )
+    monkeypatch.setattr(
+        "breos.optimization._temperature_series_from_config",
+        lambda *_args, **_kwargs: pd.Series([20.0, 20.0], index=idx),
+    )
+    monkeypatch.setattr(
+        "breos.optimization._evaluate_projected_design_metrics",
+        lambda **_kwargs: {
+            "Projected_Grid_Independence_%": 60.0,
+            "Projected_NPV_Eur": 100.0,
+            "_yearly_summary_df": yearly,
+            "_cost_projection_df": financial,
+        },
+    )
+
+    result = evaluate_projected_design(
+        weather,
+        load,
+        {
+            "location": {"latitude": 41.15, "longitude": -8.63},
+            "pv": {"module": "Suntech_STP550S_STC"},
+            "simulation": {"resolution": "h", "years_projection": 1},
+            "financials": {"project_lifespan": 1},
+            "costs": {"dc_ac_ratio": 1.25},
+        },
+        n_modules=9,
+        battery_kwh=5.0,
+        tilt=25.0,
+        azimuth=185.0,
+    )
+
+    assert isinstance(result, ProjectedDesignResult)
+    assert result.metrics["Modules"] == 9
+    assert result.metrics["Projected_NPV_Eur"] == pytest.approx(100.0)
+    pd.testing.assert_frame_equal(result.yearly, yearly)
+    pd.testing.assert_frame_equal(result.financial, financial)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -68,6 +68,31 @@ def test_resample_to_15min_keeps_all_slots_in_last_hour():
     assert resampled.index[-1] == pd.Timestamp("2025-01-01 02:45")
 
 
+def test_resample_to_15min_can_preserve_each_hours_irradiance_energy():
+    idx = pd.date_range("2025-06-21 10:00", periods=4, freq="h", tz="UTC")
+    weather = pd.DataFrame(
+        {
+            "ghi": [500.0, 700.0, 600.0, 300.0],
+            "dni": [400.0, 600.0, 500.0, 200.0],
+            "dhi": [250.0, 300.0, 350.0, 200.0],
+            "temp_air": [20.0, 21.0, 22.0, 21.0],
+        },
+        index=idx,
+    )
+
+    resampled = resample_to_15min(
+        weather,
+        method="linear",
+        latitude=41.1579,
+        longitude=-8.6291,
+        preserve_irradiance_energy=True,
+    )
+
+    for column in ("ghi", "dni", "dhi"):
+        hourly_means = resampled[column].to_numpy().reshape(len(weather), 4).mean(axis=1)
+        assert hourly_means == pytest.approx(weather[column].to_numpy())
+
+
 def test_fetch_tmy_weather_accepts_hourly_frequency_alias_and_uses_horizon_by_default(monkeypatch):
     tmy = pd.DataFrame({"ghi": [0.0]}, index=pd.date_range("2020-01-01 00:00", periods=1, freq="h"))
     captured = {}

--- a/tools/reproduce_article1.py
+++ b/tools/reproduce_article1.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 import breos  # noqa: E402
 from breos.load_profiles import load_profile  # noqa: E402
-from breos.optimization import SolarDesignProblem, optimize_system_multi_objective  # noqa: E402
+from breos.optimization import evaluate_projected_design, optimize_system_multi_objective  # noqa: E402
 from breos.weather import resample_to_15min  # noqa: E402
 
 DEFAULT_CONFIG = PROJECT_ROOT / "validation/article1/article1-projected-optimization.toml"
@@ -118,24 +118,26 @@ def _fixed_candidates(
     weather: pd.DataFrame,
     load: pd.DataFrame,
     selected_labels: set[str],
+    output_directory: Path,
 ) -> pd.DataFrame:
-    problem = SolarDesignProblem(weather, load, config, "results/article1/fixed_candidates")
     rows = []
     for reference in config["reference_candidates"]:
         if selected_labels and reference["label"] not in selected_labels:
             continue
-        candidate = [
-            float(reference["modules"]),
-            float(reference["battery_kwh"]),
-            float(reference["tilt"]),
-            float(reference["azimuth"]),
-        ]
-        output: dict = {}
-        problem._evaluate(candidate, output)
+        result = evaluate_projected_design(
+            weather,
+            load,
+            config,
+            n_modules=int(reference["modules"]),
+            battery_kwh=float(reference["battery_kwh"]),
+            tilt=float(reference["tilt"]),
+            azimuth=float(reference["azimuth"]),
+        )
+        output = result.metrics
         reproduced_gi = float(output["Projected_Grid_Independence_%"])
         reproduced_npv = float(output["Projected_NPV_Eur"])
-        reference_gi = float(reference["projected_grid_independence_pct"])
-        reference_npv = float(reference["projected_npv_eur"])
+        reference_gi = float(reference.get("projected_grid_independence_pct", float("nan")))
+        reference_npv = float(reference.get("projected_npv_eur", float("nan")))
         row = {
             "Label": reference["label"],
             "Modules": int(reference["modules"]),
@@ -150,9 +152,15 @@ def _fixed_candidates(
             "NPV_Difference_Eur": reproduced_npv - reference_npv,
         }
         for key, value in output.items():
-            if key.startswith("SteadyState_") or key.startswith("Projected_") or key.startswith("Objective_"):
+            if key.startswith("Projected_"):
                 row[key] = value
         rows.append(row)
+
+        candidate_directory = output_directory / "candidates" / str(reference["label"]).lower()
+        candidate_directory.mkdir(parents=True, exist_ok=True)
+        result.yearly.to_csv(candidate_directory / "yearly_summary.csv", index=False)
+        result.financial.to_csv(candidate_directory / "cost_projection.csv", index=False)
+        (candidate_directory / "metrics.json").write_text(json.dumps(output, indent=2, default=str) + "\n")
     return pd.DataFrame(rows)
 
 
@@ -162,6 +170,11 @@ def main() -> int:
     parser.add_argument("--rlp-directory", type=Path, required=True)
     parser.add_argument("--weather-file", type=Path, help="Override the configured weather file")
     parser.add_argument("--candidate", action="append", default=[], help="Run only the named fixed candidate")
+    parser.add_argument("--skip-fixed", action="store_true", help="Skip fixed-design evaluations")
+    parser.add_argument(
+        "--calendar-model",
+        help="Override battery.calendar_model (for example naumann_lam_field_calibrated_v2 or naumann_lam)",
+    )
     optimization_group = parser.add_mutually_exclusive_group()
     optimization_group.add_argument("--smoke-optimization", action="store_true")
     optimization_group.add_argument("--full-optimization", action="store_true")
@@ -171,14 +184,18 @@ def main() -> int:
 
     config_bytes = args.config.read_bytes()
     config = tomllib.loads(config_bytes.decode("utf-8"))
+    if args.calendar_model:
+        config.setdefault("battery", {})["calendar_model"] = args.calendar_model
     weather, load, weather_path, rlp_path = _load_inputs(config, args.rlp_directory, args.weather_file)
     args.output.mkdir(parents=True, exist_ok=True)
 
-    fixed = _fixed_candidates(config, weather, load, set(args.candidate))
+    fixed = pd.DataFrame()
     fixed_path = args.output / "fixed_candidates.csv"
-    fixed.to_csv(fixed_path, index=False)
-    print(fixed.to_string(index=False))
-    print(f"\nWrote {fixed_path}")
+    if not args.skip_fixed:
+        fixed = _fixed_candidates(config, weather, load, set(args.candidate), args.output)
+        fixed.to_csv(fixed_path, index=False)
+        print(fixed.to_string(index=False))
+        print(f"\nWrote {fixed_path}")
 
     report = {
         "breos_version": breos.__version__,
@@ -192,6 +209,9 @@ def main() -> int:
         "research_weather_sha256": RESEARCH_WEATHER_SHA256,
         "config": _display_path(args.config),
         "config_sha256": hashlib.sha256(config_bytes).hexdigest(),
+        "resolved_config_sha256": hashlib.sha256(
+            json.dumps(config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
         "resolved_config": config,
         "weather": _display_path(weather_path),
         "weather_file_sha256": _sha256(weather_path),
@@ -202,6 +222,25 @@ def main() -> int:
         "external_rlp_filename": rlp_path.name,
         "external_rlp_sha256": _sha256(rlp_path),
         "fixed_candidates": fixed.to_dict(orient="records"),
+        "fixed_candidate_artifacts": (
+            {
+                str(row["Label"]): {
+                    "yearly_summary": f"candidates/{str(row['Label']).lower()}/yearly_summary.csv",
+                    "yearly_summary_sha256": _sha256(
+                        args.output / "candidates" / str(row["Label"]).lower() / "yearly_summary.csv"
+                    ),
+                    "cost_projection": f"candidates/{str(row['Label']).lower()}/cost_projection.csv",
+                    "cost_projection_sha256": _sha256(
+                        args.output / "candidates" / str(row["Label"]).lower() / "cost_projection.csv"
+                    ),
+                    "metrics": f"candidates/{str(row['Label']).lower()}/metrics.json",
+                    "metrics_sha256": _sha256(args.output / "candidates" / str(row["Label"]).lower() / "metrics.json"),
+                }
+                for row in fixed.to_dict(orient="records")
+            }
+            if not fixed.empty
+            else {}
+        ),
     }
 
     if args.full_optimization or args.smoke_optimization:

--- a/tools/reproduce_article1.py
+++ b/tools/reproduce_article1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Reproduce the deterministic Article 1 projected optimization results."""
+"""Reproduce the forthcoming publication study's projected optimization results."""
 
 from __future__ import annotations
 
@@ -84,10 +84,11 @@ def _load_inputs(
     weather_path = weather_override or PROJECT_ROOT / simulation["weather_file"]
     rlp_path = rlp_directory / load_config["external_filename"]
     if not weather_path.is_file():
-        raise FileNotFoundError(f"Article 1 weather file not found: {weather_path}")
+        raise FileNotFoundError(f"Weather file for the forthcoming publication study not found: {weather_path}")
     if not rlp_path.is_file():
         raise FileNotFoundError(
-            f"Article 1 external RLP not found: {rlp_path}. Pass --rlp-directory with the licensed E-REDES file."
+            f"External RLP for the forthcoming publication study not found: {rlp_path}. "
+            "Pass --rlp-directory with the licensed E-REDES file."
         )
 
     weather = pd.read_csv(weather_path, index_col=0)

--- a/tools/reproduce_article1.py
+++ b/tools/reproduce_article1.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Reproduce the deterministic Article 1 projected optimization results."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gzip
+import hashlib
+import importlib.metadata
+import json
+import platform
+import shlex
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import breos  # noqa: E402
+from breos.load_profiles import load_profile  # noqa: E402
+from breos.optimization import SolarDesignProblem, optimize_system_multi_objective  # noqa: E402
+from breos.weather import resample_to_15min  # noqa: E402
+
+DEFAULT_CONFIG = PROJECT_ROOT / "validation/article1/article1-projected-optimization.toml"
+RESEARCH_COMMIT = "a0db6aae1e8d04a8260f51a34543b23bd82a1762"
+RESEARCH_PARETO_SHA256 = "5334b8361b2395f0f19b6839005964b0b61bfa0d00e5ea28f450cfb4cde0a225"
+RESEARCH_WEATHER_SHA256 = "d2258dc7ea0d6432a6ddf69f748e67e88a36b235a906d5c6ab7da96e8e6911e0"
+
+
+def _sha256(path: Path, *, decompress_gzip: bool = False) -> str:
+    digest = hashlib.sha256()
+    opener = gzip.open if decompress_gzip else Path.open
+    with opener(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _git_revision() -> dict[str, str | bool]:
+    """Return the exact source revision and whether tracked files differ from it."""
+    revision = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    tracked_status = subprocess.run(
+        ["git", "status", "--short", "--untracked-files=no"],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return {"commit": revision, "tracked_worktree_dirty": bool(tracked_status)}
+
+
+def _dependency_versions() -> dict[str, str]:
+    """Record the numerical packages that can affect deterministic output."""
+    return {package: importlib.metadata.version(package) for package in ("numpy", "pandas", "pvlib", "scipy", "pymoo")}
+
+
+def _display_path(path: Path) -> str:
+    """Prefer a repository-relative input path without hiding external inputs."""
+    try:
+        return str(path.resolve().relative_to(PROJECT_ROOT.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def _load_inputs(
+    config: dict,
+    rlp_directory: Path,
+    weather_override: Path | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, Path, Path]:
+    simulation = config["simulation"]
+    location = config["location"]
+    load_config = config["load"]
+    weather_path = weather_override or PROJECT_ROOT / simulation["weather_file"]
+    rlp_path = rlp_directory / load_config["external_filename"]
+    if not weather_path.is_file():
+        raise FileNotFoundError(f"Article 1 weather file not found: {weather_path}")
+    if not rlp_path.is_file():
+        raise FileNotFoundError(
+            f"Article 1 external RLP not found: {rlp_path}. Pass --rlp-directory with the licensed E-REDES file."
+        )
+
+    weather = pd.read_csv(weather_path, index_col=0)
+    weather.index = pd.to_datetime(weather.index, utc=True)
+    if simulation["resolution"] == "15min":
+        resampling = simulation.get("irradiance_resampling", "clear_sky")
+        if resampling not in {"clear_sky", "clear_sky_energy_conserving"}:
+            raise ValueError(f"Unsupported simulation.irradiance_resampling: {resampling!r}")
+        weather = resample_to_15min(
+            weather,
+            latitude=float(location["latitude"]),
+            longitude=float(location["longitude"]),
+            preserve_irradiance_energy=resampling == "clear_sky_energy_conserving",
+        )
+    load = load_profile(
+        str(load_config["profile_type"]),
+        float(load_config["annual_consumption_kwh"]),
+        start_date=str(weather.index[0].year) + "-01-01",
+        freq=str(simulation["resolution"]),
+        rlp_directory=str(rlp_directory),
+        timezone=str(location["timezone"]),
+    )
+    return weather, load, weather_path, rlp_path
+
+
+def _fixed_candidates(
+    config: dict,
+    weather: pd.DataFrame,
+    load: pd.DataFrame,
+    selected_labels: set[str],
+) -> pd.DataFrame:
+    problem = SolarDesignProblem(weather, load, config, "results/article1/fixed_candidates")
+    rows = []
+    for reference in config["reference_candidates"]:
+        if selected_labels and reference["label"] not in selected_labels:
+            continue
+        candidate = [
+            float(reference["modules"]),
+            float(reference["battery_kwh"]),
+            float(reference["tilt"]),
+            float(reference["azimuth"]),
+        ]
+        output: dict = {}
+        problem._evaluate(candidate, output)
+        reproduced_gi = float(output["Projected_Grid_Independence_%"])
+        reproduced_npv = float(output["Projected_NPV_Eur"])
+        reference_gi = float(reference["projected_grid_independence_pct"])
+        reference_npv = float(reference["projected_npv_eur"])
+        row = {
+            "Label": reference["label"],
+            "Modules": int(reference["modules"]),
+            "Battery_kWh": float(reference["battery_kwh"]),
+            "Tilt": float(reference["tilt"]),
+            "Azimuth": float(reference["azimuth"]),
+            "Reference_Projected_GI_%": reference_gi,
+            "BREOS_Projected_GI_%": reproduced_gi,
+            "GI_Difference_pp": reproduced_gi - reference_gi,
+            "Reference_Projected_NPV_Eur": reference_npv,
+            "BREOS_Projected_NPV_Eur": reproduced_npv,
+            "NPV_Difference_Eur": reproduced_npv - reference_npv,
+        }
+        for key, value in output.items():
+            if key.startswith("SteadyState_") or key.startswith("Projected_") or key.startswith("Objective_"):
+                row[key] = value
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--rlp-directory", type=Path, required=True)
+    parser.add_argument("--weather-file", type=Path, help="Override the configured weather file")
+    parser.add_argument("--candidate", action="append", default=[], help="Run only the named fixed candidate")
+    optimization_group = parser.add_mutually_exclusive_group()
+    optimization_group.add_argument("--smoke-optimization", action="store_true")
+    optimization_group.add_argument("--full-optimization", action="store_true")
+    parser.add_argument("--n-procs", type=int, default=1, help="Optimization worker processes")
+    parser.add_argument("--output", type=Path, default=PROJECT_ROOT / "results/article1")
+    args = parser.parse_args()
+
+    config_bytes = args.config.read_bytes()
+    config = tomllib.loads(config_bytes.decode("utf-8"))
+    weather, load, weather_path, rlp_path = _load_inputs(config, args.rlp_directory, args.weather_file)
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    fixed = _fixed_candidates(config, weather, load, set(args.candidate))
+    fixed_path = args.output / "fixed_candidates.csv"
+    fixed.to_csv(fixed_path, index=False)
+    print(fixed.to_string(index=False))
+    print(f"\nWrote {fixed_path}")
+
+    report = {
+        "breos_version": breos.__version__,
+        "breos_source": _git_revision(),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "dependency_versions": _dependency_versions(),
+        "command": shlex.join([sys.executable, *sys.argv]),
+        "research_commit": RESEARCH_COMMIT,
+        "research_pareto_sha256": RESEARCH_PARETO_SHA256,
+        "research_weather_sha256": RESEARCH_WEATHER_SHA256,
+        "config": _display_path(args.config),
+        "config_sha256": hashlib.sha256(config_bytes).hexdigest(),
+        "resolved_config": config,
+        "weather": _display_path(weather_path),
+        "weather_file_sha256": _sha256(weather_path),
+        "weather_uncompressed_sha256": _sha256(
+            weather_path,
+            decompress_gzip=weather_path.suffix == ".gz",
+        ),
+        "external_rlp_filename": rlp_path.name,
+        "external_rlp_sha256": _sha256(rlp_path),
+        "fixed_candidates": fixed.to_dict(orient="records"),
+    }
+
+    if args.full_optimization or args.smoke_optimization:
+        run_config = copy.deepcopy(config)
+        optimization = run_config["optimization"]
+        if args.smoke_optimization:
+            optimization.update({"pop_size": 4, "n_offsprings": 2, "n_gen": 1, "early_stop": False})
+        result = optimize_system_multi_objective(
+            weather,
+            load,
+            run_config,
+            results_dir=str(args.output / "optimization"),
+            pop_size=int(optimization["pop_size"]),
+            n_gen=int(optimization["n_gen"]),
+            n_offsprings=int(optimization["n_offsprings"]),
+            seed=int(optimization["seed"]),
+            verbose=True,
+            n_procs=args.n_procs,
+        )
+        pareto_path = args.output / "pareto_results.csv"
+        result.details["pareto"].to_csv(pareto_path, index=False)
+        report["optimization"] = {
+            "run_type": "full" if args.full_optimization else "smoke",
+            "settings": optimization,
+            "iterations": result.iterations,
+            "objective_basis": result.details["objective_basis"],
+            "objective_names": result.details["objective_names"],
+            "early_stop": result.details["early_stop"],
+            "n_procs": result.details["n_procs"],
+            "pareto_csv": pareto_path.name,
+            "pareto_sha256": _sha256(pareto_path),
+        }
+        print(f"Wrote {pareto_path}")
+
+    report_path = args.output / "reproduction.json"
+    report_path.write_text(json.dumps(report, indent=2, default=str) + "\n")
+    print(f"Wrote {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation/article1/README.md
+++ b/validation/article1/README.md
@@ -1,7 +1,7 @@
 # Article 1 projected-optimization reproduction
 
 This report compares four archived Article 1 Pareto candidates with the
-corrected projected optimizer prepared for the BREOS 0.5.3 release line. The
+corrected projected optimizer prepared for the BREOS 0.6.0 release line. The
 new results deliberately do not reproduce known errors in the research run.
 
 ## Provenance
@@ -22,7 +22,7 @@ new results deliberately do not reproduce known errors in the research run.
   `8dcf17574ca440f77b9092651035ae32b5e6f998`, with a clean tracked
   worktree recorded by the reproduction tool.
 - Reproduction config SHA-256:
-  `675244c823f4f6dd4947efa359266ad7b1508b1a12d85218954b1c09fc3ce32e`.
+  `c44ba45c2d3d597275ef8fb66d7403551c6489af88545238f93c64c1b1f8a44f`.
 - Bundled weather SHA-256 (compressed):
   `bf84e31b02ad9bf39f331a5ce8629b1ea8f80cd1597748e72a87a0fce56b4f15`.
 - Bundled weather SHA-256 (uncompressed):
@@ -82,6 +82,12 @@ source revision, worker count, objective names, generation count, and Pareto
 digest. Generated outputs are deliberately not committed; rerun the command
 below to create them in the chosen output directory.
 
+The reproduction command also exports a plot-independent source bundle for
+each fixed case: projected metrics, the yearly energy/degradation-state table,
+and the financial ledger. C5 (4 modules, no battery, 35° tilt, 180° azimuth) is
+included as the manuscript's low-investment benchmark. It was not part of the
+four-candidate full-precision comparison above.
+
 ## Why the results differ
 
 The archived run has a resolution error. Its TMY loader returned 8,760 hourly
@@ -133,6 +139,31 @@ uv run python tools/reproduce_article1.py \
   --n-procs 8 \
   --output results/article1
 ```
+
+Run the field-v2 fixed cases and full optimization into a separate directory:
+
+```bash
+uv run python tools/reproduce_article1.py \
+  --rlp-directory /path/to/licensed/rlp \
+  --calendar-model naumann_lam_field_calibrated_v2 \
+  --full-optimization \
+  --n-procs 8 \
+  --output results/article1-v2
+```
+
+Run the laboratory-parameter sensitivity in the same way:
+
+```bash
+uv run python tools/reproduce_article1.py \
+  --rlp-directory /path/to/licensed/rlp \
+  --calendar-model naumann_lam \
+  --full-optimization \
+  --n-procs 8 \
+  --output results/article1-lab
+```
+
+Add `--candidate C2` and omit `--full-optimization` when only the fixed C2
+degradation-model comparison is required.
 
 Run the opt-in numerical regression locally:
 

--- a/validation/article1/README.md
+++ b/validation/article1/README.md
@@ -22,7 +22,7 @@ new results deliberately do not reproduce known errors in the research run.
   `8dcf17574ca440f77b9092651035ae32b5e6f998`, with a clean tracked
   worktree recorded by the reproduction tool.
 - Reproduction config SHA-256:
-  `c44ba45c2d3d597275ef8fb66d7403551c6489af88545238f93c64c1b1f8a44f`.
+  `b35ce7d4e90b89955a580d65d0abefe9e6d588dc729bc1cc472890efcc267631`.
 - Bundled weather SHA-256 (compressed):
   `bf84e31b02ad9bf39f331a5ce8629b1ea8f80cd1597748e72a87a0fce56b4f15`.
 - Bundled weather SHA-256 (uncompressed):
@@ -84,7 +84,8 @@ below to create them in the chosen output directory.
 
 The reproduction command also exports a plot-independent source bundle for
 each fixed case: projected metrics, the yearly energy/degradation-state table,
-and the financial ledger. C5 (4 modules, no battery, 35° tilt, 180° azimuth) is
+and the financial ledger, including LCOE and lifetime emissions inputs. C5 (4
+modules, no battery, 35° tilt, 180° azimuth) is
 included as the manuscript's low-investment benchmark. It was not part of the
 four-candidate full-precision comparison above.
 

--- a/validation/article1/README.md
+++ b/validation/article1/README.md
@@ -8,6 +8,9 @@ new results deliberately do not reproduce known errors in the research run.
 
 - Archived run: `dev/results/a1_july_rerun_tuxedo/moo_15min` in the private
   research repository.
+- Earlier reference tag supplied for comparison: `a1_jun_26_submission`
+  (`6af21cc61640da7fc003d79319527631ec7cbddd`). The later July rerun above is
+  the Article 1 result set used for the numerical comparison.
 - Research revision: `a0db6aae1e8d04a8260f51a34543b23bd82a1762`.
 - Archived Pareto SHA-256:
   `5334b8361b2395f0f19b6839005964b0b61bfa0d00e5ea28f450cfb4cde0a225`.
@@ -15,6 +18,9 @@ new results deliberately do not reproduce known errors in the research run.
   `d2258dc7ea0d6432a6ddf69f748e67e88a36b235a906d5c6ab7da96e8e6911e0`.
 - Public BREOS base revision:
   `8fd1f21c4f1335350d87f91d76246b3fd1184f6d` (`origin/develop`).
+- Tested BREOS feature revision:
+  `8dcf17574ca440f77b9092651035ae32b5e6f998`, with a clean tracked
+  worktree recorded by the reproduction tool.
 - Reproduction config SHA-256:
   `675244c823f4f6dd4947efa359266ad7b1508b1a12d85218954b1c09fc3ce32e`.
 - Bundled weather SHA-256 (compressed):
@@ -51,6 +57,30 @@ candidates. Its output used exactly two objectives (`Projected_Grid_Independence
 and `Projected_NPV_Eur`), retained projected ZEB only as a diagnostic, and
 produced Pareto CSV SHA-256
 `e458780b84d477bda5ed726dfdcb7b87a7a357bf0c97a54d6443126a98674645`.
+
+## Full projected optimization
+
+The exact Article 1 NSGA-II configuration completed all 40 configured
+generations (2,050 evaluations) with seed 1 and eight worker processes. It
+returned 100 unique nondominated designs using only projected GI and projected
+NPV as objectives. Early stopping did not trigger before the generation cap.
+
+The corrected front spans 40.825173% to 88.819590% projected GI and
+−€5,280.60 to €5,379.67 projected NPV. Its maximum-NPV design has 6 modules,
+no battery, 25° tilt, and 195° azimuth. Its maximum-GI design has 9 modules, a
+20 kWh battery, 50° tilt, and 185° azimuth. A normalized closest-to-ideal
+summary point has 9 modules, a 9 kWh battery, 30° tilt, and 190° azimuth, with
+77.617510% projected GI and €2,454.04 projected NPV. This summary point is not
+an additional optimization objective or a prescribed design choice.
+
+The generated 100-row `pareto_results.csv` has SHA-256
+`24dac6a404c3d17a5ee0f3de4589d3bec9a6bcca3c78eeb3f0504b1f803c8a98`.
+The accompanying `reproduction.json` has SHA-256
+`bdcc906dfab1f55324363f44dad4144a167193f9fea29ad2dd6b4c37685233e7`.
+That JSON records the resolved configuration, environment, inputs, clean
+source revision, worker count, objective names, generation count, and Pareto
+digest. Generated outputs are deliberately not committed; rerun the command
+below to create them in the chosen output directory.
 
 ## Why the results differ
 
@@ -100,6 +130,7 @@ Run the exact NSGA-II settings after reviewing the fixed-candidate comparison:
 uv run python tools/reproduce_article1.py \
   --rlp-directory /path/to/licensed/rlp \
   --full-optimization \
+  --n-procs 8 \
   --output results/article1
 ```
 

--- a/validation/article1/README.md
+++ b/validation/article1/README.md
@@ -1,8 +1,11 @@
-# Article 1 projected-optimization reproduction
+# Forthcoming publication study: projected-optimization reproduction
 
-This report compares four archived Article 1 Pareto candidates with the
-corrected projected optimizer prepared for the BREOS 0.6.0 release line. The
-new results deliberately do not reproduce known errors in the research run.
+This report compares four archived Pareto candidates from the study supporting
+the forthcoming publication with the corrected projected optimizer prepared
+for the BREOS 0.6.0 release line. The new results deliberately do not reproduce
+known errors in the research run.
+
+The repository keeps `article1` as the internal identifier for this study.
 
 ## Provenance
 
@@ -10,7 +13,8 @@ new results deliberately do not reproduce known errors in the research run.
   research repository.
 - Earlier reference tag supplied for comparison: `a1_jun_26_submission`
   (`6af21cc61640da7fc003d79319527631ec7cbddd`). The later July rerun above is
-  the Article 1 result set used for the numerical comparison.
+  the result set used for the forthcoming publication study's numerical
+  comparison.
 - Research revision: `a0db6aae1e8d04a8260f51a34543b23bd82a1762`.
 - Archived Pareto SHA-256:
   `5334b8361b2395f0f19b6839005964b0b61bfa0d00e5ea28f450cfb4cde0a225`.
@@ -60,9 +64,9 @@ produced Pareto CSV SHA-256
 
 ## Full projected optimization
 
-The exact Article 1 NSGA-II configuration completed all 40 configured
-generations (2,050 evaluations) with seed 1 and eight worker processes. It
-returned 100 unique nondominated designs using only projected GI and projected
+The exact configuration used for the forthcoming publication study completed all
+40 configured generations (2,050 evaluations) with seed 1 and eight worker
+processes. It returned 100 unique nondominated designs using only projected GI and projected
 NPV as objectives. Early stopping did not trigger before the generation cap.
 
 The corrected front spans 40.825173% to 88.819590% projected GI and
@@ -97,8 +101,9 @@ calculation then constructed a 15-minute index and selected the nearest hourly
 irradiance value at every step. For C1, this repetition produces 4,943.362 kWh
 after a flat 96% inverter efficiency, which matches the archived 4,943.364 kWh.
 
-The Article 1 reproduction uses clear-sky-aware interpolation and then
-renormalizes each source hour's four GHI, DNI, and DHI values so their mean
+The reproduction for the forthcoming publication uses clear-sky-aware
+interpolation and then renormalizes each source hour's four GHI, DNI, and DHI
+values so their mean
 equals the original hourly value. This preserves the source irradiance energy
 while improving intra-hour solar shape. The energy-conserving option is
 explicit and leaves the established BREOS resampling default unchanged.

--- a/validation/article1/README.md
+++ b/validation/article1/README.md
@@ -1,0 +1,111 @@
+# Article 1 projected-optimization reproduction
+
+This report compares four archived Article 1 Pareto candidates with the
+corrected projected optimizer prepared for the BREOS 0.5.3 release line. The
+new results deliberately do not reproduce known errors in the research run.
+
+## Provenance
+
+- Archived run: `dev/results/a1_july_rerun_tuxedo/moo_15min` in the private
+  research repository.
+- Research revision: `a0db6aae1e8d04a8260f51a34543b23bd82a1762`.
+- Archived Pareto SHA-256:
+  `5334b8361b2395f0f19b6839005964b0b61bfa0d00e5ea28f450cfb4cde0a225`.
+- Archived weather SHA-256:
+  `d2258dc7ea0d6432a6ddf69f748e67e88a36b235a906d5c6ab7da96e8e6911e0`.
+- Public BREOS base revision:
+  `8fd1f21c4f1335350d87f91d76246b3fd1184f6d` (`origin/develop`).
+- Reproduction config SHA-256:
+  `675244c823f4f6dd4947efa359266ad7b1508b1a12d85218954b1c09fc3ce32e`.
+- Bundled weather SHA-256 (compressed):
+  `bf84e31b02ad9bf39f331a5ce8629b1ea8f80cd1597748e72a87a0fce56b4f15`.
+- Bundled weather SHA-256 (uncompressed):
+  `79af3f5edbf5040409506178b17e25a48ce1c426cb8eaff51991afb6e1199126`.
+- External E-REDES RLP SHA-256:
+  `23becc5a7bfc927b1f7604156e0e4953dcc6bb65268ca947b38db3dc4f2b28bc`.
+
+The E-REDES profile is not redistributed. Pass the directory containing the
+licensed file to the reproduction command. `reproduction.json` records the
+fully resolved config, command line, Python and BREOS versions, exact source
+revision, dirty-worktree flag, and all input hashes for every run.
+
+The nested optimizer config lives here as
+[`article1-projected-optimization.toml`](article1-projected-optimization.toml).
+It is not an App/`breos run` config; `tools/reproduce_article1.py` is its public
+entrypoint.
+
+## Fixed candidates
+
+| Candidate | Design (modules, battery, tilt, azimuth) | Archived GI | BREOS GI | Archived NPV | BREOS NPV |
+| --- | --- | ---: | ---: | ---: | ---: |
+| C1 | 6, 0 kWh, 30°, 190° | 41.056152% | 40.688173% | €5,424.43 | €5,374.16 |
+| C2 | 9, 5 kWh, 25°, 185° | 64.768329% | 63.885473% | €3,779.25 | €3,621.66 |
+| C3 | 9, 9 kWh, 35°, 190° | 78.683166% | 77.600575% | €2,642.02 | €2,456.26 |
+| C4 | 9, 20 kWh, 45°, 175° | 89.390357% | 88.749742% | −€5,094.04 | −€5,263.66 |
+
+[`fixed-candidate-comparison.csv`](fixed-candidate-comparison.csv) contains
+the full-precision values and absolute and relative differences.
+
+A two-process NSGA-II smoke run completed one generation with four evaluated
+candidates. Its output used exactly two objectives (`Projected_Grid_Independence_%`
+and `Projected_NPV_Eur`), retained projected ZEB only as a diagnostic, and
+produced Pareto CSV SHA-256
+`e458780b84d477bda5ed726dfdcb7b87a7a357bf0c97a54d6443126a98674645`.
+
+## Why the results differ
+
+The archived run has a resolution error. Its TMY loader returned 8,760 hourly
+rows even when the optimization requested a 15-minute resolution. The PV
+calculation then constructed a 15-minute index and selected the nearest hourly
+irradiance value at every step. For C1, this repetition produces 4,943.362 kWh
+after a flat 96% inverter efficiency, which matches the archived 4,943.364 kWh.
+
+The Article 1 reproduction uses clear-sky-aware interpolation and then
+renormalizes each source hour's four GHI, DNI, and DHI values so their mean
+equals the original hourly value. This preserves the source irradiance energy
+while improving intra-hour solar shape. The energy-conserving option is
+explicit and leaves the established BREOS resampling default unchanged.
+
+BREOS uses the corrected explicit AC dispatch ledger. A finite inverter
+rating applies the PVWatts part-load curve and clipping instead of an unbounded
+flat 96% conversion. For C1, the first-year result is 5,182.097 kWh DC and
+4,962.091 kWh usable AC, including 215.926 kWh conversion loss and 4.080 kWh
+curtailed DC. Battery candidates additionally carry stored energy,
+PV-origin energy, degradation state, and resistance growth across years.
+
+The outer archived MOO provenance records `other_cost_per_module = 50`, but
+the projection template that actually scored candidates resolved to €30 per
+module. The public reproduction uses €30, matching the archived candidate
+CAPEX (for example, €2,820.1968 for C1). This is an archived provenance defect,
+not a reason to alter the current cost engine.
+
+The bundled public TMY is a normalized, rounded form of the archived PVGIS
+file and therefore has a different digest. Repeating C1 with the exact archived
+weather changes the result by only +0.0145 percentage points GI and about
++€2.40 NPV. It does not explain the archived discrepancy.
+
+## Commands
+
+Run all fixed candidates:
+
+```bash
+uv run python tools/reproduce_article1.py \
+  --rlp-directory /path/to/licensed/rlp \
+  --output results/article1
+```
+
+Run the exact NSGA-II settings after reviewing the fixed-candidate comparison:
+
+```bash
+uv run python tools/reproduce_article1.py \
+  --rlp-directory /path/to/licensed/rlp \
+  --full-optimization \
+  --output results/article1
+```
+
+Run the opt-in numerical regression locally:
+
+```bash
+BREOS_ARTICLE1_RLP_DIRECTORY=/path/to/licensed/rlp \
+  uv run pytest -q tests/test_article1_reproduction.py
+```

--- a/validation/article1/article1-projected-optimization.toml
+++ b/validation/article1/article1-projected-optimization.toml
@@ -75,6 +75,12 @@ sell_price_inflation = 0.0
 project_lifespan = 20
 pv_degradation_rate = 0.005
 
+[emissions]
+country = "Portugal"
+average_grid_carbon_intensity_gco2_kwh = 127.91
+source = "Ember Climate, Europe Yearly Full Release"
+year = 2025
+
 [simulation]
 resolution = "15min"
 years_projection = 20

--- a/validation/article1/article1-projected-optimization.toml
+++ b/validation/article1/article1-projected-optimization.toml
@@ -116,3 +116,10 @@ tilt = 45.0
 azimuth = 175.0
 projected_grid_independence_pct = 89.39035743523462
 projected_npv_eur = -5094.0374517273485
+
+[[reference_candidates]]
+label = "C5"
+modules = 4
+battery_kwh = 0.0
+tilt = 35.0
+azimuth = 180.0

--- a/validation/article1/article1-projected-optimization.toml
+++ b/validation/article1/article1-projected-optimization.toml
@@ -1,0 +1,118 @@
+name = "Article 1 projected optimization reproduction"
+inverter_efficiency = 0.96
+
+[location]
+latitude = 41.1579
+longitude = -8.6291
+timezone = "Europe/Lisbon"
+name = "Porto, Portugal"
+
+[load]
+profile_type = "6"
+annual_consumption_kwh = 5000.0
+external_filename = "EREDES_2025_BTN_1000kwh_15min.csv"
+
+[pv]
+module = "Suntech_STP550S_STC"
+degradation_rate = 0.005
+
+[battery]
+eol_percentage = 0.70
+calendar_model = "naumann_lam_field_calibrated"
+max_soc = 0.90
+min_soc = 0.10
+charge_efficiency = 0.974679434
+discharge_efficiency = 0.974679434
+# Research input: 85 A at 51.2 V, expressed through the public power cap.
+max_charge_power_w = 4352.0
+enable_replacement = true
+replacement_cost = "calculate"
+
+[optimization]
+algorithm = "nsga2"
+objective_basis = "projected"
+pop_size = 100
+n_offsprings = 50
+n_gen = 40
+seed = 1
+
+[optimization.early_stop]
+ftol = 0.0025
+period = 10
+min_gen = 20
+n_skip = 0
+
+[constraints]
+budget_eur = 15000.0
+max_area_m2 = 25.0
+max_modules = 20
+max_battery_kwh = 30.0
+max_tilt_deg = "adjust"
+enforce_zeb = false
+
+[costs]
+electricity_cost = 0.2582
+electricity_sold_cost = 0.04
+daily_power_cost = 0.30
+module_cost_per_w = 0.125
+storage_cost_per_kwh = 500.0
+inverter_cost_per_kw_hybrid = 102.58
+inverter_cost_per_kw_simple = 48.37
+installation_cost_per_module = 350.0
+installation_cost_battery = 350.0
+# The projection template used to score the archived Pareto front resolved to
+# EUR 30/module. The outer MOO provenance incorrectly recorded EUR 50/module.
+other_cost_per_module = 30.0
+other_costs = 0.0
+maintenance_cost_per_panel = 10.0
+maintenance_cost = 0.0
+dc_ac_ratio = 1.25
+
+[financials]
+discount_rate = 0.05
+inflation_rate = 0.02
+sell_price_inflation = 0.0
+project_lifespan = 20
+pv_degradation_rate = 0.005
+
+[simulation]
+resolution = "15min"
+years_projection = 20
+weather_file = "validation/data/weather/porto_tmy_2005_2023_pvgis-sarah3.csv.gz"
+irradiance_resampling = "clear_sky_energy_conserving"
+
+[[reference_candidates]]
+label = "C1"
+modules = 6
+battery_kwh = 0.0
+tilt = 30.0
+azimuth = 190.0
+projected_grid_independence_pct = 41.056152035721105
+projected_npv_eur = 5424.42676447725
+
+[[reference_candidates]]
+label = "C2"
+modules = 9
+battery_kwh = 5.0
+tilt = 25.0
+azimuth = 185.0
+projected_grid_independence_pct = 64.76832911500924
+projected_npv_eur = 3779.2543999748195
+
+[[reference_candidates]]
+label = "C3"
+modules = 9
+battery_kwh = 9.0
+tilt = 35.0
+azimuth = 190.0
+projected_grid_independence_pct = 78.68316595800997
+projected_npv_eur = 2642.017104647359
+
+[[reference_candidates]]
+label = "C4"
+modules = 9
+battery_kwh = 20.0
+tilt = 45.0
+azimuth = 175.0
+projected_grid_independence_pct = 89.39035743523462
+projected_npv_eur = -5094.0374517273485

--- a/validation/article1/article1-projected-optimization.toml
+++ b/validation/article1/article1-projected-optimization.toml
@@ -1,4 +1,4 @@
-name = "Article 1 projected optimization reproduction"
+name = "Forthcoming publication study projected optimization reproduction"
 inverter_efficiency = 0.96
 
 [location]


### PR DESCRIPTION
BREOS previously scored multi-objective sizing candidates from one representative year. That search is cheaper, but it does not model the PV degradation, battery fade, or replacement events that determine a design's lifetime value.

This PR adds projected lifetime scoring and makes it the default. Each candidate is simulated across a repeated-TMY project lifetime and optimized for lifetime grid independence and NPV. The previous annual basis remains available as `optimization.objective_basis = "steady_state"` for lower-cost screening. The PR also includes the configurations, source tables, and fixed-design workflow needed to reproduce results for a forthcoming publication.

## What changed

- Make `optimization.objective_basis = "projected"` the default for `optimize_system_multi_objective`.
- Keep `optimization.objective_basis = "steady_state"` as an explicit annual screening basis. It retains the three objectives of grid independence, NPV, and ZEB ratio, and estimates battery replacement from first-year SoH loss.
- Carry battery degradation and physical state between projected years, and record replacements when they occur.
- Keep projected ZEB as a diagnostic or optional feasibility constraint, not a third objective.
- Add `evaluate_projected_design` to evaluate one fixed design without NSGA-II. It returns projected metrics, annual energy and degradation-state data, discounted financial data, LCOE, and configured lifetime avoided emissions.
- Export yearly and financial source tables for each candidate.
- Add a version-controlled forthcoming-publication configuration, the deterministic `tools/reproduce_article1.py` workflow, and usage documentation. Internal `article1` paths and identifiers remain for compatibility.
- Retitle `AGENTS.md` to `BREOS`, add a plain project description, and keep the `breos.App` guidance next to the facade entry in the project map.

## Compatibility and cost

The default change is intentional and user-visible. A caller that omits `objective_basis` now receives a two-objective projected front instead of a three-objective annual front. Candidate scoring also costs `years_projection` simulated years, or `financials.project_lifespan` when that key is absent, instead of one simulated year.

Set `optimization.objective_basis = "steady_state"` to retain the former result shape and lower evaluation cost. Unknown values still raise `ValueError`. The forthcoming-publication configuration continues to set `objective_basis = "projected"` explicitly so the study does not depend on an implicit default.

## Known follow-up

After a projected search, `optimize_system_multi_objective` calls `problem._evaluate` once per Pareto candidate to collect the `Projected_*` diagnostics. The study uses a population of 100 for 40 generations. A front of about 100 members adds about 100 full 20-year evaluations to roughly 4,000 search evaluations, or about 2.5%. Caching diagnostics during the search can remove this extra work, but that change is outside this PR.

## Validation

- `python -m pytest -q` - 847 passed, 8 skipped, and 2 deselected.
- `python -m pytest -q tests/test_optimization.py tests/test_optimization_parity.py tests/test_projected_optimization.py tests/test_article1_reproduction.py` - 23 passed and 1 skipped because the licensed external profile was not configured.
- `ruff check breos/optimization.py tests/test_optimization.py tests/test_optimization_parity.py` - passed.
- `ruff format --check breos/optimization.py tests/test_optimization.py tests/test_optimization_parity.py` - 3 files already formatted.
- `BREOS_DOCS_OFFLINE=1 sphinx-build -W -b html docs /tmp/breos-pr126-default-docs` - build succeeded.
- `git diff --check` - passed.

## Notes for reviewers

This is the base of a stacked chain of twelve PRs. The release plan records the merge order, and each subsequent PR targets its parent.

The numerical outputs for the forthcoming-publication study are not final. They will be regenerated from the merged 0.6.0 release candidate before the release PR. The later bundle verifier rejects results produced from another commit.
