### PR TITLE
Use instant Open-Meteo radiation for Article solar timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,10 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   within-year timestep indices at which the pack was replaced.
 
 ### Changed
-- The Article 1 configurations now evaluate solar position at the interval
-  start. This matches the effectively instantaneous PVGIS SARAH3 TMY labels
-  and is closer than mid-interval for Open-Meteo's preceding-hour radiation
-  means.
+- Open-Meteo historical weather downloads now request instantaneous radiation
+  instead of preceding-hour means. The Article 1 configurations evaluate solar
+  position at the interval start, matching both the Open-Meteo timestamps and
+  the effectively instantaneous PVGIS SARAH3 TMY labels.
 - `remap_datetime_index_years` now shifts tz-naive and fixed-offset indices
   without a Python-level pass over the index, about 43x faster on a 15-minute
   year. Indices under a zone that can have offset transitions keep the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
   within-year timestep indices at which the pack was replaced.
 
 ### Changed
+- The Article 1 configurations now evaluate solar position at the interval
+  start. This matches the effectively instantaneous PVGIS SARAH3 TMY labels
+  and is closer than mid-interval for Open-Meteo's preceding-hour radiation
+  means.
 - `remap_datetime_index_years` now shifts tz-naive and fixed-offset indices
   without a Python-level pass over the index, about 43x faster on a 15-minute
   year. Indices under a zone that can have offset transitions keep the

