### PR TITLE
Declare 0.6.2 and record which version produced each published result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to BREOS are documented here. Format follows [Keep a Changel
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-09-03
+
+### Added
+- Added `tools/revision/task3_eol_sweep.py`, the Task 3 end-of-life sweep. It
+  quantifies how much of storage economics follows from the battery replacement
+  assumption, by running three degradation models at their accepted knee
+  orientations against 80%, 70% and replacement-disabled settings. The sweep
+  previously existed only inside a result directory and could not be re-run from
+  a later release. The pinned commit, lattice location and output directory are
+  now options; the models, the 210-design grid, the candidate replays and the
+  verification against the accepted lattice are unchanged, and the config stays
+  pinned by hash.
+
+### Changed
+- The forthcoming publication's reproduction configurations now use the accepted
+  representative candidate set rather than the superseded manuscript set. C2
+  becomes 9 modules and 7 kWh at 35/200, the Gate 2 replacement for a manuscript
+  design that sat off the accepted front. C1, C3 and C4 move to their
+  accepted-lattice orientations. C5 is unchanged and stays an off-front
+  benchmark. Each candidate's expected values now come from the accepted
+  lattice, so reference columns compare against the accepted front.
+- Both publication configurations replace the absolute 4352 W battery power cap
+  with a symmetric 1.0 C capacity-proportional limit. The absolute cap did not
+  scale with pack size and so under-limited small packs; 1 C is the BYD
+  Battery-Box Premium HVS family rating at every size. Results generated before
+  this change reproduce the superseded candidate set and need rerunning.
+
 ## [0.6.1] - 2026-09-03
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,7 +20,7 @@ keywords:
   - solar
   - degradation
 license: BSD-3-Clause
-version: 0.6.1
+version: 0.6.2
 date-released: "2026-09-03"
 preferred-citation:
   type: article

--- a/validation/article1/README.md
+++ b/validation/article1/README.md
@@ -17,6 +17,10 @@ Use the [source-data runbook](runbook.md) for the Monte Carlo and verification
 commands. Use the [manuscript audit](manuscript-v2-audit.md) to map each result
 to the generated CSV or JSON source data.
 
+Use the [data availability and citation scope](data-availability.md) page to
+find where the generated bundles are deposited and which BREOS version to cite
+for each result.
+
 ## Scope
 
 The workflow generates:

--- a/validation/article1/data-availability.md
+++ b/validation/article1/data-availability.md
@@ -1,0 +1,48 @@
+# Data availability and citation scope
+
+Generated results are not committed. `results/` is ignored, and the
+deterministic bundle alone is 863 MB. The bundles behind the forthcoming
+publication are deposited at <!-- TODO: Zenodo DOI and record URL --> and that
+deposit is the authoritative copy.
+
+## Which version produced which result
+
+The results were not all produced by one release. Cite the version that
+generated each one.
+
+| Result | Deposited as | BREOS version | Commit |
+| --- | --- | --- | --- |
+| Deterministic C1-C5 tables and the seeded Monte Carlo study | `publication-1c` | 0.6.2 | `b3d0034` |
+| Battery-cost and degradation cross-sensitivity | `cost-degradation-cross` | 0.6.2 | `b3d0034` |
+| Task 3 end-of-life sweep | `task3-eol-0.6.2` | 0.6.2 | `30c35cb` |
+| Figure 2 gate, Task 2 Porto, the Task 4 lattice and NSGA-II validation, Tasks 5, 5b, 5f, 6 and 7, and the figures | see the 0.6.1 deposit | 0.6.1 | — |
+
+Splitting the citation this way is what the provenance files record, not a
+convenience. Every `reproduction.json` and `provenance.json` inside the three
+0.6.2 bundles records the commit named above with
+`"tracked_worktree_dirty": false`, alongside the resolved configuration, the
+input hashes, and the Python, NumPy, pandas, pvlib and SciPy versions used.
+
+BREOS 0.6.2 changes no model behaviour relative to 0.6.1. Regenerating
+`validation/baselines/breos_baseline.json` on 0.6.2 changed only the recorded
+version string; every validation figure is unchanged.
+
+## What the deposit contains
+
+<!-- TODO: state whether the per-year trajectories are included. -->
+
+Each Monte Carlo case directory holds:
+
+- `summary.json` — the case's aggregate metrics.
+- `runs.csv` — one row per trajectory: 10,000 rows, 18 columns.
+- `yearly.csv` — one row per trajectory-year: 200,000 rows, 65 columns, holding
+  the energy, degradation-state and discounted-cost paths behind the summaries.
+
+The five `yearly.csv` files account for 850 MB of the 863 MB total; the five
+`runs.csv` files account for 13 MB.
+
+## Reproducing a bundle
+
+Check out the commit named in the table above, then follow the
+[source-data runbook](runbook.md). `tools/verify_article1_bundle.py` checks a
+generated bundle against its recorded provenance.

--- a/validation/baselines/breos_baseline.json
+++ b/validation/baselines/breos_baseline.json
@@ -1,5 +1,5 @@
 {
-  "breos_version": "0.6.1",
+  "breos_version": "0.6.2",
   "generated": "2026-09-03",
   "system": {
     "module": "Generic_400W",


### PR DESCRIPTION
## Summary

The package bumped to 0.6.2, but nothing in the repository said so. `CITATION.cff`
still read `version: 0.6.1`, the changelog had an empty `[Unreleased]` section
with neither 0.6.2 change recorded, and the drift-test baseline still stamped
`"breos_version": "0.6.1"`. Anyone citing BREOS 0.6.2 for the forthcoming
publication would be naming a version the repository never declared.

The second gap is provenance. Generated results are gitignored, so a reader who
finds a figure in the article has no path from it back to a version, a commit,
or a file. That matters more than usual here because the results were not all
produced by one release: three bundles come from 0.6.2 and everything else is a
0.6.1 artifact.

This PR declares 0.6.2 in the release metadata and records, per result, which
version produced it and where the data lives.

## What changed

- Bumped `CITATION.cff` to `version: 0.6.2`.
- Added a `[0.6.2]` changelog section covering the accepted representative set,
  the 1 C battery limit, and the ported Task 3 end-of-life sweep.
- Regenerated `validation/baselines/breos_baseline.json` on 0.6.2, as the
  release checklist requires after a version bump.
- Added `validation/article1/data-availability.md` and linked it from
  `validation/article1/README.md`.

## Technical details

Regenerating the baseline changed exactly one line — the recorded version
string. Every validation figure across every site and transposition model is
byte-identical to the 0.6.1 baseline. That is worth stating plainly: the 0.6.2
changes are reproduction configuration and tooling, and they do not move model
behaviour.

The citation split is what the provenance files record, not an editorial
choice. Every `reproduction.json` and `provenance.json` in the three 0.6.2
bundles records its commit with `"tracked_worktree_dirty": false`.

| Result | BREOS version | Commit |
| --- | --- | --- |
| `publication-1c` (deterministic and Monte Carlo) | 0.6.2 | `b3d0034` |
| `cost-degradation-cross` | 0.6.2 | `b3d0034` |
| `task3-eol-0.6.2` | 0.6.2 | `30c35cb` |
| Figure 2 gate, Task 2 Porto, Task 4 lattice and NSGA-II validation, Tasks 5/5b/5f, 6, 7, and the figures | 0.6.1 | — |

The page also records the deposit's shape, since `results/` is ignored
(`.gitignore:12`) and the deterministic bundle is 863 MB. Of that, the five
Monte Carlo `yearly.csv` files are 850 MB (200,000 rows by 65 columns each) and
the five `runs.csv` files are 13 MB (10,000 rows by 18 columns each).

## Known limitations

Two values in `data-availability.md` are marked `TODO` and must be filled before
merge:

- The Zenodo DOI and record URL. The deposit has not been made.
- Whether the deposit includes the per-year trajectories (`yearly.csv`) or only
  the per-trajectory summaries and the deterministic tables.

## Follow-ups

- Deposit the bundles and replace the DOI placeholder.
- Tag `article1-0.6.2-results` at `30c35cb` so the cited commits have a stable
  name.

## Validation

Run on this branch:

- `uv run python validation/run_breos.py --write-baseline` — regenerated; diff
  is the version string only.
- `uv run pytest tests/test_validation_drift.py -q` — 99 passed, 7 skipped.
- `uv run ruff check breos/ tests/ tools/` — all checks passed.
- `uv run ruff format --check breos/ tests/ tools/` — 179 files already
  formatted.

Not run here: the full `uv run pytest tests/ -v` suite and the Sphinx docs
build. CI covers both.

## Stack context

Stacked on #148. Based on `chore/0.6.2-simulation-candidate`; GitHub will
retarget this to `develop` once #148 merges.

## Test plan
- [ ] Tests pass (`uv run pytest tests/ -v`)
