### PR TITLE
test: exercise upcoming-publication recovery calculations

### DIFF
--- a/tests/test_validation_recovery.py
+++ b/tests/test_validation_recovery.py
@@ -1,0 +1,126 @@
+"""Checks for the Article 1 validation-recovery verifier."""
+
+import json
+
+import pandas as pd
+import pytest
+
+from tools.validation.recovery.verify_recovery import verify
+
+
+def _write_csv(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def _valid_recovery_tree(root):
+    _write_csv(
+        root / "validation_sandia_task13_recovered_20260902/thermal_metrics.csv",
+        [
+            {
+                "model": "breos_faiman_default",
+                "gpoa_threshold_W_m2": 200,
+                "n": 26_023,
+                "bias_C": -0.038,
+                "rmse_C": 2.993,
+                "r": 0.970,
+            }
+        ],
+    )
+    _write_csv(
+        root / "validation_pcoe_recovered_20260902/thermal_metrics.csv",
+        [
+            {
+                "model": "breos_faiman_default",
+                "gpoa_threshold_W_m2": 200,
+                "n": 12_708,
+                "bias_C": 2.694,
+                "rmse_C": 3.821,
+            }
+        ],
+    )
+    reunion = root / "validation_reunion_microgrid_recovered_20260902"
+    _write_csv(
+        reunion / "thermal_metrics.csv",
+        [
+            {
+                "model": "breos_faiman_default",
+                "poa_threshold_W_m2": 200,
+                "n": 108_986,
+                "bias_C": 8.882,
+                "rmse_C": 11.162,
+            }
+        ],
+    )
+    _write_csv(reunion / "battery_thermal_metrics.csv", [{"n": 5_655, "bias_C": -3.292}])
+    _write_csv(
+        root / "validation_orientation_diversity_recovered_20260902/orientation_screen_metrics.csv",
+        [
+            {"panel": "Total", "model": "common_radiation", "rmse_W": 159.126, "r2": 0.8},
+            {"panel": "Total", "model": "radiation_plus_aoi", "rmse_W": 131.821, "r2": 0.883},
+        ],
+    )
+    dkasc = root / "validation_dkasc_recovered_20260902/results"
+    _write_csv(
+        dkasc / "transposition_leg_a.csv",
+        [
+            {
+                "transposition": "perez",
+                "perez_set": "allsitescomposite1990",
+                "albedo": "default",
+                "bias_%": -0.4787011936222662,
+                "r": 0.9931215534958022,
+            }
+        ],
+    )
+    _write_csv(
+        dkasc / "transposition_leg_b.csv",
+        [{"transposition": "perez", "ratio_err_%": 0.5949768499216912}],
+    )
+    hkust = root / "validation_hkust_timing-corrected-exploratory-v4_recovered_20260902"
+    hkust.mkdir(parents=True)
+    (hkust / "aggregate_metrics.json").write_text(
+        json.dumps(
+            {
+                "sites_scored": 56,
+                "test_raw_energy_bias_pct": 27.122,
+                "all_scored_sites": {
+                    "pooled_daylight_raw_metrics": {
+                        "rmse_W": 10_635.397,
+                        "r": 0.911280,
+                    }
+                },
+            }
+        )
+    )
+
+
+def test_recovery_verifier_accepts_every_recorded_checkpoint(tmp_path, capsys):
+    _valid_recovery_tree(tmp_path)
+
+    verify(tmp_path)
+
+    output = capsys.readouterr().out
+    assert output.count("PASS ") == 17
+    assert output.endswith("All recovered local-data validations reproduce their recorded checkpoints.\n")
+
+
+def test_recovery_verifier_rejects_numerical_drift(tmp_path):
+    _valid_recovery_tree(tmp_path)
+    sandia = tmp_path / "validation_sandia_task13_recovered_20260902/thermal_metrics.csv"
+    frame = pd.read_csv(sandia)
+    frame.loc[0, "bias_C"] = -0.050
+    frame.to_csv(sandia, index=False)
+
+    with pytest.raises(AssertionError, match="Sandia bias C"):
+        verify(tmp_path)
+
+
+def test_recovery_verifier_rejects_ambiguous_checkpoint_rows(tmp_path):
+    _valid_recovery_tree(tmp_path)
+    sandia = tmp_path / "validation_sandia_task13_recovered_20260902/thermal_metrics.csv"
+    frame = pd.read_csv(sandia)
+    pd.concat([frame, frame], ignore_index=True).to_csv(sandia, index=False)
+
+    with pytest.raises(AssertionError, match="Expected one row.*found 2"):
+        verify(tmp_path)

--- a/tests/test_validation_recovery_metrics.py
+++ b/tests/test_validation_recovery_metrics.py
@@ -1,0 +1,95 @@
+"""Numerical checks for the recovered validation drivers."""
+
+import numpy as np
+import pytest
+
+from tools.validation.recovery.hkust.drivers.hkust_validate import _finite_metric
+from tools.validation.recovery.orientation_diversity.drivers.orientation_screen import (
+    _metric_row as orientation_metric,
+)
+from tools.validation.recovery.pcoe.drivers.pcoe_validate import (
+    _metric_row as pcoe_metric,
+)
+from tools.validation.recovery.pcoe.drivers.pcoe_validate import _power_consistency_row
+from tools.validation.recovery.reunion_microgrid.drivers.reunion_validate import _metrics as reunion_metric
+from tools.validation.recovery.sandia_task13.drivers.sandia_thermal_validate import (
+    _metric_row as sandia_metric,
+)
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        sandia_metric("model", 200, np.array([1.0, 2.0, 4.0]), np.array([2.0, 2.0, 5.0])),
+        pcoe_metric("current", "model", 200, np.array([1.0, 2.0, 4.0]), np.array([2.0, 2.0, 5.0])),
+    ],
+)
+def test_thermal_driver_metrics_use_prediction_minus_measurement(row):
+    assert row["n"] == 3
+    assert row["bias_C"] == pytest.approx(2 / 3)
+    assert row["mae_C"] == pytest.approx(2 / 3)
+    assert row["rmse_C"] == pytest.approx(np.sqrt(2 / 3))
+    assert -1.0 <= row["r"] <= 1.0
+
+
+def test_pcoe_power_consistency_counts_large_absolute_and_relative_errors():
+    row = _power_consistency_row(
+        "all",
+        actual=np.array([100.0, 200.0, 300.0]),
+        derived=np.array([111.0, 198.0, 312.0]),
+    )
+
+    assert row["bias_derived_minus_Pdc_W"] == pytest.approx(7.0)
+    assert row["mae_W"] == pytest.approx(25 / 3)
+    assert row["rmse_W"] == pytest.approx(np.sqrt(269 / 3))
+    assert row["abs_error_gt_10W"] == 2
+    assert row["relative_error_gt_1pct"] == 2
+
+
+def test_reunion_metrics_drop_nonfinite_pairs_and_report_constant_correlation():
+    row = reunion_metric(
+        "thermal",
+        "model",
+        actual=np.array([1.0, np.nan, 3.0]),
+        predicted=np.array([2.0, 100.0, 2.0]),
+        unit="C",
+    )
+
+    assert row["n"] == 2
+    assert row["bias_C"] == 0.0
+    assert row["mae_C"] == 1.0
+    assert row["rmse_C"] == 1.0
+    assert row["r"] is None
+
+
+def test_orientation_metric_reports_a_perfect_fit_and_missing_second_coefficient():
+    row = orientation_metric(
+        "PV-1",
+        "common_radiation",
+        "radiation",
+        coefficients=np.array([2.0]),
+        actual=np.array([1.0, 2.0, 4.0]),
+        predicted=np.array([1.0, 2.0, 4.0]),
+    )
+
+    assert row["bias_W"] == 0.0
+    assert row["rmse_W"] == 0.0
+    assert row["r"] == pytest.approx(1.0)
+    assert row["r2"] == pytest.approx(1.0)
+    assert np.isnan(row["coefficient_2"])
+
+
+def test_hkust_metric_handles_empty_and_constant_populations():
+    assert _finite_metric(np.array([]), np.array([])) == {
+        "n": 0,
+        "bias_W": None,
+        "mae_W": None,
+        "rmse_W": None,
+        "r": None,
+        "r2": None,
+    }
+
+    constant = _finite_metric(np.array([2.0, 2.0]), np.array([3.0, 3.0]))
+    assert constant["bias_W"] == 1.0
+    assert constant["r"] is None
+    assert constant["r2"] is None