--- a/breos/weather.py
+++ b/breos/weather.py
@@ -406,6 +406,10 @@ def fetch_weather_data(
     """
     Fetch historical weather data from the Open-Meteo API.
 
+    Radiation values use Open-Meteo's instantaneous fields at each timestamp.
+    The returned columns keep BREOS's established names without the provider's
+    ``_instant`` suffix.
+
     Args:
         latitude: Latitude of the location
         longitude: Longitude of the location
@@ -435,6 +439,17 @@ def fetch_weather_data(
             "Install with: uv add openmeteo-requests requests-cache"
         )
 
+    hourly_fields = (
+        ("temperature_2m", "temperature_2m"),
+        ("wind_speed_10m", "wind_speed_10m"),
+        ("shortwave_radiation_instant", "shortwave_radiation"),
+        ("direct_radiation_instant", "direct_radiation"),
+        ("diffuse_radiation_instant", "diffuse_radiation"),
+        ("direct_normal_irradiance_instant", "direct_normal_irradiance"),
+        ("global_tilted_irradiance_instant", "global_tilted_irradiance"),
+        ("terrestrial_radiation_instant", "terrestrial_radiation"),
+    )
+
     # Setup the Open-Meteo API client with cache and retry. Cache expires
     # after 30 days so we don't serve indefinitely-stale entries if a single
     # bad response was ever written.
@@ -450,16 +465,7 @@ def fetch_weather_data(
         "longitude": longitude,
         "start_date": start_date,
         "end_date": end_date,
-        "hourly": [
-            "temperature_2m",
-            "wind_speed_10m",
-            "shortwave_radiation",
-            "direct_radiation",
-            "diffuse_radiation",
-            "direct_normal_irradiance",
-            "global_tilted_irradiance",
-            "terrestrial_radiation",
-        ],
+        "hourly": [provider_name for provider_name, _output_name in hourly_fields],
         "wind_speed_unit": "ms",
         "timezone": "GMT",
         "tilt": tilt,
@@ -478,20 +484,18 @@ def fetch_weather_data(
             freq=pd.Timedelta(seconds=hourly.Interval()),
             inclusive="left",
         ),
-        "temperature_2m": hourly.Variables(0).ValuesAsNumpy(),
-        "wind_speed_10m": hourly.Variables(1).ValuesAsNumpy(),
-        "shortwave_radiation": hourly.Variables(2).ValuesAsNumpy(),
-        "direct_radiation": hourly.Variables(3).ValuesAsNumpy(),
-        "diffuse_radiation": hourly.Variables(4).ValuesAsNumpy(),
-        "direct_normal_irradiance": hourly.Variables(5).ValuesAsNumpy(),
-        "global_tilted_irradiance": hourly.Variables(6).ValuesAsNumpy(),
-        "terrestrial_radiation": hourly.Variables(7).ValuesAsNumpy(),
+        **{
+            output_name: hourly.Variables(index).ValuesAsNumpy()
+            for index, (_provider_name, output_name) in enumerate(hourly_fields)
+        },
     }
 
     hourly_dataframe = pd.DataFrame(data=hourly_data)
     hourly_dataframe.set_index("date", inplace=True)
     hourly_dataframe.attrs[_WEATHER_METADATA_KEY] = {
         "source": "OpenMeteo_historical",
+        "provider_hourly_fields": [provider_name for provider_name, _output_name in hourly_fields],
+        "radiation_time_basis": "instant",
         "horizon": _unknown_horizon_metadata("openmeteo"),
     }
 

--- a/tests/test_article1_bundle_tools.py
+++ b/tests/test_article1_bundle_tools.py
@@ -6,10 +6,18 @@ import pytest
 
 from tools.preflight_article1_inputs import EXPECTED_SHA256, _checked_input
 from tools.verify_article1_bundle import (
+    EXPECTED_HISTORICAL_WEATHER_SHA256,
     EXPECTED_MONTE_CARLO_YEARLY_COLUMNS,
     BundleAudit,
     _report_source_paths,
 )
+
+ARTICLE1_INSTANT_WEATHER_SHA256 = "0b2d42e6f3e2309aed3c0f65de461cab11b885173f6e45f0cd93adee29417650"
+
+
+def test_article1_tools_pin_instant_openmeteo_weather():
+    assert EXPECTED_SHA256["historical_weather"] == ARTICLE1_INSTANT_WEATHER_SHA256
+    assert EXPECTED_HISTORICAL_WEATHER_SHA256 == ARTICLE1_INSTANT_WEATHER_SHA256
 
 
 def test_article1_input_preflight_accepts_only_pinned_hash(tmp_path, monkeypatch):

--- a/tests/test_article1_montecarlo.py
+++ b/tests/test_article1_montecarlo.py
@@ -36,6 +36,7 @@ def test_article1_montecarlo_config_pins_manuscript_method():
     }
     assert config["battery_temperature"] == "weather"
     assert config["battery_indoor_model"] == {"enabled": True}
+    assert config["solar_position"] == "interval-start"
     module = _pv_module_provenance(config)
     assert module["parameters"]["T_Pmax_pct"] == -0.34
     assert module["parameters"]["T_Voc_pct"] == -0.26

--- a/tests/test_article1_reproduction.py
+++ b/tests/test_article1_reproduction.py
@@ -20,7 +20,7 @@ from tools.reproduce_article1 import (
 )
 
 EXPECTED_RLP_SHA256 = "23becc5a7bfc927b1f7604156e0e4953dcc6bb65268ca947b38db3dc4f2b28bc"
-EXPECTED_CONFIG_SHA256 = "48181f462f6af8d8f25b26e480542b7ffadf9a73fd835a972d83441029c8e009"
+EXPECTED_CONFIG_SHA256 = "1c8029f8d339d6bc67ab31229c4a1033e55a9ac299b9047d3a34d84b2c9b703f"
 FIXED_REGRESSION_LABELS = {"C1", "C2", "C3", "C4"}
 
 
@@ -44,6 +44,7 @@ def test_article1_config_pins_projected_run_controls():
         "early_stop": {"ftol": 0.0025, "period": 10, "min_gen": 20, "n_skip": 0},
     }
     assert config["constraints"]["enforce_zeb"] is False
+    assert config["solar_position"] == "interval-start"
     assert config["pv"]["module_width_m"] == 1.134
     assert config["pv"]["module_length_m"] == 2.278
     assert config["battery"]["temperature"] == "weather"

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -9,6 +9,7 @@ import pytest
 from breos.weather import (
     build_battery_temperature_series,
     fetch_tmy_weather_data,
+    fetch_weather_data,
     load_weather,
     parse_weather_filename,
     preload_weather_by_year,
@@ -25,6 +26,82 @@ def _write_leap_year_15min_weather(tmp_path):
     path = tmp_path / "weather.csv"
     df.to_csv(path, index=False)
     return path, df
+
+
+def test_fetch_weather_data_requests_instant_openmeteo_radiation(monkeypatch):
+    captured = {}
+
+    class FakeSession:
+        def mount(self, *_args, **_kwargs):
+            pass
+
+    class FakeVariable:
+        def __init__(self, value):
+            self.value = value
+
+        def ValuesAsNumpy(self):
+            return np.array([self.value], dtype=float)
+
+    class FakeHourly:
+        def Time(self):
+            return 0
+
+        def TimeEnd(self):
+            return 3600
+
+        def Interval(self):
+            return 3600
+
+        def Variables(self, index):
+            return FakeVariable(index)
+
+    class FakeResponse:
+        def Hourly(self):
+            return FakeHourly()
+
+    class FakeClient:
+        def __init__(self, *, session):
+            captured["session"] = session
+
+        def weather_api(self, url, *, params):
+            captured["url"] = url
+            captured["params"] = params
+            return [FakeResponse()]
+
+    monkeypatch.setattr("breos.weather.requests_cache.CachedSession", lambda *_args, **_kwargs: FakeSession())
+    monkeypatch.setattr("breos.weather.openmeteo_requests.Client", FakeClient)
+
+    weather = fetch_weather_data(
+        latitude=41.1579,
+        longitude=-8.6291,
+        start_date="2024-06-01",
+        end_date="2024-06-01",
+        tilt=0,
+        azimuth=0,
+        save_to_file=False,
+    )
+
+    assert captured["params"]["hourly"] == [
+        "temperature_2m",
+        "wind_speed_10m",
+        "shortwave_radiation_instant",
+        "direct_radiation_instant",
+        "diffuse_radiation_instant",
+        "direct_normal_irradiance_instant",
+        "global_tilted_irradiance_instant",
+        "terrestrial_radiation_instant",
+    ]
+    assert list(weather.columns) == [
+        "temperature_2m",
+        "wind_speed_10m",
+        "shortwave_radiation",
+        "direct_radiation",
+        "diffuse_radiation",
+        "direct_normal_irradiance",
+        "global_tilted_irradiance",
+        "terrestrial_radiation",
+    ]
+    assert weather.attrs["breos_weather_metadata"]["radiation_time_basis"] == "instant"
 
 
 def test_battery_temperature_helper_applies_indoor_default():

--- a/tools/preflight_article1_inputs.py
+++ b/tools/preflight_article1_inputs.py
@@ -18,7 +18,8 @@ RLP_HOURLY_FILENAME = "EREDES_2025_BTN_1000kwh_hourly.csv"
 EXPECTED_SHA256 = {
     "external_rlp_15min": "23becc5a7bfc927b1f7604156e0e4953dcc6bb65268ca947b38db3dc4f2b28bc",
     "external_rlp_hourly": "6ae15efed9b179537349ee1c1c5747065f18db876920e073e8670bf412d20d6b",
-    "historical_weather": "71c26d072c09faf16dab37230cfe8b2d430bd39344333227d00c7be4e76a188a",
+    # Open-Meteo 2005-2024 snapshot fetched with instantaneous radiation.
+    "historical_weather": "0b2d42e6f3e2309aed3c0f65de461cab11b885173f6e45f0cd93adee29417650",
     "bundled_tmy": "bf84e31b02ad9bf39f331a5ce8629b1ea8f80cd1597748e72a87a0fce56b4f15",
     "validation_monthly": "d2b777e2b58abdad055abe25ec45c7fd879947f498622b6f17966b8d4803d1cb",
     "validation_weekly": "b5ff0311df777b62f22de1111ba277321203e57e2ab5c6eac67e6673880d397b",

--- a/tools/verify_article1_bundle.py
+++ b/tools/verify_article1_bundle.py
@@ -25,6 +25,7 @@ EXPECTED_ARTIFACT_HASH_KEYS = {
     "yearly_csv_sha256",
     "yearly_summary_sha256",
 }
+EXPECTED_HISTORICAL_WEATHER_SHA256 = "0b2d42e6f3e2309aed3c0f65de461cab11b885173f6e45f0cd93adee29417650"
 EXPECTED_EXTERNAL_VALIDATION_HASHES = {
     "monthly_results.csv": "d2b777e2b58abdad055abe25ec45c7fd879947f498622b6f17966b8d4803d1cb",
     "weekly_results.csv": "b5ff0311df777b62f22de1111ba277321203e57e2ab5c6eac67e6673880d397b",
@@ -388,8 +389,7 @@ class BundleAudit:
                 "unexpected hourly E-REDES input hash",
             )
             self.expect(
-                manifest_inputs.get("historical_weather", {}).get("sha256")
-                == "71c26d072c09faf16dab37230cfe8b2d430bd39344333227d00c7be4e76a188a",
+                manifest_inputs.get("historical_weather", {}).get("sha256") == EXPECTED_HISTORICAL_WEATHER_SHA256,
                 "unexpected historical-weather input hash",
             )
         for filename, expected in EXPECTED_EXTERNAL_VALIDATION_HASHES.items():

--- a/validation/article1/article1-montecarlo.toml
+++ b/validation/article1/article1-montecarlo.toml
@@ -23,11 +23,10 @@ battery_max_charge_power_w = 4352.0
 battery_temperature = "weather"
 battery_indoor_model = { enabled = true }
 inverter_efficiency = 0.96
-# Open-Meteo radiation is a preceding-hour mean. BREOS does not yet support
-# that source-specific offset; interval-start is the closer available solar
-# position convention. Use Perez transposition and Marion diffuse/ground IAM
-# instead of beam-only IAM; the beam-only default is a documented 0.5-1.5%
-# systematic overestimate.
+# The pinned Open-Meteo weather snapshot uses the provider's instantaneous
+# radiation fields, so evaluate solar position at the interval start. Use
+# Perez transposition and Marion diffuse/ground IAM instead of beam-only IAM;
+# the beam-only default is a documented 0.5-1.5% systematic overestimate.
 transposition_model = "perez"
 solar_position = "interval-start"
 diffuse_iam = "marion"

--- a/validation/article1/article1-montecarlo.toml
+++ b/validation/article1/article1-montecarlo.toml
@@ -23,11 +23,13 @@ battery_max_charge_power_w = 4352.0
 battery_temperature = "weather"
 battery_indoor_model = { enabled = true }
 inverter_efficiency = 0.96
-# Best-available PV chain. Perez transposition with mid-interval solar
-# position, and Marion diffuse/ground IAM instead of beam-only -- the
-# beam-only default is a documented 0.5-1.5% systematic overestimate.
+# Open-Meteo radiation is a preceding-hour mean. BREOS does not yet support
+# that source-specific offset; interval-start is the closer available solar
+# position convention. Use Perez transposition and Marion diffuse/ground IAM
+# instead of beam-only IAM; the beam-only default is a documented 0.5-1.5%
+# systematic overestimate.
 transposition_model = "perez"
-solar_position = "mid-interval"
+solar_position = "interval-start"
 diffuse_iam = "marion"
 inverter_loading_ratio = 1.25
 inflation_rate = 0.02

--- a/validation/article1/article1-projected-optimization.toml
+++ b/validation/article1/article1-projected-optimization.toml
@@ -1,10 +1,11 @@
 name = "Article 1 projected optimization reproduction"
 inverter_efficiency = 0.96
-# Best-available PV chain. Perez transposition with mid-interval solar
-# position, and Marion diffuse/ground IAM instead of beam-only -- the
+# The PVGIS SARAH3 TMY irradiance is effectively instantaneous at its hourly
+# label, so evaluate the solar position at the interval start. Use Perez
+# transposition and Marion diffuse/ground IAM instead of beam-only IAM; the
 # beam-only default is a documented 0.5-1.5% systematic overestimate.
 transposition_model = "perez"
-solar_position = "mid-interval"
+solar_position = "interval-start"
 diffuse_iam = "marion"
 
 [location]


### PR DESCRIPTION
BREOS requested Open-Meteo's unsuffixed radiation fields, which are preceding-hour means, but evaluated solar position at or after the labelled timestamp. The PVGIS SARAH3 TMY is effectively instantaneous near its label, so one solar-position convention could not align both sources.

This PR makes the Open-Meteo downloader request the provider's `*_instant` radiation fields and sets both configurations to `interval-start`. New Open-Meteo downloads and the PVGIS TMY can therefore use the same convention.

## What changed

- Request instantaneous GHI, direct horizontal radiation, DHI, DNI, global tilted irradiance, and terrestrial radiation from the Open-Meteo Archive API.
- Keep BREOS's existing output column names so current consumers continue to work.
- Record the requested provider fields and `radiation_time_basis = "instant"` in the weather metadata sidecar.
- Pin the replacement 2005-2024 Porto weather snapshot by SHA-256 in Article preflight and bundle verification.
- Evaluate Article 1 solar position at the interval start for deterministic, context, and Monte Carlo runs.
- Add regressions for the provider request, normalized output schema, time-basis metadata, Article configuration, and weather hash.

## Impact and compatibility

Existing saved CSVs do not change automatically. Re-download historical weather to obtain instantaneous radiation.

The replacement Porto file has the same 175,320 hourly timestamps as the previous snapshot. Its total GHI is 0.5% lower. Open-Meteo also revised some non-radiation values since the old snapshot was saved, so the new SHA-256 pins the complete downloaded file rather than radiation alone.

The replacement file remains an external Article input and is not committed. All affected publication outputs must be regenerated after this change.

## Validation

- `/home/leo/code/breos/.venv/bin/pytest -q tests/test_weather.py tests/test_article1_bundle_tools.py tests/test_article1_reproduction.py tests/test_article1_montecarlo.py tests/test_article1_context.py tests/test_run_article1_tool.py` - 52 passed, 1 skipped
- `/home/leo/code/breos/.venv/bin/ruff check` on the changed Python files - passed
- `/home/leo/code/breos/.venv/bin/ruff format --check` on the changed Python files - 7 files already formatted
- `git diff --check` - passed
- A live one-day Archive API probe returned all six requested `*_instant` radiation arrays.
- The downloaded 2005-2024 file passed `_checked_input("historical_weather", ...)` with SHA-256 `0b2d42e6f3e2309aed3c0f65de461cab11b885173f6e45f0cd93adee29417650`.
- `tools/reproduce_article1_montecarlo.py --case all --validate-only` accepted C1-C5 with the replacement file.

## Stack context

This PR follows #137 and targets `perf/0.6.x-pv-only-year-cache`. PR #131 separately removes private third-party comparison data from public bundles. This PR changes only the historical Open-Meteo input pin and does not restore those private-data requirements.