--- a/tools/validation/recovery/verify_recovery.py
+++ b/tools/validation/recovery/verify_recovery.py
@@ -28,12 +28,8 @@ def _one(frame: pd.DataFrame, **conditions: Any) -> pd.Series:
     return selected.iloc[0]
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("output_root", type=Path)
-    args = parser.parse_args()
-    root = args.output_root
-
+def verify(root: Path) -> None:
+    """Verify one recovered validation output tree."""
     sandia = pd.read_csv(root / "validation_sandia_task13_recovered_20260902" / "thermal_metrics.csv")
     row = _one(sandia, model="breos_faiman_default", gpoa_threshold_W_m2=200)
     if int(row["n"]) != 26_023:
@@ -110,6 +106,13 @@ def main() -> None:
     _close("HKUST raw daylight r", pooled["r"], 0.911280, 0.000001)
 
     print("All recovered local-data validations reproduce their recorded checkpoints.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_root", type=Path)
+    args = parser.parse_args()
+    verify(args.output_root)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The recovered validation drivers produce evidence used by the upcoming publication, but their calculations and archive checkpoints previously had no automated tests. This stacked PR adds a focused safety net before those tools become part of the 0.6.2 reproducibility release.

## What changed

- expose the recovery verifier as a callable function while preserving its command-line behavior
- test a complete synthetic recovery tree across all expected packages and checkpoints
- reject numerical drift and ambiguous recovered rows
- test the core Sandia, PCoE, Reunion, orientation, and HKUST metric calculations with synthetic arrays
- cover sign conventions, RMSE and threshold calculations, finite-value filtering, correlations, and R²

## Why this is stacked

This PR targets `test/0.6.x-external-validation-recovery` so the test changes remain reviewable independently of the recovered validation archive in #144. The publication replay and validation tooling are planned for the 0.6.2 reproducibility release rather than the focused 0.6.1 library release in #146.

## Validation

- `uv run pytest -q tests/test_validation_recovery.py tests/test_validation_recovery_metrics.py` — 9 passed
- `uv run ruff check tools/validation/recovery tests/test_validation_recovery.py tests/test_validation_recovery_metrics.py` — passed
- `uv run ruff format --check tools/validation/recovery tests/test_validation_recovery.py tests/test_validation_recovery_metrics.py` — 18 files already formatted
- `git diff --check` — passed

## Limits

These tests validate the recovery checkpoints and numerical kernels with synthetic inputs. They do not replay the licensed or external datasets, exercise every ingestion path, or replace a clean end-to-end rerun for the upcoming publication. That full replay remains a release gate for 0.6.2.
